### PR TITLE
Install fix with lock

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -128,6 +128,9 @@ class Downloader
             foreach ($body['vulnerabilities'] as $name => $vulns) {
                 $data['vulnerabilities'][$name] = $vulns;
             }
+            foreach ($body['locks'] ?? [] as $name => $lock) {
+                $data['locks'][$name] = $lock;
+            }
         }
         return $data;
     }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex;
+
+use Composer\Json\JsonFile;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Lock
+{
+    private $json;
+    private $lock = [];
+
+    public function __construct($lockFile)
+    {
+        $this->json = new JsonFile($lockFile);
+        if ($this->json->exists()) {
+            $this->lock = $this->json->read();
+        }
+    }
+
+    public function has($name): bool
+    {
+        return array_key_exists($name, $this->lock);
+    }
+
+    public function add($name, $data)
+    {
+        $this->lock[$name] = $data;
+    }
+
+    public function remove($name)
+    {
+        unset($this->lock[$name]);
+    }
+
+    public function write()
+    {
+        $this->json->write($this->lock);
+    }
+}


### PR DESCRIPTION
To fix #192 and some more edge cases, we need a proper lock file for Symfony recipes instead of trying to guess via the state of Composer. The lock stores more than needed for now, but that opens up some more opportunities for the future.

fixes #192
