### PR TITLE
[BUG] copy of .env.dist only if it exists

### DIFF
--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -34,7 +34,7 @@ class EnvConfigurator extends AbstractConfigurator
             }
         }
         $data .= sprintf('###< %s ###%s', $recipe->getName(), PHP_EOL);
-        if (!file_exists(getcwd().'/.env')) {
+        if (!file_exists(getcwd().'/.env') && file_exists(getcwd().'/.env.dist')) {
             copy(getcwd().'/.env.dist', getcwd().'/.env');
         }
         file_put_contents(getcwd().'/.env.dist', $data, FILE_APPEND);


### PR DESCRIPTION
I might not have used Symfony Flex the right way, and I got an error after requiring my first package. Flex tries to copy the file `.env.dist` while this file doesn't exist yet.

```bash
$ git clone git@github.com:symfony/sandbox.git app && cd app
$ composer install
$ composer req doctrine -vvv
```

```
Downloading https://symfony.sh/m/doctrine/doctrine-bundle/1.6.x-dev
    Detected auto-configuration settings for "doctrine/doctrine-bundle"
    Enabling the package as a Symfony bundle
    Setting configuration and copying files
    Adding environment variable defaults

Installation failed, reverting ./composer.json to its original content.


  [ErrorException]
  copy(/app/.env.dist): failed to open stream: No such file or directory


Exception trace:
 () at /app/vendor/symfony/flex/src/Configurator/EnvConfigurator.php:38
 Composer\Util\ErrorHandler::handle() at n/a:n/a
 copy() at /app/vendor/symfony/flex/src/Configurator/EnvConfigurator.php:38
 Symfony\Flex\Configurator\EnvConfigurator->configure() at /app/vendor/symfony/flex/src/Configurator.php:52
```