### PR TITLE
Fix escaping in .env and phpunit.xml.dist

### DIFF
--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -48,6 +48,9 @@ class EnvConfigurator extends AbstractConfigurator
                 $data .= '# '.$value."\n";
             } else {
                 $value = $this->options->expandTargetDir($value);
+                if (false !== strpbrk($value, " \t\n&!\"")) {
+                    $value = '"'.str_replace(array('\\', '"', "\t", "\n"), array('\\\\', '\\"', '\t', '\n'), $value).'"';
+                }
                 $data .= "$key=$value\n";
             }
         }

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -77,10 +77,15 @@ class EnvConfigurator extends AbstractConfigurator
                     $value = bin2hex(random_bytes(16));
                 }
                 if ('#' === $key[0]) {
-                    $data .= '        <!-- '.$value." -->\n";
+                    $doc = new \DOMDocument();
+                    $data .= '        '.$doc->saveXML($doc->createComment(' '.$value.' '))."\n";
                 } else {
                     $value = $this->options->expandTargetDir($value);
-                    $data .= "        <env name=\"$key\" value=\"$value\" />\n";
+                    $doc = new \DOMDocument();
+                    $fragment = $doc->createElement('env');
+                    $fragment->setAttribute('name', $key);
+                    $fragment->setAttribute('value', $value);
+                    $data .= '        '.$doc->saveXML($fragment)."\n";
                 }
             }
             $data = $this->markXmlData($recipe, $data);

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -40,8 +40,12 @@ class EnvConfiguratorTest extends TestCase
         copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunitDist);
         copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunit);
         $configurator->configure($recipe, [
-            'APP_ENV' => 'test',
+            'APP_ENV' => 'test bar',
             'APP_DEBUG' => '0',
+            'APP_PARAGRAPH' => "foo\n\"bar\"\\t",
+            'DATABASE_URL' => 'mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7',
+            'MAILER_URL' => 'null://localhost',
+            'MAILER_USER' => 'fabien',
             '#1' => 'Comment 1',
             '#2' => 'Comment 3',
             'APP_SECRET' => 's3cretf0rt3st"<>',
@@ -50,11 +54,15 @@ class EnvConfiguratorTest extends TestCase
         $envContents = <<<EOF
 
 ###> FooBundle ###
-APP_ENV=test
+APP_ENV="test bar"
 APP_DEBUG=0
+APP_PARAGRAPH="foo\\n\\"bar\\"\\\\t"
+DATABASE_URL="mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7"
+MAILER_URL=null://localhost
+MAILER_USER=fabien
 # Comment 1
 # Comment 3
-APP_SECRET=s3cretf0rt3st"<>
+APP_SECRET="s3cretf0rt3st\"<>"
 ###< FooBundle ###
 
 EOF;
@@ -73,8 +81,12 @@ EOF;
         <env name="KERNEL_CLASS" value="App\Kernel" />
 
         <!-- ###+ FooBundle ### -->
-        <env name="APP_ENV" value="test"/>
+        <env name="APP_ENV" value="test bar"/>
         <env name="APP_DEBUG" value="0"/>
+        <env name="APP_PARAGRAPH" value="foo&#10;&quot;bar&quot;\\t"/>
+        <env name="DATABASE_URL" value="mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&amp;serverVersion=5.7"/>
+        <env name="MAILER_URL" value="null://localhost"/>
+        <env name="MAILER_USER" value="fabien"/>
         <!-- Comment 1 -->
         <!-- Comment 3 -->
         <env name="APP_SECRET" value="s3cretf0rt3st&quot;&lt;&gt;"/>

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -44,7 +44,7 @@ class EnvConfiguratorTest extends TestCase
             'APP_DEBUG' => '0',
             '#1' => 'Comment 1',
             '#2' => 'Comment 3',
-            'APP_SECRET' => 's3cretf0rt3st',
+            'APP_SECRET' => 's3cretf0rt3st"<>',
         ]);
 
         $envContents = <<<EOF
@@ -54,7 +54,7 @@ APP_ENV=test
 APP_DEBUG=0
 # Comment 1
 # Comment 3
-APP_SECRET=s3cretf0rt3st
+APP_SECRET=s3cretf0rt3st"<>
 ###< FooBundle ###
 
 EOF;
@@ -73,11 +73,11 @@ EOF;
         <env name="KERNEL_CLASS" value="App\Kernel" />
 
         <!-- ###+ FooBundle ### -->
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="0" />
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="0"/>
         <!-- Comment 1 -->
         <!-- Comment 3 -->
-        <env name="APP_SECRET" value="s3cretf0rt3st" />
+        <env name="APP_SECRET" value="s3cretf0rt3st&quot;&lt;&gt;"/>
         <!-- ###- FooBundle ### -->
     </php>
 


### PR DESCRIPTION
fixes symfony/recipes#233, #180, and #182