### PR TITLE
Fix container parameters configurator

### DIFF
--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -49,7 +49,7 @@ class EnvConfigurator extends AbstractConfigurator
             } else {
                 $value = $this->options->expandTargetDir($value);
                 if (false !== strpbrk($value, " \t\n&!\"")) {
-                    $value = '"'.str_replace(array('\\', '"', "\t", "\n"), array('\\\\', '\\"', '\t', '\n'), $value).'"';
+                    $value = '"'.str_replace(['\\', '"', "\t", "\n"], ['\\\\', '\\"', '\t', '\n'], $value).'"';
                 }
                 $data .= "$key=$value\n";
             }

--- a/src/SymfonyBundle.php
+++ b/src/SymfonyBundle.php
@@ -72,7 +72,7 @@ class SymfonyBundle
         $class = $namespace.'\\';
         $parts = explode('\\', $namespace);
         $suffix = $parts[count($parts) - 1];
-        $classes = array($class.$suffix);
+        $classes = [$class.$suffix];
         $acc = '';
         foreach (array_slice($parts, 0, -1) as $part) {
             if ('Bundle' === $part) {

--- a/tests/Configurator/ContainerConfiguratorTest.php
+++ b/tests/Configurator/ContainerConfiguratorTest.php
@@ -56,4 +56,125 @@ services:
 EOF
         , file_get_contents($config));
     }
+
+    public function testConfigureWithoutParametersKey()
+    {
+        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $config = sys_get_temp_dir().'/config/services.yaml';
+        file_put_contents($config, <<<EOF
+services:
+
+EOF
+        );
+        $configurator = new ContainerConfigurator(
+            $this->getMockBuilder('Composer\Composer')->getMock(),
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Symfony\Flex\Options')->getMock()
+        );
+        $configurator->configure($recipe, ['locale' => 'en']);
+        $this->assertEquals(<<<EOF
+parameters:
+    locale: 'en'
+
+services:
+
+EOF
+        , file_get_contents($config));
+
+        $configurator->unconfigure($recipe, ['locale' => 'en']);
+        $this->assertEquals(<<<EOF
+parameters:
+
+services:
+
+EOF
+        , file_get_contents($config));
+    }
+
+    public function testConfigureWithoutDuplicated()
+    {
+        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $config = sys_get_temp_dir().'/config/services.yaml';
+        file_put_contents($config, <<<EOF
+parameters:
+    locale: es
+
+services:
+
+EOF
+        );
+        $configurator = new ContainerConfigurator(
+            $this->getMockBuilder('Composer\Composer')->getMock(),
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Symfony\Flex\Options')->getMock()
+        );
+        $configurator->configure($recipe, ['locale' => 'en']);
+        $this->assertEquals(<<<EOF
+parameters:
+    locale: es
+
+services:
+
+EOF
+        , file_get_contents($config));
+
+        $configurator->unconfigure($recipe, ['locale' => 'en']);
+        $this->assertEquals(<<<EOF
+parameters:
+
+services:
+
+EOF
+        , file_get_contents($config));
+    }
+
+    public function testConfigureWithComplexContent()
+    {
+        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $config = sys_get_temp_dir().'/config/services.yaml';
+        file_put_contents($config, <<<EOF
+parameters:
+    # comment 1
+    locale: es
+
+    # comment 2
+    foo: bar
+
+services:
+
+EOF
+        );
+        $configurator = new ContainerConfigurator(
+            $this->getMockBuilder('Composer\Composer')->getMock(),
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Symfony\Flex\Options')->getMock()
+        );
+        $configurator->configure($recipe, ['locale' => 'en', 'foobar' => 'baz']);
+        $this->assertEquals(<<<EOF
+parameters:
+    # comment 1
+    locale: es
+
+    # comment 2
+    foo: bar
+    foobar: 'baz'
+
+services:
+
+EOF
+        , file_get_contents($config));
+
+        $configurator->unconfigure($recipe, ['locale' => 'en', 'foobar' => 'baz']);
+        $this->assertEquals(<<<EOF
+parameters:
+    # comment 1
+
+    # comment 2
+    foo: bar
+
+services:
+
+EOF
+        , file_get_contents($config));
+    }
 }


### PR DESCRIPTION
Fixes #202

- Configure and add `parameters` key if it does not exists.
- Configure without duplicated.
- Complex configuration with linebreak and comments.