### PR TITLE
simplify matching for showing makefile targets

### DIFF
--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -40,7 +40,7 @@ endif
 .DEFAULT_GOAL := help
 .PHONY: help
 help:
-	@grep -E '^[a-zA-Z-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-15s\033[0m %s\\n", $$1, $$2}'
+	@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z-]+:.*?## .*$$/ {printf "\033[32m%-15s\033[0m %s\\n", $$1, $$2}' Makefile | sort
 
 EOF
             );


### PR DESCRIPTION
does not use grep anymore, awk can do this as well