### PR TITLE
Simplifying autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
         "symfony/phpunit-bridge": "^3.2.8"
     },
     "autoload": {
-        "classmap": [
-            "src/Flex.php"
-        ],
         "psr-4": {
             "Symfony\\Flex\\": "src"
         }


### PR DESCRIPTION
Since the namespace was last changed, the `classmap` section of the Composer autoloader settings is not necessary.  This file is autoloaded anyway because of the `psr-4` section below.