### PR TITLE
Fix PHP 7.0 compatibility

### DIFF
--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -36,7 +36,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
-            if ('/' === $source[-1]) {
+            if ('/' === substr($source, -1)) {
                 $this->copyDir($from.'/'.$source, $to.'/'.$target);
             } else {
                 if (!is_dir(dirname($to.'/'.$target))) {
@@ -54,7 +54,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
-            if ('/' === $source[-1]) {
+            if ('/' === substr($source, -1)) {
                 $this->removeFilesFromDir($from.'/'.$source, $to.'/'.$target);
             } else {
                 @unlink($to.'/'.$target);

--- a/src/Configurator/CopyFromRecipeConfigurator.php
+++ b/src/Configurator/CopyFromRecipeConfigurator.php
@@ -34,7 +34,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
-            if ('/' === $source[-1]) {
+            if ('/' === substr($source, -1)) {
                 $this->copyDir($source, $to.'/'.$target, $files);
             } else {
                 $this->copyFile($to.'/'.$target, $files[$source]['contents'], $files[$source]['executable']);
@@ -72,7 +72,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
     {
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
-            if ('/' === $source[-1]) {
+            if ('/' === substr($source, -1)) {
                 foreach (array_keys($files) as $file) {
                     if (0 === strpos($file, $source)) {
                         $this->removeFile($to.'/'.$target.'/'.substr($file, strlen($source)));


### PR DESCRIPTION
Negative string offsets (`$string[-1]`) only work since `7.1`:
 * https://wiki.php.net/rfc/negative-string-offsets
 * https://3v4l.org/kOlne

Other solution could be `substr($source, -1)` if your prefer.