### PR TITLE
Do not rely on a hard coded config-dir in BundlesConfigurator

### DIFF
--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -100,6 +100,6 @@ class BundlesConfigurator extends AbstractConfigurator
 
     private function getConfFile(): string
     {
-        return getcwd().'/config/bundles.php';
+        return $this->options->expandTargetDir('%CONFIG_DIR%/bundles.php');
     }
 }

--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -15,20 +15,22 @@ require_once __DIR__.'/TmpDirMock.php';
 
 use Symfony\Flex\Configurator\BundlesConfigurator;
 use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Options;
 
 class BundlesConfiguratorTest extends TestCase
 {
     public function testConfigure()
     {
+        $config = sys_get_temp_dir().'/config/bundles.php';
+
         $configurator = new BundlesConfigurator(
             $this->getMockBuilder('Composer\Composer')->getMock(),
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
-            $this->getMockBuilder('Symfony\Flex\Options')->getMock()
+            new Options(['config-dir' => dirname($config)])
         );
 
         $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
 
-        $config = sys_get_temp_dir().'/config/bundles.php';
         @unlink($config);
         $configurator->configure($recipe, [
             'FooBundle' => ['dev', 'test'],


### PR DESCRIPTION
Currently, when `config-dir` is changed in `composer.json`, the `bundles.php` file is the only one generated in a hard coded location (`config/bundles.php`). Everything else is nicely put in the directory configured in `composer.json`. 

This is an attempt to fix the issue so that `config-dir` is respected by flex consistently.