### PR TITLE
Use correct typehint 

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -185,7 +185,7 @@ class Downloader
         $this->degradedMode = true;
     }
 
-    private function getOptions(array $headers): array
+    private function getOptions(iterable $headers): array
     {
         $options = ['http' => ['header' => $headers]];
 


### PR DESCRIPTION
Simple fix for compatibility mismatch between the actual usage (always passing iterable) and the type hint (array) revealed by phpstan.