### PR TITLE
[WIP][Proposal] Replace dir vars in copied manifest files

### DIFF
--- a/src/Configurator/CopyFromRecipeConfigurator.php
+++ b/src/Configurator/CopyFromRecipeConfigurator.php
@@ -62,7 +62,14 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
             mkdir(dirname($to), 0777, true);
         }
 
-        file_put_contents($to, $contents);
+        $dirVars = ['%BIN_DIR%', '%CONF_DIR%', '%CONFIG_DIR%', '%SRC_DIR%', '%VAR_DIR%', '%PUBLIC_DIR%'];
+
+        file_put_contents($to, str_replace(
+            $dirVars,
+            array_map(function ($dirVar) { return $this->options->expandTargetDir($dirVar); }, $dirVars),
+            $contents
+        ));
+
         if ($executable) {
             @chmod($to, fileperms($to) | 0111);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.0 (1.1)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | there is no test (yet) (so "no")
| Fixed tickets | #196
| License       | MIT
| Doc PR        | ---

With this PR we can replace the directory variables, that are already available in the `manifest.json` files (`%BIN_DIR%`, `%CONF_DIR%`, `%CONFIG_DIR%`, `%SRC_DIR%`, `%VAR_DIR%`, `%PUBLIC_DIR%`) inside all files, that are copied from manifests.
So, this can makes manifests more usable with a modified directory structure.

(Yes, this is very WIP, and I know, that we have to update all recipies to take advantage of this change. Use case for this PR is, to have something to discuss in the related ticket #196 )

I'm not sure, if it makes sense to limit this feature to `yaml` (or configuration) files only.