### PR TITLE
Sort bundles.php alphabetically

### DIFF
--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -78,6 +78,10 @@ class BundlesConfigurator extends AbstractConfigurator
     private function dump(string $file, array $bundles)
     {
         $contents = "<?php\n\nreturn [\n";
+
+        // sort bundles alphabetically to prevent unnecessary merge-conflicts
+        ksort($bundles);
+
         foreach ($bundles as $class => $envs) {
             $contents .= "    $class::class => [";
             foreach (array_keys($envs) as $env) {

--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -40,8 +40,8 @@ class BundlesConfiguratorTest extends TestCase
 <?php
 
 return [
-    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     FooBundle::class => ['dev' => true, 'test' => true],
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
 ];
 
 EOF


### PR DESCRIPTION
Generated `bundles.php` should be sorted alphabetically to prevent unnecessary merge-conflicts. 
`symfony.lock` and `composer.json` are already sorted automatically.