### PR TITLE
PHPUnit version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: nightly
-  allow_failures:
-    - php: nightly
   fast_finish: true
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
 env:
   global:
     - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+    - SYMFONY_PHPUNIT_VERSION="6.1"
     - COMPOSER_FLAGS=''
 
 install:


### PR DESCRIPTION
Increases PHPUnit version from `5.4` to `6.1`.

Fixes [nightly build](https://travis-ci.org/symfony/flex/jobs/227983361), which is currently an allowable failure.

(The problem was that PHPUnit 5.4 returns non-zero exit code in PHP master because [each() will be deprecated](https://github.com/php/php-src/commit/06a034016280435feb80eea4d674ca5688ab4c06) in 7.2.)