### PR TITLE
Add help command and set it by default

### DIFF
--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -36,7 +36,7 @@ ifndef APP_ENV
 endif
 
 .DEFAULT_GOAL := help
-.PHONY : help
+.PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 

--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -38,7 +38,7 @@ endif
 .DEFAULT_GOAL := help
 .PHONY: help
 help:
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 
 EOF

--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -35,6 +35,11 @@ ifndef APP_ENV
 	include .env
 endif
 
+.DEFAULT_GOAL := help
+.PHONY : help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
 
 EOF
             );


### PR DESCRIPTION
This is a very opinionated PR so be free to close it if you don't like it.

When `make` is used without argument it will print an help showing available targets for the current project (`make help` can also be used). The output is based on this [post](https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html) but can be simplified.

![csgrxlf](https://user-images.githubusercontent.com/395137/30494647-4b00acd6-9a49-11e7-902b-9e1eab2fd8e1.png)

To use this feature "recipes" will have to comment public targets, for instance :

```makefile
cache-clear: ## Clear the cache
ifdef CONSOLE
	@$(CONSOLE) cache:clear --no-warmup
else
	@rm -rf var/cache/*
endif
```

Targets that are not commented are not visible (usefull to "hide" target used internaly like `serve_as_php` or `serve_as_symfony`)
