### PR TITLE
do not resolve php or extensions

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -12,6 +12,7 @@
 namespace Symfony\Flex;
 
 use Composer\Package\Version\VersionParser;
+use Composer\Repository\PlatformRepository;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -46,7 +47,7 @@ class PackageResolver
         // second pass to resolve package names
         $packages = [];
         foreach ($explodedArguments as $i => $argument) {
-            if ('php' !== $argument && 0 !== strpos($argument, 'ext-') && false === strpos($argument, '/')) {
+            if (false === strpos($argument, '/') && !preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument)) {
                 if (null === self::$aliases) {
                     self::$aliases = $this->downloader->get('/aliases.json')->getBody();
                 }

--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -46,7 +46,7 @@ class PackageResolver
         // second pass to resolve package names
         $packages = [];
         foreach ($explodedArguments as $i => $argument) {
-            if (false === strpos($argument, '/')) {
+            if ('php' !== $argument && 0 !== strpos($argument, 'ext-') && false === strpos($argument, '/')) {
                 if (null === self::$aliases) {
                     self::$aliases = $this->downloader->get('/aliases.json')->getBody();
                 }

--- a/tests/PackageResolverTest.php
+++ b/tests/PackageResolverTest.php
@@ -43,6 +43,14 @@ class PackageResolverTest extends TestCase
                 ['cli:lts', 'validator=3.2', 'translation', 'next'],
                 ['symfony/console:^3.4', 'symfony/validator:3.2', 'symfony/translation:^4.0@dev']
             ],
+            [
+                ['php'],
+                ['php']
+            ],
+            [
+                ['ext-mongodb'],
+                ['ext-mongodb']
+            ],
         ];
     }
 


### PR DESCRIPTION
The Composer plugin is preventing the following commands from executing successfully:

```
composer require php
composer require ext-mongodb # (etc)
```