### PR TITLE
Make Flex compatible with Composer <1.3

### DIFF
--- a/src/Command/RequireCommand.php
+++ b/src/Command/RequireCommand.php
@@ -30,7 +30,10 @@ class RequireCommand extends BaseRequireCommand
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
         $input->setArgument('packages', $this->resolver->resolve($input->getArgument('packages')));
-        $input->setOption('no-suggest', true);
+
+        if ($input->hasOption('no-suggest')) {
+            $input->setOption('no-suggest', true);
+        }
 
         return parent::execute($input, $output);
     }

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -30,7 +30,10 @@ class UpdateCommand extends BaseUpdateCommand
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
         $input->setArgument('packages', $this->resolver->resolve($input->getArgument('packages')));
-        $input->setOption('no-suggest', true);
+
+        if ($input->hasOption('no-suggest')) {
+            $input->setOption('no-suggest', true);
+        }
 
         return parent::execute($input, $output);
     }


### PR DESCRIPTION
If the option doesn't exist in the definition, an error is thrown.

This makes flex compatible with Composer versions that do not have this option in the command definition.

Fixes #68 