### PR TITLE
★

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -169,7 +169,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
         if ($this->displayThanksReminder) {
             $love = '\\' === DIRECTORY_SEPARATOR ? 'love' : '💖 ';
-            $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '⭐ ';
+            $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '★ ';
 
             $this->io->writeError('');
             $this->io->writeError('What about running <comment>composer global require symfony/thanks && composer thanks</> now?');

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -168,9 +168,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
 
         if ($this->displayThanksReminder) {
+            $love = '\\' === DIRECTORY_SEPARATOR ? 'love' : '💖 ';
+            $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '⭐ ';
+
             $this->io->writeError('');
             $this->io->writeError('What about running <comment>composer global require symfony/thanks && composer thanks</> now?');
-            $this->io->writeError('This will spread some love by sending a star to the GitHub repositories of your fellow package maintainers.');
+            $this->io->writeError(sprintf('This will spread some %s by sending a %s to the GitHub repositories of your fellow package maintainers.', $love, $star));
             $this->io->writeError('');
         }
 


### PR DESCRIPTION
Same as https://github.com/symfony/thanks/pull/34

Reverts https://github.com/symfony/flex/pull/280 and replaces the breaking character by another one:

The ⭐ emoji contains the \x90 byte that breaks Docker toolbox on Windows (see docker/toolbox#695).
Let's use ★ instead.
  
  