### PR TITLE
Fix line breaks for error messages

### DIFF
--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -50,7 +50,7 @@ class ScriptExecutor
 
         $cmdOutput = new StreamOutput(fopen('php://memory', 'rw'), OutputInterface::VERBOSITY_VERBOSE, $this->io->isDecorated());
         $outputHandler = function ($type, $buffer) use ($cmdOutput) {
-            $cmdOutput->write($buffer, OutputInterface::OUTPUT_RAW);
+            $cmdOutput->write($buffer, false, OutputInterface::OUTPUT_RAW);
         };
 
         $this->io->writeError(sprintf('Executing script %s', $parsedCmd), $this->io->isVerbose());


### PR DESCRIPTION
The arguments provided to the `StreamOutput` instance were not correctly set, leading to error messages with double line breaks like in this screenshot:

<img width="295" alt="app_ _michael_michaelsmbp2017_ _-zsh_ _160x45" src="https://user-images.githubusercontent.com/344445/32548842-6cc884fc-c487-11e7-8459-d32f5d19c16c.png">
