### PR TITLE
Point users towards Symfony documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ dependencies.
 
 [1]: https://symfony.com/doc/current/setup/flex.html
 [2]: https://symfony.com
-[2]: https://symfony.sh
+[3]: https://symfony.sh

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
     <img src="https://symfony.com/logos/symfony_black_02.svg">
 </a></p>
 
-[Symfony Flex][1] helps developers create Symfony applications, from the most
+[Symfony Flex][1] helps developers create [Symfony][2] applications, from the most
 simple micro-style projects to the more complex ones with dozens of
 dependencies.
 
-[Discover][2] the available recipes.
+[Discover][3] the available recipes.
 
 [1]: https://symfony.com/doc/current/setup/flex.html
-[2]: https://symfony.sh/
+[2]: https://symfony.com
+[2]: https://symfony.sh

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
     <img src="https://symfony.com/logos/symfony_black_02.svg">
 </a></p>
 
-[Symfony][1] Flex helps developers create Symfony applications, from the most
+[Symfony Flex][1] helps developers create Symfony applications, from the most
 simple micro-style projects to the more complex ones with dozens of
 dependencies.
 
-[Read more][2] about using it for your own project.
+[Discover][2] the available recipes.
 
-[1]: https://symfony.com
-[2]: https://medium.com/@fabpot/symfony-4-a-quick-demo-da7d32be323
+[2]: https://symfony.com/doc/current/setup/flex.html
+[2]: https://symfony.sh/

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ dependencies.
 
 [Discover][2] the available recipes.
 
-[2]: https://symfony.com/doc/current/setup/flex.html
+[1]: https://symfony.com/doc/current/setup/flex.html
 [2]: https://symfony.sh/


### PR DESCRIPTION
When I land on this page now it feels like this is still experimental because of this as currently the readme is pointing the user to a blog post of over half a year ago when Flex was less complete and Symfony 3.4 and 4.0 were not released yet. I think it would be less confusing to just link to the actual current documentation on symfony.com instead which will be kept in sync with new developments.