### PR TITLE
Fix flex v1.0.55 using wrong class name

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -436,7 +436,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             ScriptEvents::POST_CREATE_PROJECT_CMD => 'configureProject',
             ScriptEvents::POST_INSTALL_CMD => 'install',
             ScriptEvents::POST_UPDATE_CMD => 'update',
-            PluginEvents::COMMAND => 'inspectCommand',
+            CommandEvent::COMMAND => 'inspectCommand',
             'auto-scripts' => 'executeAutoScripts',
         ];
     }


### PR DESCRIPTION
Ref https://github.com/symfony/flex/pull/262#pullrequestreview-86327921