### PR TITLE
Add >= to "configuring" message

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -328,7 +328,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             return $origin;
         }
 
-        return sprintf('<info>%s</> (<comment>%s</>): From %s', $matches[1], $matches[2], 'auto-generated recipe' === $matches[3] ? '<comment>'.$matches[3].'</>' : $matches[3]);
+        return sprintf('<info>%s</> (<comment>>=%s</>): From %s', $matches[1], $matches[2], 'auto-generated recipe' === $matches[3] ? '<comment>'.$matches[3].'</>' : $matches[3]);
     }
 
     private function shouldRecordOperation(OperationInterface $operation): bool

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -91,7 +91,7 @@ class FlexTest extends TestCase
 
         $this->assertSame(<<<EOF
 Symfony operations: 1 recipe ()
-  - Configuring dummy/dummy (1.0): From github.com/symfony/recipes:master
+  - Configuring dummy/dummy (>=1.0): From github.com/symfony/recipes:master
 
 EOF
             , $io->getOutput()


### PR DESCRIPTION
It's surprising to see "3.3" when installing a 4.0.0 component. This should fix it.