### PR TITLE
Fix windows php invocation issues

### DIFF
--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -129,6 +129,6 @@ class ScriptExecutor
 
         $phpArgs = implode(' ', array_map('escapeshellarg', $arguments));
 
-        return escapeshellarg($php) . ($phpArgs ? ' '.$phpArgs : '') . ' ' . $cmd;
+        return escapeshellarg($php).($phpArgs ? ' '.$phpArgs : '').' '.$cmd;
     }
 }

--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -129,6 +129,6 @@ class ScriptExecutor
 
         $phpArgs = implode(' ', array_map('escapeshellarg', $arguments));
 
-        return $php.($phpArgs ? ' '.$phpArgs : '').' '.$cmd;
+        return escapeshellarg($php) . ($phpArgs ? ' '.$phpArgs : '') . ' ' . $cmd;
     }
 }


### PR DESCRIPTION
On windows the php binary may be located in a directory with spaces, IE "C:/Program Files/php/7.1/php.exe". Without escaping the php invocation you will receive an error:

```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  'C:\Program' is not recognized as an internal or external command,
!!  operable program or batch file.
!!
!!
```
This fixes that issue