### PR TITLE
Fix missed argument in BundlesConfigurator::unconfigure()

### DIFF
--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -47,7 +47,7 @@ class BundlesConfigurator extends AbstractConfigurator
         }
 
         $registered = $this->load($file);
-        foreach (array_keys($this->parse($bundles, $registered)) as $class) {
+        foreach (array_keys($this->parse($bundles, [])) as $class) {
             unset($registered[$class]);
         }
         $this->dump($file, $registered);

--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -47,7 +47,7 @@ class BundlesConfigurator extends AbstractConfigurator
         }
 
         $registered = $this->load($file);
-        foreach (array_keys($this->parse($bundles)) as $class) {
+        foreach (array_keys($this->parse($bundles, $registered)) as $class) {
             unset($registered[$class]);
         }
         $this->dump($file, $registered);


### PR DESCRIPTION
[Configurator\BundlesConfigurator] fix in method unconfigure() 

Missed second argument for method $this->parse is added.