### PR TITLE
Sort recipes on update before configuration

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -118,7 +118,11 @@ class Flex implements PluginInterface, EventSubscriberInterface
     {
         $operation = $event->getOperation();
         if ($this->shouldRecordOperation($operation)) {
-            $this->operations[] = $operation;
+            if ($operation instanceof InstallOperation && 'symfony/framework-bundle' === $operation->getPackage()->getName()) {
+                array_unshift($this->operations, $operation);
+            } else {
+                $this->operations[] = $operation;
+            }
         }
     }
 


### PR DESCRIPTION
Recipe for `symfony/framework-bundle` must be applied after recipe for `symfony/flex` and before all other recipes on install/update.

See #225 
