### PR TITLE
support for custom symfony.lock file path

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -182,7 +182,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    public function getLockFilePath()
+    private function getLockFilePath()
     {
         $composerFile = Factory::getComposerFile();
         $lockFilePath = "json" === pathinfo($composerFile, PATHINFO_EXTENSION)
@@ -197,7 +197,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             "symfony" => $symfonyLock
         ];
     }
-    public function isComposerLockMissing()
+    private function isComposerLockMissing()
     {
         return file_exists(Factor::getComposerFile()) && !file_exists($this->getLockFilePath()->composer);
     }

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -101,7 +101,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $this->configurator = new Configurator($composer, $io, $this->options);
         $this->downloader = new Downloader($composer, $io, $this->rfs);
         $this->downloader->setFlexId($this->getFlexId());
-        $this->lock = new Lock($this->getLockFilePath()->symfony);
+        $this->lock = new Lock($this->getSymfonyLockFilePath());
 
         $populateRepoCacheDir = __CLASS__ === self::class;
         if ($composer->getPluginManager()) {
@@ -182,25 +182,28 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    private function getLockFilePath()
+    private function getComposerLockFilePath()
     {
         $composerFile = Factory::getComposerFile();
         $lockFilePath = "json" === pathinfo($composerFile, PATHINFO_EXTENSION)
                 ? substr($composerFile, 0, -4).'lock'
                 :  $composerFile .  '.lock';
+        return $lockFilePath;
+    }
+
+    private function getSymfonyLockFilePath()
+    {
+        $lockFilePath = $this->getComposerLockFilePath();
         $symfonyLock = str_replace("composer.", "symfony.", $lockFilePath);
         if (getenv("SYMFONY_LOCKFILE_PATH")) {
             $symfonyLock  = getenv("SYMFONY_LOCKFILE_PATH");
         }
-        return (object)[
-            "composer" => $lockFilePath,
-            "symfony" => $symfonyLock
-        ];
+        return $symfonyLock;
     }
 
     private function isComposerLockMissing()
     {
-        return file_exists(Factory::getComposerFile()) && !file_exists($this->getLockFilePath()->composer);
+        return file_exists(Factory::getComposerFile()) && !file_exists($this->getComposerLockFilePath());
     }
 
     public function configureProject(Event $event)

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -101,7 +101,11 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $this->configurator = new Configurator($composer, $io, $this->options);
         $this->downloader = new Downloader($composer, $io, $this->rfs);
         $this->downloader->setFlexId($this->getFlexId());
-        $this->lock = new Lock(str_replace(Factory::getComposerFile(), 'composer.json', 'symfony.lock'));
+        $lock_file_path = str_replace(Factory::getComposerFile(), 'composer.json', 'symfony.lock');
+        if(getenv("SYMFONY_LOCKFILE_PATH")) {
+          $lock_file_path  = getenv("SYMFONY_LOCKFILE_PATH");
+        }
+        $this->lock = new Lock($lock_file_path);
 
         $populateRepoCacheDir = __CLASS__ === self::class;
         if ($composer->getPluginManager()) {

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -169,7 +169,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                 }
             }
 
-            if ($populateRepoCacheDir && isset(self::$repoReadingCommands[$command]) && ('install' !== $command || ($this->composerLockMissing()))) {
+            if ($populateRepoCacheDir && isset(self::$repoReadingCommands[$command]) && ('install' !== $command || ($this->isComposerLockMissing()))) {
                 $this->populateRepoCacheDir();
             }
 

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -197,10 +197,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
             "symfony" => $symfonyLock
         ];
     }
+
     private function isComposerLockMissing()
     {
         return file_exists(Factor::getComposerFile()) && !file_exists($this->getLockFilePath()->composer);
     }
+
     public function configureProject(Event $event)
     {
         $json = new JsonFile(Factory::getComposerFile());

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -200,7 +200,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     private function isComposerLockMissing()
     {
-        return file_exists(Factor::getComposerFile()) && !file_exists($this->getLockFilePath()->composer);
+        return file_exists(Factory::getComposerFile()) && !file_exists($this->getLockFilePath()->composer);
     }
 
     public function configureProject(Event $event)

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -102,8 +102,8 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $this->downloader = new Downloader($composer, $io, $this->rfs);
         $this->downloader->setFlexId($this->getFlexId());
         $lock_file_path = str_replace(Factory::getComposerFile(), 'composer.json', 'symfony.lock');
-        if(getenv("SYMFONY_LOCKFILE_PATH")) {
-          $lock_file_path  = getenv("SYMFONY_LOCKFILE_PATH");
+        if (getenv("SYMFONY_LOCKFILE_PATH")) {
+            $lock_file_path  = getenv("SYMFONY_LOCKFILE_PATH");
         }
         $this->lock = new Lock($lock_file_path);
 
@@ -173,7 +173,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                 }
             }
 
-            if ($populateRepoCacheDir && isset(self::$repoReadingCommands[$command]) && ('install' !== $command || (file_exists('composer.json') && !file_exists('composer.lock')))) {
+            if ($populateRepoCacheDir && isset(self::$repoReadingCommands[$command]) && ('install' !== $command || ($this->composerLockMissing()))) {
                 $this->populateRepoCacheDir();
             }
 
@@ -186,6 +186,15 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
+    public function composerLockMissing()
+    {
+        if (getenv("COMPOSER")) {
+            $composer_file = getenv("COMPOSER");
+            $composer_lock = str_replace(".json", ".lock", $composer_file);
+            return file_exists($composer_file) && !file_exists($composer_lock);
+        }
+        return file_exists('composer.json') && !file_exists('composer.lock');
+    }
     public function configureProject(Event $event)
     {
         $json = new JsonFile(Factory::getComposerFile());

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -78,6 +78,25 @@ class FlexTest extends TestCase
         ];
     }
 
+    /**
+     * dataset0: custom COMPOSER env is set, generates correct symfony lock
+     * dataset1: nothing overriden, just verify default names
+     * dataset2: composer = default, custom symfony.lock path
+     * @testWith ["composer.beta.json","", "composer.beta.lock", "symfony.beta.lock"]
+     *           ["","", "./composer.lock", "./symfony.lock"]
+     *           ["","symfony.beta.lock", "./composer.lock", "symfony.beta.lock"]
+     */
+    public function testSymfonyLock($composerEnv, $symfonyEnv, $expectedComposer, $expectedSymfony ) {
+
+
+        putenv("COMPOSER=" . $composerEnv);
+        putenv("SYMFONY_LOCKFILE_PATH=" . $symfonyEnv);
+
+        $flex = new Flex();
+        $r = $flex->getLockFilePath();
+        $this->assertEquals($expectedComposer, $r->composer);
+        $this->assertEquals($expectedSymfony, $r->symfony);
+    }
     public function testPostInstall()
     {
         $package = new Package('dummy/dummy', '1.0.0', '1.0.0');

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -106,9 +106,10 @@ class FlexTest extends TestCase
         putenv("SYMFONY_LOCKFILE_PATH=" . $symfonyEnv);
 
         $flex = new Flex();
-        $r = $this->invokeMethod($flex, 'getLockFilePath', []);
-        $this->assertEquals($expectedComposer, $r->composer);
-        $this->assertEquals($expectedSymfony, $r->symfony);
+        $symfonyLockFile = $this->invokeMethod($flex, 'getSymfonyLockFilePath', []);
+        $composerLockFile = $this->invokeMethod($flex, 'getComposerLockFilePath', []);
+        $this->assertEquals($expectedComposer, $composerLockFile);
+        $this->assertEquals($expectedSymfony, $symfonyLockFile);
 
         putenv("COMPOSER=''");
         putenv("SYMFONY_LOCKFILE_PATH=''");

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -98,12 +98,7 @@ class FlexTest extends TestCase
     }
 
     /**
-     * dataset0: custom COMPOSER env is set, generates correct symfony lock
-     * dataset1: nothing overriden, just verify default names
-     * dataset2: composer = default, custom symfony.lock path
-     * @testWith ["composer.beta.json","", "composer.beta.lock", "symfony.beta.lock"]
-     *           ["","", "./composer.lock", "./symfony.lock"]
-     *           ["","symfony.beta.lock", "./composer.lock", "symfony.beta.lock"]
+     * @dataProvider getLockFileTestCases
      */
     public function testSymfonyLock($composerEnv, $symfonyEnv, $expectedComposer, $expectedSymfony)
     {
@@ -117,6 +112,18 @@ class FlexTest extends TestCase
 
         putenv("COMPOSER=''");
         putenv("SYMFONY_LOCKFILE_PATH=''");
+    }
+
+    /**
+     * dataset0: custom COMPOSER env is set, generates correct symfony lock
+     * dataset1: nothing overriden, just verify default names
+     * dataset2: composer = default, custom symfony.lock path
+     */
+    public function getLockFileTestCases()
+    {
+        return  [["composer.beta.json","", "composer.beta.lock", "symfony.beta.lock"],
+                 ["","", "./composer.lock", "./symfony.lock"],
+                 ["","symfony.beta.lock", "./composer.lock", "symfony.beta.lock"]];
     }
 
     public function testPostInstall()

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -118,6 +118,7 @@ class FlexTest extends TestCase
         putenv("COMPOSER=''");
         putenv("SYMFONY_LOCKFILE_PATH=''");
     }
+
     public function testPostInstall()
     {
         $package = new Package('dummy/dummy', '1.0.0', '1.0.0');

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -32,7 +32,6 @@ use Symfony\Flex\Response;
 
 class FlexTest extends TestCase
 {
-
     /**
     * Call protected/private method of a class.
     * taken from Juan Tremino's fantastic tutorial
@@ -108,8 +107,6 @@ class FlexTest extends TestCase
      */
     public function testSymfonyLock($composerEnv, $symfonyEnv, $expectedComposer, $expectedSymfony)
     {
-
-
         putenv("COMPOSER=" . $composerEnv);
         putenv("SYMFONY_LOCKFILE_PATH=" . $symfonyEnv);
 
@@ -117,7 +114,6 @@ class FlexTest extends TestCase
         $r = $this->invokeMethod($flex, 'getLockFilePath', []);
         $this->assertEquals($expectedComposer, $r->composer);
         $this->assertEquals($expectedSymfony, $r->symfony);
-
 
         putenv("COMPOSER=''");
         putenv("SYMFONY_LOCKFILE_PATH=''");

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -96,6 +96,10 @@ class FlexTest extends TestCase
         $r = $flex->getLockFilePath();
         $this->assertEquals($expectedComposer, $r->composer);
         $this->assertEquals($expectedSymfony, $r->symfony);
+
+
+        putenv("COMPOSER=''");
+        putenv("SYMFONY_LOCKFILE_PATH=''");
     }
     public function testPostInstall()
     {

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -115,16 +115,14 @@ class FlexTest extends TestCase
         putenv("SYMFONY_LOCKFILE_PATH=''");
     }
 
-    /**
-     * dataset0: custom COMPOSER env is set, generates correct symfony lock
-     * dataset1: nothing overriden, just verify default names
-     * dataset2: composer = default, custom symfony.lock path
-     */
     public function getLockFileTestCases()
     {
-        return  [["composer.beta.json","", "composer.beta.lock", "symfony.beta.lock"],
-                 ["","", "./composer.lock", "./symfony.lock"],
-                 ["","symfony.beta.lock", "./composer.lock", "symfony.beta.lock"]];
+        // custom COMPOSER env is set, generates correct symfony lock
+        yield ["composer.beta.json","", "composer.beta.lock", "symfony.beta.lock"];
+        // nothing overriden, just verify default names
+        yield ["","", "./composer.lock", "./symfony.lock"];
+        // composer = default, custom symfony.lock path
+        yield ["","symfony.beta.lock", "./composer.lock", "symfony.beta.lock"];
     }
 
     public function testPostInstall()

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -43,7 +43,7 @@ class FlexTest extends TestCase
     *
     * @return mixed Method return.
     */
-    public function invokeMethod(&$object, $methodName, array $parameters = array())
+    private function invokeMethod($object, $methodName, array $parameters = array())
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -32,6 +32,26 @@ use Symfony\Flex\Response;
 
 class FlexTest extends TestCase
 {
+
+    /**
+    * Call protected/private method of a class.
+    * taken from Juan Tremino's fantastic tutorial
+    * https://jtreminio.com/2013/03/unit-testing-tutorial-part-3-testing-protected-private-methods-coverage-reports-and-crap/
+    *
+    * @param object &$object    Instantiated object that we will run method on.
+    * @param string $methodName Method name to call
+    * @param array  $parameters Array of parameters to pass into method.
+    *
+    * @return mixed Method return.
+    */
+    public function invokeMethod(&$object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method->invokeArgs($object, $parameters);
+    }
+
     /**
      * @dataProvider getRecordTests
      */
@@ -86,14 +106,15 @@ class FlexTest extends TestCase
      *           ["","", "./composer.lock", "./symfony.lock"]
      *           ["","symfony.beta.lock", "./composer.lock", "symfony.beta.lock"]
      */
-    public function testSymfonyLock($composerEnv, $symfonyEnv, $expectedComposer, $expectedSymfony ) {
+    public function testSymfonyLock($composerEnv, $symfonyEnv, $expectedComposer, $expectedSymfony)
+    {
 
 
         putenv("COMPOSER=" . $composerEnv);
         putenv("SYMFONY_LOCKFILE_PATH=" . $symfonyEnv);
 
         $flex = new Flex();
-        $r = $flex->getLockFilePath();
+        $r = $this->invokeMethod($flex, 'getLockFilePath', []);
         $this->assertEquals($expectedComposer, $r->composer);
         $this->assertEquals($expectedSymfony, $r->symfony);
 


### PR DESCRIPTION
we are using 2 different composer.json files. to  handle beta and master builds.


e.g:

installing beta dependencies:
`COMPOSER=composer.beta.json composer install`

`symfony.lock` is not really capable of handling a situation like this.
this PR adds a env `SYMFONY_LOCKFILE_PATH`

this way one can set the name/path of the symfony.lock file

for us it results in:
`COMPOSER=composer.beta.json SYMFONY_LOCKFILE_PATH=symfony.beta.lock composer install`

and for master/prod
`composer install`


let me know if you want me to change anything in this PR.
keep up the good work ❤️ 