### PR TITLE
Use \n instead of PHP_EOL

### DIFF
--- a/src/Configurator/AbstractConfigurator.php
+++ b/src/Configurator/AbstractConfigurator.php
@@ -54,6 +54,6 @@ abstract class AbstractConfigurator
 
     protected function markData(Recipe $recipe, $data)
     {
-        return PHP_EOL.sprintf('###> %s ###%s%s%s###< %s ###%s', $recipe->getName(), PHP_EOL, rtrim($data, PHP_EOL), PHP_EOL, $recipe->getName(), PHP_EOL);
+        return "\n".sprintf('###> %s ###%s%s%s###< %s ###%s', $recipe->getName(), "\n", rtrim($data, "\r\n"), "\n", $recipe->getName(), "\n");
     }
 }

--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -77,15 +77,15 @@ class BundlesConfigurator extends AbstractConfigurator
 
     private function dump(string $file, iterable $bundles): void
     {
-        $contents = '<?php'.PHP_EOL.PHP_EOL.'return ['.PHP_EOL;
+        $contents = "<?php\n\nreturn [\n";
         foreach ($bundles as $class => $envs) {
             $contents .= "    '$class' => [";
             foreach (array_keys($envs) as $env) {
                 $contents .= "'$env' => true, ";
             }
-            $contents = substr($contents, 0, -2).'],'.PHP_EOL;
+            $contents = substr($contents, 0, -2)."],\n";
         }
-        $contents .= '];'.PHP_EOL;
+        $contents .= "];\n";
 
         if (!is_dir(dirname($file))) {
             mkdir(dirname($file), 0777, true);

--- a/src/Configurator/ContainerConfigurator.php
+++ b/src/Configurator/ContainerConfigurator.php
@@ -51,7 +51,7 @@ class ContainerConfigurator extends AbstractConfigurator
             }
             foreach ($parameters as $key => $value) {
                 // FIXME: var_export() only works for basics types, but we don't have access to the Symfony YAML component here
-                $lines[] = sprintf("    %s: %s%s", $key, var_export($value, true), PHP_EOL);
+                $lines[] = sprintf("    %s: %s%s", $key, var_export($value, true), "\n");
             }
         }
         file_put_contents($target, implode('', $lines));

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -33,10 +33,10 @@ class EnvConfigurator extends AbstractConfigurator
                 $value = bin2hex(random_bytes(16));
             }
             if ('#' === $key[0]) {
-                $data .= '# '.$value.PHP_EOL;
+                $data .= '# '.$value."\n";
             } else {
                 $value = $this->options->expandTargetDir($value);
-                $data .= "$key=$value".PHP_EOL;
+                $data .= "$key=$value\n";
             }
         }
         if (!file_exists(getcwd().'/.env')) {
@@ -55,7 +55,7 @@ class EnvConfigurator extends AbstractConfigurator
                 continue;
             }
 
-            $contents = preg_replace(sprintf('{%s+###> %s ###.*###< %s ###%s+}s', PHP_EOL, $recipe->getName(), $recipe->getName(), PHP_EOL), PHP_EOL, file_get_contents($env), -1, $count);
+            $contents = preg_replace(sprintf('{+###> %s ###.*###< %s ###%s+}s', "\n", $recipe->getName(), $recipe->getName(), "\n"), "\n", file_get_contents($env), -1, $count);
             if (!$count) {
                 continue;
             }

--- a/src/Configurator/GitignoreConfigurator.php
+++ b/src/Configurator/GitignoreConfigurator.php
@@ -29,9 +29,9 @@ class GitignoreConfigurator extends AbstractConfigurator
 
         $data = '';
         foreach ($vars as $value) {
-            $data .= "$value".PHP_EOL;
+            $data .= "$value\n";
         }
-        file_put_contents($gitignore, ltrim($this->markData($recipe, $data), PHP_EOL), FILE_APPEND);
+        file_put_contents($gitignore, ltrim($this->markData($recipe, $data), "\r\n"), FILE_APPEND);
     }
 
     public function unconfigure(Recipe $recipe, $vars): void
@@ -41,12 +41,12 @@ class GitignoreConfigurator extends AbstractConfigurator
             return;
         }
 
-        $contents = preg_replace(sprintf('{%s+###> %s ###.*###< %s ###%s+}s', PHP_EOL, $recipe->getName(), $recipe->getName(), PHP_EOL), PHP_EOL, file_get_contents($file), -1, $count);
+        $contents = preg_replace(sprintf('{%s+###> %s ###.*###< %s ###%s+}s', "\n", $recipe->getName(), $recipe->getName(), "\n"), "\n", file_get_contents($file), -1, $count);
         if (!$count) {
             return;
         }
 
         $this->write('Removing entries in .gitignore');
-        file_put_contents($file, ltrim($contents, PHP_EOL));
+        file_put_contents($file, ltrim($contents, "\r\n"));
     }
 }

--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -27,19 +27,19 @@ class MakefileConfigurator extends AbstractConfigurator
             return;
         }
 
-        $data = $this->markData($recipe, implode(PHP_EOL, $definitions));
+        $data = $this->markData($recipe, implode("\n", $definitions));
 
         if (!file_exists($makefile)) {
-            file_put_contents(getcwd().'/Makefile', str_replace("\n", PHP_EOL, <<<EOF
+            file_put_contents(getcwd().'/Makefile', <<<EOF
 ifndef APP_ENV
 	include .env
 endif
 
 
 EOF
-            ));
+            );
         }
-        file_put_contents(getcwd().'/Makefile', ltrim($data, PHP_EOL), FILE_APPEND);
+        file_put_contents(getcwd().'/Makefile', ltrim($data, "\r\n"), FILE_APPEND);
     }
 
     public function unconfigure(Recipe $recipe, $vars): void
@@ -48,7 +48,7 @@ EOF
             return;
         }
 
-        $contents = preg_replace(sprintf('{%s+###> %s ###.*###< %s ###%s+}s', PHP_EOL, $recipe->getName(), $recipe->getName(), PHP_EOL), PHP_EOL, file_get_contents($makefile), -1, $count);
+        $contents = preg_replace(sprintf('{%s+###> %s ###.*###< %s ###%s+}s', "\n", $recipe->getName(), $recipe->getName(), "\n"), "\n", file_get_contents($makefile), -1, $count);
         if (!$count) {
             return;
         }
@@ -57,7 +57,7 @@ EOF
         if (!trim($contents)) {
             @unlink($makefile);
         } else {
-            file_put_contents($makefile, ltrim($contents, PHP_EOL));
+            file_put_contents($makefile, ltrim($contents, "\r\n"));
         }
     }
 }

--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -67,7 +67,7 @@ class ScriptExecutor
             $this->io->writeError(' <error>[KO]</error>');
             $this->io->writeError(sprintf('<error>Script %s returned with error code %s</error>', $cmd, $exitCode));
             fseek($cmdOutput->getStream(), 0);
-            foreach (explode(PHP_EOL, stream_get_contents($cmdOutput->getStream())) as $line) {
+            foreach (explode("\n", stream_get_contents($cmdOutput->getStream())) as $line) {
                 $this->io->writeError('!!  '.$line);
             }
 


### PR DESCRIPTION
Using `PHP_EOL` may cause issues when some developers use Windows while others use UNIX. I propose to follow the UNIX convention.

Still a WIP.