### PR TITLE
Upgrade code to use PHP 7.1 features

### DIFF
--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -36,7 +36,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
-            if ('/' === $source[strlen($source) - 1]) {
+            if ('/' === $source[-1]) {
                 $this->copyDir($from.'/'.$source, $to.'/'.$target);
             } else {
                 if (!is_dir(dirname($to.'/'.$target))) {
@@ -54,7 +54,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
-            if ('/' === $source[strlen($source) - 1]) {
+            if ('/' === $source[-1]) {
                 $this->removeFilesFromDir($from.'/'.$source, $to.'/'.$target);
             } else {
                 @unlink($to.'/'.$target);

--- a/src/Configurator/CopyFromRecipeConfigurator.php
+++ b/src/Configurator/CopyFromRecipeConfigurator.php
@@ -34,7 +34,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
-            if ('/' === $source[strlen($source) - 1]) {
+            if ('/' === $source[-1]) {
                 $this->copyDir($source, $to.'/'.$target, $files);
             } else {
                 $this->copyFile($to.'/'.$target, $files[$source]);
@@ -70,7 +70,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
-            if ('/' === $source[strlen($source) - 1]) {
+            if ('/' === $source[-1]) {
                 foreach (array_keys($files) as $file) {
                     if (0 === strpos($file, $source)) {
                         $this->removeFile($to.'/'.$target.'/'.substr($file, strlen($source)));

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -23,7 +23,7 @@ use Composer\Json\JsonFile;
  */
 class Downloader
 {
-    const ENDPOINT = 'https://flex.symfony.com';
+    private const ENDPOINT = 'https://flex.symfony.com';
 
     private $io;
     private $sess;


### PR DESCRIPTION
As of https://github.com/fabpot/flex/commit/eb603a775df3b7a206b26028a2449b5d53405f61 Flex requires PHP 7.1, so in addition to scalar type hints and return types added in #46, we can use more PHP 7.1 features (http://php.net/manual/en/migration71.new-features.php).