### PR TITLE
Only try to unpack packages when the user used a package name

### DIFF
--- a/src/Command/RequireCommand.php
+++ b/src/Command/RequireCommand.php
@@ -47,14 +47,16 @@ class RequireCommand extends BaseRequireCommand
             $op->addPackage($package['name'], $package['version'] ?? '', $input->getOption('dev'));
         }
 
-        $unpacker = new Unpacker($this->getComposer());
-        $result = $unpacker->unpack($op);
-        $io = $this->getIo();
-        foreach ($result->getUnpacked() as $pkg) {
-            $io->writeError(sprintf('<info>Unpacked %s dependencies</>', $pkg->getName()));
-        }
+        if ($packages) {
+            $unpacker = new Unpacker($this->getComposer());
+            $result = $unpacker->unpack($op);
+            $io = $this->getIo();
+            foreach ($result->getUnpacked() as $pkg) {
+                $io->writeError(sprintf('<info>Unpacked %s dependencies</>', $pkg->getName()));
+            }
 
-        $input->setArgument('packages', $result->getRequired());
+            $input->setArgument('packages', $result->getRequired());
+        }
 
         if ($input->hasOption('no-suggest')) {
             $input->setOption('no-suggest', true);


### PR DESCRIPTION
My solution to fix #252 .

As said in the title I'd say it's only needed to unpack the packages if the user entered a package. With this fix you can just use "composer require" again and search for packages using the composer suggestions.