### PR TITLE
Make Flex work on PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ sudo: false
 
 matrix:
   include:
-    - php: 7.1
+    - php: 7.0
     - php: 7.1
       env: COMPOSER_FLAGS='--prefer-lowest'
-    - php: nightly
+    - php: 7.2
   fast_finish: true
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.0",
         "composer-plugin-api": "^1.1"
     },
     "require-dev": {

--- a/src/Command/RemoveCommand.php
+++ b/src/Command/RemoveCommand.php
@@ -27,7 +27,7 @@ class RemoveCommand extends BaseRemoveCommand
         parent::__construct();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $input->setArgument('packages', $this->resolver->resolve($input->getArgument('packages')));
 

--- a/src/Command/RequireCommand.php
+++ b/src/Command/RequireCommand.php
@@ -27,7 +27,7 @@ class RequireCommand extends BaseRequireCommand
         parent::__construct();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $input->setArgument('packages', $this->resolver->resolve($input->getArgument('packages')));
 

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -27,7 +27,7 @@ class UpdateCommand extends BaseUpdateCommand
         parent::__construct();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $input->setArgument('packages', $this->resolver->resolve($input->getArgument('packages')));
 

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -44,7 +44,7 @@ class Configurator
         ];
     }
 
-    public function install(Recipe $recipe): void
+    public function install(Recipe $recipe)
     {
         $manifest = $recipe->getManifest();
         foreach (array_keys($this->configurators) as $key) {
@@ -54,7 +54,7 @@ class Configurator
         }
     }
 
-    public function unconfigure(Recipe $recipe): void
+    public function unconfigure(Recipe $recipe)
     {
         $manifest = $recipe->getManifest();
         foreach (array_keys($this->configurators) as $key) {

--- a/src/Configurator/AbstractConfigurator.php
+++ b/src/Configurator/AbstractConfigurator.php
@@ -32,11 +32,11 @@ abstract class AbstractConfigurator
         $this->options = $options;
     }
 
-    abstract public function configure(Recipe $recipe, $config): void;
+    abstract public function configure(Recipe $recipe, $config);
 
-    abstract public function unconfigure(Recipe $recipe, $config): void;
+    abstract public function unconfigure(Recipe $recipe, $config);
 
-    protected function write($messages): void
+    protected function write($messages)
     {
         if (!is_array($messages)) {
             $messages = [$messages];

--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -18,7 +18,7 @@ use Symfony\Flex\Recipe;
  */
 class BundlesConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $bundles): void
+    public function configure(Recipe $recipe, $bundles)
     {
         $this->write('Enabling the package as a Symfony bundle');
         $file = $this->getConfFile();
@@ -38,7 +38,7 @@ class BundlesConfigurator extends AbstractConfigurator
         $this->dump($file, $registered);
     }
 
-    public function unconfigure(Recipe $recipe, $bundles): void
+    public function unconfigure(Recipe $recipe, $bundles)
     {
         $this->write('Disabling the Symfony bundle');
         $file = $this->getConfFile();
@@ -53,7 +53,7 @@ class BundlesConfigurator extends AbstractConfigurator
         $this->dump($file, $registered);
     }
 
-    private function parse(iterable $manifest, iterable $registered): iterable
+    private function parse(array $manifest, array $registered): array
     {
         $bundles = [];
         foreach ($manifest as $class => $envs) {
@@ -65,7 +65,7 @@ class BundlesConfigurator extends AbstractConfigurator
         return $bundles;
     }
 
-    private function load(string $file): iterable
+    private function load(string $file): array
     {
         $bundles = file_exists($file) ? (require $file) : [];
         if (!is_array($bundles)) {
@@ -75,7 +75,7 @@ class BundlesConfigurator extends AbstractConfigurator
         return $bundles;
     }
 
-    private function dump(string $file, iterable $bundles): void
+    private function dump(string $file, array $bundles)
     {
         $contents = "<?php\n\nreturn [\n";
         foreach ($bundles as $class => $envs) {

--- a/src/Configurator/ComposerScriptsConfigurator.php
+++ b/src/Configurator/ComposerScriptsConfigurator.php
@@ -21,7 +21,7 @@ use Symfony\Flex\Recipe;
  */
 class ComposerScriptsConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $scripts): void
+    public function configure(Recipe $recipe, $scripts)
     {
         $json = new JsonFile(Factory::getComposerFile());
 
@@ -35,7 +35,7 @@ class ComposerScriptsConfigurator extends AbstractConfigurator
         file_put_contents($json->getPath(), $manipulator->getContents());
     }
 
-    public function unconfigure(Recipe $recipe, $scripts): void
+    public function unconfigure(Recipe $recipe, $scripts)
     {
         $json = new JsonFile(Factory::getComposerFile());
 

--- a/src/Configurator/ContainerConfigurator.php
+++ b/src/Configurator/ContainerConfigurator.php
@@ -18,13 +18,13 @@ use Symfony\Flex\Recipe;
  */
 class ContainerConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $parameters): void
+    public function configure(Recipe $recipe, $parameters)
     {
         $this->write('Setting parameters');
         $this->addParameters($parameters);
     }
 
-    public function unconfigure(Recipe $recipe, $parameters): void
+    public function unconfigure(Recipe $recipe, $parameters)
     {
         $this->write('Unsetting parameters');
         $target = getcwd().'/config/services.yaml';
@@ -40,7 +40,7 @@ class ContainerConfigurator extends AbstractConfigurator
         file_put_contents($target, implode('', $lines));
     }
 
-    private function addParameters(iterable $parameters): void
+    private function addParameters(array $parameters)
     {
         $target = getcwd().'/config/services.yaml';
         $lines = [];

--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -18,21 +18,21 @@ use Symfony\Flex\Recipe;
  */
 class CopyFromPackageConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $config): void
+    public function configure(Recipe $recipe, $config)
     {
         $this->write('Setting configuration and copying files');
         $packageDir = $this->composer->getInstallationManager()->getInstallPath($recipe->getPackage());
         $this->copyFiles($config, $packageDir, getcwd());
     }
 
-    public function unconfigure(Recipe $recipe, $config): void
+    public function unconfigure(Recipe $recipe, $config)
     {
         $this->write('Removing configuration and files');
         $packageDir = $this->composer->getInstallationManager()->getInstallPath($recipe->getPackage());
         $this->removeFiles($config, $packageDir, getcwd());
     }
 
-    private function copyFiles(iterable $manifest, string $from, string $to): void
+    private function copyFiles(array $manifest, string $from, string $to)
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
@@ -50,7 +50,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
         }
     }
 
-    private function removeFiles(iterable $manifest, string $from, string $to): void
+    private function removeFiles(array $manifest, string $from, string $to)
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
@@ -62,7 +62,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
         }
     }
 
-    private function copyDir(string $source, string $target): void
+    private function copyDir(string $source, string $target)
     {
         if (!is_dir($target)) {
             mkdir($target, 0777, true);
@@ -80,7 +80,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
         }
     }
 
-    public function copyFile(string $source, string $target): void
+    public function copyFile(string $source, string $target)
     {
         if (file_exists($target)) {
             return;
@@ -89,7 +89,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
         @chmod($target, fileperms($target) | (fileperms($source) & 0111));
     }
 
-    private function removeFilesFromDir(string $source, string $target): void
+    private function removeFilesFromDir(string $source, string $target)
     {
         $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($source, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($iterator as $item) {

--- a/src/Configurator/CopyFromRecipeConfigurator.php
+++ b/src/Configurator/CopyFromRecipeConfigurator.php
@@ -18,19 +18,19 @@ use Symfony\Flex\Recipe;
  */
 class CopyFromRecipeConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $config): void
+    public function configure(Recipe $recipe, $config)
     {
         $this->write('Setting configuration and copying files');
         $this->copyFiles($config, $recipe->getFiles(), getcwd());
     }
 
-    public function unconfigure(Recipe $recipe, $config): void
+    public function unconfigure(Recipe $recipe, $config)
     {
         $this->write('Removing configuration and files');
         $this->removeFiles($config, $recipe->getFiles(), getcwd());
     }
 
-    private function copyFiles(iterable $manifest, iterable $files, string $to): void
+    private function copyFiles(array $manifest, array $files, string $to)
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
@@ -42,7 +42,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
         }
     }
 
-    private function copyDir(string $source, string $target, iterable $files): void
+    private function copyDir(string $source, string $target, array $files)
     {
         foreach ($files as $file => $data) {
             if (0 === strpos($file, $source)) {
@@ -52,7 +52,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
         }
     }
 
-    private function copyFile(string $to, string $contents, bool $executable): void
+    private function copyFile(string $to, string $contents, bool $executable)
     {
         if (file_exists($to)) {
             return;
@@ -68,7 +68,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
         }
     }
 
-    private function removeFiles(iterable $manifest, iterable $files, string $to): void
+    private function removeFiles(array $manifest, array $files, string $to)
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
@@ -84,7 +84,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
         }
     }
 
-    private function removeFile(string $to): void
+    private function removeFile(string $to)
     {
         @unlink($to);
 

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -18,7 +18,7 @@ use Symfony\Flex\Recipe;
  */
 class EnvConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $vars): void
+    public function configure(Recipe $recipe, $vars)
     {
         $this->write('Adding environment variable defaults');
 
@@ -26,13 +26,13 @@ class EnvConfigurator extends AbstractConfigurator
         $this->configurePhpUnit($recipe, $vars);
     }
 
-    public function unconfigure(Recipe $recipe, $vars): void
+    public function unconfigure(Recipe $recipe, $vars)
     {
         $this->unconfigureEnvFiles($recipe, $vars);
         $this->unconfigurePhpUnit($recipe, $vars);
     }
 
-    private function configureEnvDist(Recipe $recipe, $vars): void
+    private function configureEnvDist(Recipe $recipe, $vars)
     {
         $distenv = getcwd().'/.env.dist';
         if ($this->isFileMarked($recipe, $distenv)) {
@@ -59,7 +59,7 @@ class EnvConfigurator extends AbstractConfigurator
         file_put_contents(getcwd().'/.env', $data, FILE_APPEND);
     }
 
-    private function configurePhpUnit(Recipe $recipe, $vars): void
+    private function configurePhpUnit(Recipe $recipe, $vars)
     {
         foreach (['phpunit.xml.dist', 'phpunit.xml'] as $file) {
             $phpunit = getcwd().'/'.$file;
@@ -88,7 +88,7 @@ class EnvConfigurator extends AbstractConfigurator
         }
     }
 
-    private function unconfigureEnvFiles(Recipe $recipe, $vars): void
+    private function unconfigureEnvFiles(Recipe $recipe, $vars)
     {
         foreach (['.env', '.env.dist'] as $file) {
             $env = getcwd().'/'.$file;
@@ -106,7 +106,7 @@ class EnvConfigurator extends AbstractConfigurator
         }
     }
 
-    private function unconfigurePhpUnit(Recipe $recipe, $vars): void
+    private function unconfigurePhpUnit(Recipe $recipe, $vars)
     {
         foreach (['phpunit.xml.dist', 'phpunit.xml'] as $file) {
             $phpunit = getcwd().'/'.$file;

--- a/src/Configurator/GitignoreConfigurator.php
+++ b/src/Configurator/GitignoreConfigurator.php
@@ -18,7 +18,7 @@ use Symfony\Flex\Recipe;
  */
 class GitignoreConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $vars): void
+    public function configure(Recipe $recipe, $vars)
     {
         $this->write('Adding entries to .gitignore');
 
@@ -34,7 +34,7 @@ class GitignoreConfigurator extends AbstractConfigurator
         file_put_contents($gitignore, "\n".ltrim($this->markData($recipe, $data), "\r\n"), FILE_APPEND);
     }
 
-    public function unconfigure(Recipe $recipe, $vars): void
+    public function unconfigure(Recipe $recipe, $vars)
     {
         $file = getcwd().'/.gitignore';
         if (!file_exists($file)) {

--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -18,7 +18,7 @@ use Symfony\Flex\Recipe;
  */
 class MakefileConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $definitions): void
+    public function configure(Recipe $recipe, $definitions)
     {
         $this->write('Adding Makefile entries');
 
@@ -42,7 +42,7 @@ EOF
         file_put_contents(getcwd().'/Makefile', "\n".ltrim($data, "\r\n"), FILE_APPEND);
     }
 
-    public function unconfigure(Recipe $recipe, $vars): void
+    public function unconfigure(Recipe $recipe, $vars)
     {
         if (!file_exists($makefile = getcwd().'/Makefile')) {
             return;

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -26,8 +26,8 @@ use Composer\Json\JsonFile;
  */
 class Downloader
 {
-    private const DEFAULT_ENDPOINT = 'https://symfony.sh';
-    private const MAX_LENGTH = 1000;
+    private static $DEFAULT_ENDPOINT = 'https://symfony.sh';
+    private static $MAX_LENGTH = 1000;
 
     private $io;
     private $sess;
@@ -47,7 +47,7 @@ class Downloader
         if (getenv('SYMFONY_ENDPOINT')) {
             $endpoint = getenv('SYMFONY_ENDPOINT');
         } else {
-            $endpoint = $composer->getPackage()->getExtra()['symfony']['endpoint'] ?? self::DEFAULT_ENDPOINT;
+            $endpoint = $composer->getPackage()->getExtra()['symfony']['endpoint'] ?? self::$DEFAULT_ENDPOINT;
         }
         $this->endpoint = rtrim($endpoint, '/');
         $this->io = $io;
@@ -57,12 +57,12 @@ class Downloader
         $this->sess = bin2hex(random_bytes(16));
     }
 
-    public function setFlexId(?string $id): void
+    public function setFlexId(string $id = null)
     {
         $this->flexId = $id;
     }
 
-    public function setRepositories(array $repos): void
+    public function setRepositories(array $repos)
     {
         $this->repos = $repos;
     }
@@ -105,7 +105,7 @@ class Downloader
             if ($date = $package->getReleaseDate()) {
                 $path .= ','.$date->format('U');
             }
-            if (strlen($chunk) + strlen($path) > self::MAX_LENGTH) {
+            if (strlen($chunk) + strlen($path) > self::$MAX_LENGTH) {
                 $paths[] = '/p/'.$chunk;
                 $chunk = $path;
             } elseif ($chunk) {
@@ -168,7 +168,7 @@ class Downloader
         }
     }
 
-    private function fetchFile(string $url, string $cacheKey, iterable $headers): Response
+    private function fetchFile(string $url, string $cacheKey, array $headers): Response
     {
         $options = $this->getOptions($headers);
         $retries = 3;
@@ -198,7 +198,7 @@ class Downloader
         }
     }
 
-    private function fetchFileIfLastModified(string $url, string $cacheKey, string $lastModifiedTime, iterable $headers): Response
+    private function fetchFileIfLastModified(string $url, string $cacheKey, string $lastModifiedTime, array $headers): Response
     {
         $headers[] = 'If-Modified-Since: '.$lastModifiedTime;
         $options = $this->getOptions($headers);
@@ -246,7 +246,7 @@ class Downloader
         return $response;
     }
 
-    private function switchToDegradedMode(\Exception $e, string $url): void
+    private function switchToDegradedMode(\Exception $e, string $url)
     {
         if (!$this->degradedMode) {
             $this->io->writeError('<warning>'.$e->getMessage().'</warning>');

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -98,7 +98,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    public function configureProject(Event $event): void
+    public function configureProject(Event $event)
     {
         $json = new JsonFile(Factory::getComposerFile());
         $manipulator = new JsonManipulator(file_get_contents($json->getPath()));
@@ -108,12 +108,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
         file_put_contents($json->getPath(), $manipulator->getContents());
     }
 
-    public function record(PackageEvent $event): void
+    public function record(PackageEvent $event)
     {
         $this->operations[] = $event->getOperation();
     }
 
-    public function prepare(Event $event): void
+    public function prepare(Event $event)
     {
         // be careful: the logic in this method won't be run when Flex is not installed yet
         if (!$this->originalLockHash) {
@@ -121,7 +121,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    private function updateOriginalLockHash(): void
+    private function updateOriginalLockHash()
     {
         $locker = $this->composer->getLocker();
         if ($locker && $locker->isLocked()) {
@@ -129,12 +129,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    public function install(Event $event): void
+    public function install(Event $event)
     {
         $this->update($event);
     }
 
-    public function update(Event $event): void
+    public function update(Event $event)
     {
         if (!file_exists(getcwd().'/.env') && file_exists(getcwd().'/.env.dist')) {
             copy(getcwd().'/.env.dist', getcwd().'/.env');
@@ -223,7 +223,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    public function executeAutoScripts(Event $event): void
+    public function executeAutoScripts(Event $event)
     {
         $event->stopPropagation();
 
@@ -296,7 +296,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         return new Options($options);
     }
 
-    private function getFlexId(): ?string
+    private function getFlexId()
     {
         $extra = $this->composer->getPackage()->getExtra();
 
@@ -332,7 +332,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         return sprintf('<info>%s</> (<comment>%s</>): From %s', $matches[1], $matches[2], 'auto-generated recipe' === $matches[3] ? '<comment>'.$matches[3].'</>' : $matches[3]);
     }
 
-    public static function getSubscribedEvents(): iterable
+    public static function getSubscribedEvents(): array
     {
         if (!self::$activated) {
             return [];

--- a/src/Options.php
+++ b/src/Options.php
@@ -23,7 +23,7 @@ class Options
         $this->options = $options;
     }
 
-    public function get(string $name): ?string
+    public function get(string $name)
     {
         return $this->options[$name] ?? null;
     }

--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -19,7 +19,7 @@ use Composer\Repository\PlatformRepository;
  */
 class PackageResolver
 {
-    private const SYMFONY_VERSIONS = ['lts', 'previous', 'stable', 'next'];
+    private static $SYMFONY_VERSIONS = ['lts', 'previous', 'stable', 'next'];
     private static $aliases;
     private static $versions;
     private $downloader;
@@ -29,7 +29,7 @@ class PackageResolver
         $this->downloader = $downloader;
     }
 
-    public function resolve(iterable $arguments = []): iterable
+    public function resolve(array $arguments = []): array
     {
         $versionParser = new VersionParser();
 
@@ -60,7 +60,7 @@ class PackageResolver
                         $versionParser->parseConstraints($argument);
                     } catch (\UnexpectedValueException $e) {
                         // is it a special Symfony version?
-                        if (!in_array($argument, self::SYMFONY_VERSIONS, true)) {
+                        if (!in_array($argument, self::$SYMFONY_VERSIONS, true)) {
                             $this->throwAlternatives($argument, $i);
                         }
                     }
@@ -95,7 +95,7 @@ class PackageResolver
 
         if ('next' === $version) {
             $version = '^'.self::$versions[$version].'@dev';
-        } elseif (in_array($version, self::SYMFONY_VERSIONS, true)) {
+        } elseif (in_array($version, self::$SYMFONY_VERSIONS, true)) {
             $version = '^'.self::$versions[$version];
         }
 
@@ -105,7 +105,7 @@ class PackageResolver
     /**
      * @throws \UnexpectedValueException
      */
-    private function throwAlternatives(string $argument, int $position): void
+    private function throwAlternatives(string $argument, int $position)
     {
         $alternatives = [];
         foreach (self::$aliases as $alias => $package) {

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -55,7 +55,7 @@ class Recipe
         return $this->data['manifest'];
     }
 
-    public function getFiles(): iterable
+    public function getFiles(): array
     {
         return $this->data['files'] ?? [];
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -24,7 +24,7 @@ class Response implements \JsonSerializable
     /**
      * @param mixed $body The response as JSON
      */
-    public function __construct($body, iterable $headers = [], int $code = 200)
+    public function __construct($body, array $headers = [], int $code = 200)
     {
         $this->body = $body;
         $this->origHeaders = $headers;
@@ -42,9 +42,9 @@ class Response implements \JsonSerializable
         return $this->headers[strtolower($name)][0] ?? '';
     }
 
-    public function getHeaders(string $name): ?array
+    public function getHeaders(string $name): array
     {
-        return $this->headers[strtolower($name)] ?? null;
+        return $this->headers[strtolower($name)] ?? [];
     }
 
     public function getBody()
@@ -52,7 +52,7 @@ class Response implements \JsonSerializable
         return $this->body;
     }
 
-    public function getOrigHeaders(): iterable
+    public function getOrigHeaders(): array
     {
         return $this->origHeaders;
     }
@@ -74,7 +74,7 @@ class Response implements \JsonSerializable
         return ['body' => $this->body, 'headers' => $this->headers];
     }
 
-    private function parseHeaders(iterable $headers): array
+    private function parseHeaders(array $headers): array
     {
         $values = [];
         foreach (array_reverse($headers) as $header) {

--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -41,7 +41,7 @@ class ScriptExecutor
     /**
      * @throws ScriptExecutionException if the executed command returns a non-0 exit code
      */
-    public function execute(string $type, string $cmd): void
+    public function execute(string $type, string $cmd)
     {
         $parsedCmd = $this->options->expandTargetDir($cmd);
         if (null === $expandedCmd = $this->expandCmd($type, $parsedCmd)) {
@@ -76,7 +76,7 @@ class ScriptExecutor
         }
     }
 
-    private function expandCmd(string $type, string $cmd): ?string
+    private function expandCmd(string $type, string $cmd)
     {
         switch ($type) {
             case 'symfony-cmd':
@@ -90,7 +90,7 @@ class ScriptExecutor
         }
     }
 
-    private function expandSymfonyCmd(string $cmd): ?string
+    private function expandSymfonyCmd(string $cmd)
     {
         $repo = $this->composer->getRepositoryManager()->getLocalRepository();
         if (!$repo->findPackage('symfony/console', new EmptyConstraint())) {


### PR DESCRIPTION
IMHO, enforcing 7.1 is only slowing down the adoption of Flex.
Unlike other existing projects that can tell "use the previous existing version",
we're starting with no community at all, and we want to spread adoption.
This is a strategic move to me.

Symfony 3.4 does work with 7.0, so PHP 7.0 users/companies that want to start new projects on it will have the choice to start with an already outdated standard edition, or nothing. This may hurt the Symfony project.

We have to provide a better alternative to them: Flex on PHP 7.0.
Here it is.