### PR TITLE
Alphabetize bundles by key

### DIFF
--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -77,6 +77,7 @@ class BundlesConfigurator extends AbstractConfigurator
 
     private function dump(string $file, iterable $bundles): void
     {
+        ksort($bundles);
         $contents = '<?php'.PHP_EOL.PHP_EOL.'return ['.PHP_EOL;
         foreach ($bundles as $class => $envs) {
             $contents .= "    '$class' => [";

--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -33,13 +33,15 @@ class BundlesConfiguratorTest extends TestCase
         $configurator->configure($recipe, [
             'FooBundle' => ['dev', 'test'],
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all'],
+            'Symfony\Bundle\DebugBundle\DebugBundle' => ['all'],
         ]);
         $this->assertEquals(<<<EOF
 <?php
 
 return [
-    'Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all' => true],
     'FooBundle' => ['dev' => true, 'test' => true],
+    'Symfony\Bundle\DebugBundle\DebugBundle' => ['all' => true],
+    'Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all' => true],
 ];
 
 EOF


### PR DESCRIPTION
This helps organize bundles by vendor and bundle family. This is for UX and has no bearing on the performance of the application.

As an example, after setting up an initial skeleton project, I wanted to install api-platform, but since the default "minimum-stability" of skeleton is "stable" instead of "dev," a quick `composer req api` fails. So, I installed all of the libraries and bundles in https://github.com/api-platform/api-pack/blob/master/composer.json, then I ran `composer require admin` for added complexity. I took a look at my `bundles.php` and saw this:

```php
return [
    'Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all' => true],
    'Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle' => ['all' => true],
    'Doctrine\Bundle\DoctrineBundle\DoctrineBundle' => ['all' => true],
    'Symfony\Bundle\SecurityBundle\SecurityBundle' => ['all' => true],
    'Symfony\Bundle\TwigBundle\TwigBundle' => ['all' => true],
    'Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle' => ['all' => true],
    'JavierEguiluz\Bundle\EasyAdminBundle\EasyAdminBundle' => ['all' => true],
];
```

The bundles appear to be randomly sorted and I have a harder time quickly grokking which bundles are installed. Wouldn't it be nice to see all of these bundles arranged alphabetically so that I can see them grouped by vendor and maybe library family? Perhaps, something like this:

```php
return [
    'Doctrine\Bundle\DoctrineBundle\DoctrineBundle' => ['all' => true],
    'Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle' => ['all' => true],
    'JavierEguiluz\Bundle\EasyAdminBundle\EasyAdminBundle' => ['all' => true],
    'Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle' => ['all' => true],
    'Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all' => true],
    'Symfony\Bundle\SecurityBundle\SecurityBundle' => ['all' => true],
    'Symfony\Bundle\TwigBundle\TwigBundle' => ['all' => true],
];
```
As can be seen above, I can quickly tell that I have 2 Doctrine bundles, 3 Symfony bundles, a JavierEguiluz bundle, and a Sensio bundle. In the first example, I cannot quickly discern which bundles I have.

Imagine what this will look like once more and more bundles are added!