### PR TITLE
Workaround: Avoid emojis which cause terminal failures in Docker

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -171,12 +171,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
 
         if ($this->displayThanksReminder) {
-            $love = '\\' === DIRECTORY_SEPARATOR ? 'love' : '💖 ';
-            $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '⭐ ';
-
             $this->io->writeError('');
             $this->io->writeError('What about running <comment>composer global require symfony/thanks && composer thanks</> now?');
-            $this->io->writeError(sprintf('This will spread some %s by sending a %s to the GitHub repositories of your fellow package maintainers.', $love, $star));
+            $this->io->writeError('This will spread some love by sending a star to the GitHub repositories of your fellow package maintainers.');
             $this->io->writeError('');
         }
 


### PR DESCRIPTION
Sending certain unicode values to STDOUT may cause Docker terminals to abruptly quit and disconnect for some users, as noted in docker/toolbox#695  and moby/moby#22345. In this particular case the issue is triggered by the emoji star (U+2B50) which was added in #262 / 0a45ec98fe91340001746baa1336c5d9d827f938 . 

While this is **not a bug in Flex**, I still recommend skipping the cosmetic emojis, since their appeal is probably outweighed by the impact and users and the potential that some users will incorrectly blame Flex when `composer update` disconnects their terminal halfway through the "thanks reminder."