### PR TITLE
Allowing to extend configurators and recipes

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -64,6 +64,23 @@ class Configurator
         }
     }
 
+    public function add(string $name, string $class)
+    {
+        if (false === strpos($name, '/')) {
+            throw new \InvalidArgumentException(sprintf('Flex configurator name "%s" must be prefixed with the vendor name, ex. "foo/custom-configurator".', $name));
+        }
+
+        if (isset($this->configurators[$name])) {
+            throw new \InvalidArgumentException(sprintf('Flex configurator with the name "%s" already exists.', $name));
+        }
+
+        if (!is_subclass_of($class, AbstractConfigurator::class)) {
+            throw new \InvalidArgumentException(sprintf('Flex configurator class "%s" must extend the class "%s".', $class, AbstractConfigurator::class));
+        }
+
+        $this->configurators[$name] = $class;
+    }
+
     private function get($key): AbstractConfigurator
     {
         if (!isset($this->configurators[$key])) {

--- a/src/FetchRecipesEvent.php
+++ b/src/FetchRecipesEvent.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex;
+
+use Composer\DependencyResolver\Operation\OperationInterface;
+use Composer\EventDispatcher\Event;
+use Composer\Package\PackageInterface;
+
+/**
+ * @author François Pluchino <francois.pluchino@gmail.com>
+ */
+class FetchRecipesEvent extends Event
+{
+    private $operations;
+
+    private $manifests = [];
+
+    /**
+     * @param string               $name       The event name
+     * @param OperationInterface[] $operations The operations of Composer
+     * @param array                $manifests  The manifests
+     */
+    public function __construct(string $name, array $operations, array $manifests)
+    {
+        parent::__construct($name);
+        $this->operations = $operations;
+        $this->manifests = $manifests;
+    }
+
+    /**
+     * @return OperationInterface[]
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    public function addManifest(PackageInterface $package, array $manifest)
+    {
+        $name = $package->getName();
+        $manifest['is_contrib'] = true;
+        if (!isset($manifest['origin'])) {
+            $manifest['origin'] = sprintf('%s:%s@composer-plugin recipe', $name, $package->getPrettyVersion());
+        }
+        $this->manifests[$name] = $manifest;
+    }
+
+    public function hasManifest(string $name): bool
+    {
+        return isset($this->manifests[$name]);
+    }
+
+    public function getManifest(string $name): array
+    {
+        return $this->manifests[$name] ?? [];
+    }
+
+    public function getManifests(): array
+    {
+        return $this->manifests;
+    }
+}

--- a/src/FlexEvents.php
+++ b/src/FlexEvents.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex;
+
+/**
+ * @author François Pluchino <francois.pluchino@gmail.com>
+ */
+class FlexEvents
+{
+    /**
+     * @Event("Symfony\Flex\FetchRecipesEvent")
+     */
+    const FETCH_RECIPES = 'flex.fetch_recipes';
+}

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests;
+
+use Composer\Composer;
+use Composer\IO\NullIO;
+use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Configurator;
+use Symfony\Flex\Options;
+
+class ConfiguratorTest extends TestCase
+{
+    public function testAdd()
+    {
+        $composer = new Composer();
+        $io = new NullIO();
+        $options = new Options();
+        $configurator = new Configurator($composer, $io, $options);
+        $ref = new \ReflectionClass($configurator);
+        $property = $ref->getProperty('configurators');
+        $property->setAccessible(true);
+
+        $this->assertArrayNotHasKey('foo/mock-configurator', $property->getValue($configurator));
+        $mockConfigurator = $this->getMockForAbstractClass(Configurator\AbstractConfigurator::class, [$composer, $io, $options]);
+        $configurator->add('foo/mock-configurator', get_class($mockConfigurator));
+        $this->assertArrayHasKey('foo/mock-configurator', $property->getValue($configurator));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Flex configurator name "mock-configurator" must be prefixed with the vendor name, ex. "foo/custom-configurator".
+     */
+    public function testAddWithoutVendorName()
+    {
+        $composer = new Composer();
+        $io = new NullIO();
+        $options = new Options();
+        $configurator = new Configurator($composer, $io, $options);
+        $mockConfigurator = $this->getMockForAbstractClass(Configurator\AbstractConfigurator::class, [$composer, $io, $options]);
+        $configurator->add('mock-configurator', get_class($mockConfigurator));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Flex configurator with the name "foo/mock-configurator" already exists.
+     */
+    public function testAddWithExistingConfiguratorName()
+    {
+        $composer = new Composer();
+        $io = new NullIO();
+        $options = new Options();
+        $configurator = new Configurator($composer, $io, $options);
+        $mockConfigurator = $this->getMockForAbstractClass(Configurator\AbstractConfigurator::class, [$composer, $io, $options]);
+        $configurator->add('foo/mock-configurator', get_class($mockConfigurator));
+        $configurator->add('foo/mock-configurator', get_class($mockConfigurator));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Flex configurator class "stdClass" must extend the class "Symfony\Flex\Configurator\AbstractConfigurator".
+     */
+    public function testAddWithoutAbstractConfiguratorClass()
+    {
+        $composer = new Composer();
+        $io = new NullIO();
+        $options = new Options();
+        $configurator = new Configurator($composer, $io, $options);
+        $configurator->add('foo/mock-configurator', \stdClass::class);
+    }
+}

--- a/tests/FetchRecipesEventTest.php
+++ b/tests/FetchRecipesEventTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests;
+
+use Composer\Package\PackageInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Flex\FetchRecipesEvent;
+
+class FetchRecipesEventTest extends TestCase
+{
+    public function testAddManifest()
+    {
+        $event = new FetchRecipesEvent('event.name', [], []);
+        $this->assertSame([], $event->getOperations());
+        $this->assertFalse($event->hasManifest('foo/bar'));
+        $this->assertSame([], $event->getManifest('foo/bar'));
+
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package->expects($this->once())->method('getName')->willReturn('foo/bar');
+        $package->expects($this->once())->method('getPrettyVersion')->willReturn('1.0.0');
+
+        $event->addManifest($package, ['manifest' => ['configurator' => 'action']]);
+        $this->assertTrue($event->hasManifest('foo/bar'));
+
+        $expected = [
+            'manifest' => ['configurator' => 'action'],
+            'is_contrib' => true,
+            'origin' => 'foo/bar:1.0.0@composer-plugin recipe',
+        ];
+        $this->assertSame($expected, $event->getManifest('foo/bar'));
+        $this->assertSame(['foo/bar' => $expected], $event->getManifests());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #173
| License       | MIT
| Doc PR        | ~

Symfony Flex as a great automation tool to standardize the project configuration system, but for the moment, it is limited to the specific configurators in her source code.

It would be very interesting to be able to extend the features of Flex with other plugin Composer. This would allow for example to add a new specific configurator to a project, or to set up recipes for private repositories (see #71).

All recipes added by a Composer plugin are considered like recipes of contributor, with a specific origin. So, the process of the contributor's recipes is retained (wizard, skip, or accept the recipe).

To add a new configurator, it's simple:

```php
<?php

namespace Foo\FlexExtension;

use Composer\Composer;
use Composer\EventDispatcher\EventSubscriberInterface;
use Composer\IO\IOInterface;
use Composer\Plugin\PluginInterface;
use Symfony\Flex\FetchRecipesEvent;
use Symfony\Flex\FlexEvents;

class FlexExtension implements PluginInterface, EventSubscriberInterface
{
    /**
     * {@inheritdoc}
     */
    public static function getSubscribedEvents()
    {
        return array(
            FlexEvents::FETCH_RECIPES => array(
                array('fetchRecipes', 0),
            ),
        );
    }

    /**
     * {@inheritdoc}
     */
    public function activate(Composer $composer, IOInterface $io)
    {
        foreach($composer->getPluginManager()->getPlugins() as $plugin) {
            if ($plugin instanceof \Symfony\Flex\Flex) {
                $plugin->add('foo/custom-configurator', \CustomConfigurator::class);
                break;
            }
        }
    }
    
    public function fetchRecipes(FetchRecipesEvent $event)
    {
        $composerOperations = $event->getOperations();
        // loop logic in operations
        $event->addManifest('bar/foo', [
            'foo/custom-configurator' => [
                'custom' => 'config',
            ],
        ]);
    }
}
```

> **Note:** The configurator name must have a vendor prefix.