### PR TITLE
Fix tests on Windows: Normalize line-endings

### DIFF
--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -154,7 +154,7 @@ Symfony operations: 1 recipe ()
 
 EOF
             ,
-            $io->getOutput()
+            str_replace("\r\n", "\n", $io->getOutput())
         );
     }
 


### PR DESCRIPTION
Tests were failing on Windows.


### Before:

```
λ vendor\bin\simple-phpunit.bat

PHPUnit 5.7.26 by Sebastian Bergmann and contributors.

Testing Symfony Flex Test Suite
..........F...................                                    30 / 30 (100%)

Time: 428 ms, Memory: 6.00MB

There was 1 failure:

1) Symfony\Flex\Tests\FlexTest::testPostInstall
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 #Warning: Strings contain different line endings!
 Symfony operations: 1 recipe ()
   - Configuring dummy/dummy (>=1.0): From github.com/symfony/recipes:master
```

### After

```
λ vendor\bin\simple-phpunit.bat
PHPUnit 5.7.26 by Sebastian Bergmann and contributors.

Testing Symfony Flex Test Suite
..............................                                    30 / 30 (100%)

Time: 752 ms, Memory: 6.00MB

OK (30 tests, 92 assertions)
```