### PR TITLE
Change the way we install contrib packages

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -37,7 +37,6 @@ class Downloader
     private $endpoint;
     private $caFile;
     private $flexId;
-    private $allowContrib = false;
     private $repos = [];
 
     public function __construct(Composer $composer, IoInterface $io)
@@ -61,11 +60,6 @@ class Downloader
     public function setFlexId(?string $id): void
     {
         $this->flexId = $id;
-    }
-
-    public function allowContrib(bool $allow): void
-    {
-        $this->allowContrib = $allow;
     }
 
     public function setRepositories(array $repos): void
@@ -267,10 +261,6 @@ class Downloader
 
         if ($this->flexId) {
             $options['http']['header'][] = 'Project: '.$this->flexId;
-        }
-
-        if ($this->allowContrib) {
-            $options['http']['header'][] = 'Allow-Contrib: 1';
         }
 
         if ($this->repos) {

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -65,13 +65,8 @@ class Recipe
         return $this->data['origin'] ?? '';
     }
 
-    public function isNotInstallable(): bool
+    public function isContrib(): bool
     {
-        return $this->data['not_installable'] ?? false;
-    }
-
-    public function isEmpty(): bool
-    {
-        return count($this->data) > 0;
+        return $this->data['is_contrib'] ?? false;
     }
 }

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -15,6 +15,7 @@ use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\Installer\PackageEvent;
 use Composer\Package\Locker;
+use Composer\Package\RootPackageInterface;
 use Composer\Script\Event;
 use Composer\IO\BufferIO;
 use Composer\Package\Package;
@@ -61,10 +62,14 @@ class FlexTest extends TestCase
         $locker = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
         $locker->expects($this->any())->method('getLockData')->will($this->returnValue(['content-hash' => 'random']));
 
-        $flex = \Closure::bind(function () use ($configurator, $downloader, $io, $locker) {
+        $package = $this->getMockBuilder(RootPackageInterface::class)->disableOriginalConstructor()->getMock();
+        $package->expects($this->any())->method('getExtra')->will($this->returnValue(['symfony' => ['allow-contrib' => true]]));
+
+        $flex = \Closure::bind(function () use ($configurator, $downloader, $io, $locker, $package) {
             $flex = new Flex();
             $flex->composer = new Composer();
             $flex->composer->setLocker($locker);
+            $flex->composer->setPackage($package);
             $flex->io = $io;
             $flex->configurator = $configurator;
             $flex->downloader = $downloader;


### PR DESCRIPTION
When using Flex "extensively", installing contrib repos is a bit frustrating. If you opt-out (the default), you have a warning that the recipe won't be installed. The way to fix it is to 1/ remove the package 2/ enable contrib 3/ reinstall the package.

Instead, what about asking the question to the user and act accordingly (that means less to learn as enabling contrib is done automatically when selecting `[p]`)?

