### PR TITLE
Remove the return type in Configurator::get()

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -64,7 +64,7 @@ class Configurator
         }
     }
 
-    private function get($key): AbstractConfigurator
+    private function get($key)
     {
         if (!isset($this->configurators[$key])) {
             throw new \InvalidArgumentException(sprintf('Unknown configurator "%s".', $key));


### PR DESCRIPTION
I'm not proposing to merge this PR. This is just to tell you that issue #12 is solved by this change. But probably there's a better solution.