### PR TITLE
Check if file config/services.yaml exists in container configurator

### DIFF
--- a/src/Configurator/ContainerConfigurator.php
+++ b/src/Configurator/ContainerConfigurator.php
@@ -29,15 +29,17 @@ class ContainerConfigurator extends AbstractConfigurator
         $this->write('Unsetting parameters');
         $target = getcwd().'/config/services.yaml';
         $lines = [];
-        foreach (file($target) as $line) {
-            foreach (array_keys($parameters) as $key) {
-                if (preg_match("/^\s+$key\:/", $line)) {
-                    continue 2;
+        if (file_exists($target)) {
+            foreach (file($target) as $line) {
+                foreach (array_keys($parameters) as $key) {
+                    if (preg_match("/^\s+$key\:/", $line)) {
+                        continue 2;
+                    }
                 }
+                $lines[] = $line;
             }
-            $lines[] = $line;
+            file_put_contents($target, implode('', $lines));
         }
-        file_put_contents($target, implode('', $lines));
     }
 
     private function addParameters(array $parameters)
@@ -46,23 +48,25 @@ class ContainerConfigurator extends AbstractConfigurator
         $endAt = 0;
         $isParameters = false;
         $lines = [];
-        foreach (file($target) as $i => $line) {
-            $lines[] = $line;
-            if (!$isParameters && !preg_match('/^parameters\:/', $line)) {
-                continue;
-            }
-            if (!$isParameters) {
-                $isParameters = true;
-                continue;
-            }
-            if (!preg_match('/^\s+.*/', $line) && '' !== trim($line)) {
-                $endAt = $i - 1;
-                $isParameters = false;
-                continue;
-            }
-            foreach ($parameters as $key => $value) {
-                if (preg_match("/^\s+$key\:/", $line)) {
-                    unset($parameters[$key]);
+        if (file_exists($target)) {
+            foreach (file($target) as $i => $line) {
+                $lines[] = $line;
+                if (!$isParameters && !preg_match('/^parameters\:/', $line)) {
+                    continue;
+                }
+                if (!$isParameters) {
+                    $isParameters = true;
+                    continue;
+                }
+                if (!preg_match('/^\s+.*/', $line) && '' !== trim($line)) {
+                    $endAt = $i - 1;
+                    $isParameters = false;
+                    continue;
+                }
+                foreach ($parameters as $key => $value) {
+                    if (preg_match("/^\s+$key\:/", $line)) {
+                        unset($parameters[$key]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
I tried to use Flex without `symfony/framework-bundle`. And i found that composer failed on `composer require symfony/flex symfony/translation` (inside empty directory).

```
C:\Users\Mindubaev\Docker\3\test>composer require symfony/flex symfony/translation
Using version ^1.0 for symfony/flex
Using version ^4.0 for symfony/translation
./composer.json has been created
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 3 installs, 0 updates, 0 removals
  - Installing symfony/flex (v1.0.44): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.6.0): Loading from cache
  - Installing symfony/translation (v4.0.0): Loading from cache
Writing lock file
Generating autoload files
Symfony operations: 2 recipes (758a6b4154678ac32e8aea9774634c4b)
  - Configuring symfony/flex (>=1.0): From github.com/symfony/recipes:master
  - Configuring symfony/translation (>=3.3): From github.com/symfony/recipes:master


  [ErrorException]
  file(C:\Users\Mindubaev\Docker\3\test/config/services.yaml): failed to open stream: No such file or directory
```

This PR fixes this issue.

Btw, composer failed even when i run `composer require symfony/flex symfony/translation symfony/framework-bundle` (but, i do not know how to fix this)