### PR TITLE
Don't include the "name" and "description" properties in composer.json

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -67,21 +67,11 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     public function configureProject(Event $event)
     {
-        $projectName = strtolower(basename(getcwd()));
-        if (!empty($_SERVER['USERNAME'])) {
-            $packageName = $_SERVER['USERNAME'].'/'.$projectName;
-        } elseif (true === extension_loaded('posix') && $user = posix_getpwuid(posix_getuid())) {
-            $packageName = $user['name'].'/'.$projectName;
-        } elseif (get_current_user()) {
-            $packageName = get_current_user().'/'.$projectName;
-        } else {
-            // needed because package names must use the "foo/bar" format
-            $packageName = $projectName.'/'.$projectName;
-        }
-
         $json = new JsonFile(Factory::getComposerFile());
         $manipulator = new JsonManipulator(file_get_contents($json->getPath()));
-        $manipulator->addProperty('name', $packageName);
+        // 'name' and 'description' are only required for public packages
+        $manipulator->removeProperty('name');
+        $manipulator->removeProperty('description');
         file_put_contents($json->getPath(), $manipulator->getContents());
     }
 


### PR DESCRIPTION
I was reading the [Composer schema doc](https://getcomposer.org/doc/04-schema.md#name) and I saw that `name` and `description` are only required when you package is public and installable via Packagist.org.

Can we assume that most of the projects created with Flex are proprietary and will never be published? If that's the case, we can safely remove these two properties.

---

The only minor confusion is that `composer validate` checks by default if your package is ready to be publicly released, so it says that `name` and `description` is required. To check the validity of proprietary packages, you must run `composer validate --no-check-publish`