### PR TITLE
Proposal for adding a %VAR_DIR% variable

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -218,6 +218,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             'conf-dir' => 'conf',
             'etc-dir' => 'etc',
             'src-dir' => 'src',
+            'var-dir' => 'var',
             'web-dir' => 'web',
         ], $this->composer->getPackage()->getExtra());
 


### PR DESCRIPTION
In https://github.com/symfony/recipes-contrib/pull/5 we can see this:

```json
{
    "...": "...",

    "env": {
        "JWT_PRIVATE_KEY_PATH": "%kernel.project_dir%/var/jwt/private.pem",
        "JWT_PUBLIC_KEY_PATH": "%kernel.project_dir%/var/jwt/public.pem"
    }
}
```

He's using Symfony params in the value of the `env` vars because there's no `%VAR_DIR%` variable. We provide vars for every other dir (bin/, etc/, conf/, src/, web/) so, should we provide it for var/ too?