### PR TITLE
Allow to define the amount of bytes for generated values

### DIFF
--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -41,9 +41,7 @@ class EnvConfigurator extends AbstractConfigurator
 
         $data = '';
         foreach ($vars as $key => $value) {
-            if ('%generate(secret)%' === $value) {
-                $value = bin2hex(random_bytes(16));
-            }
+            $value = $this->replaceGeneratedValue($value);
             if ('#' === $key[0] && is_numeric(substr($key, 1))) {
                 $data .= '# '.$value."\n";
 
@@ -78,9 +76,7 @@ class EnvConfigurator extends AbstractConfigurator
 
             $data = '';
             foreach ($vars as $key => $value) {
-                if ('%generate(secret)%' === $value) {
-                    $value = bin2hex(random_bytes(16));
-                }
+                $value = $this->replaceGeneratedValue($value);
                 if ('#' === $key[0]) {
                     if (is_numeric(substr($key, 1))) {
                         $doc = new \DOMDocument();
@@ -141,5 +137,22 @@ class EnvConfigurator extends AbstractConfigurator
             $this->write(sprintf('Removed environment variables from %s', $file));
             file_put_contents($phpunit, $contents);
         }
+    }
+
+    private function replaceGeneratedValue($value)
+    {
+        if ('%generate(secret)%' === $value) {
+            return $this->generateRandomBytes();
+        }
+        if (preg_match('~^%generate\(([0-9]+)\)%$~', $value, $matches)) {
+            return $this->generateRandomBytes($matches[1]);
+        }
+
+        return $value;
+    }
+
+    private function generateRandomBytes($length = 16)
+    {
+        return bin2hex(random_bytes($length));
     }
 }

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -144,7 +144,7 @@ class EnvConfigurator extends AbstractConfigurator
         if ('%generate(secret)%' === $value) {
             return $this->generateRandomBytes();
         }
-        if (preg_match('~^%generate\(secret,\s?([0-9]+)\)%$~', $value, $matches)) {
+        if (preg_match('~^%generate\(secret,\s*([0-9]+)\)%$~', $value, $matches)) {
             return $this->generateRandomBytes($matches[1]);
         }
 

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -144,7 +144,7 @@ class EnvConfigurator extends AbstractConfigurator
         if ('%generate(secret)%' === $value) {
             return $this->generateRandomBytes();
         }
-        if (preg_match('~^%generate\(([0-9]+)\)%$~', $value, $matches)) {
+        if (preg_match('~^%generate\(secret,\s?([0-9]+)\)%$~', $value, $matches)) {
             return $this->generateRandomBytes($matches[1]);
         }
 

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -36,7 +36,8 @@ class EnvConfiguratorTest extends TestCase
 
         $phpunit = sys_get_temp_dir().'/phpunit.xml';
         $phpunitDist = $phpunit.'.dist';
-        @unlink($phpunit, $phpunitDist);
+        @unlink($phpunit);
+        @unlink($phpunitDist);
         copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunitDist);
         copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunit);
         $configurator->configure($recipe, [
@@ -143,5 +144,45 @@ EOF
         $this->assertFileEquals(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunit);
 
         @unlink($phpunit, $env);
+    }
+
+    public function testConfigureGeneratedSecret()
+    {
+        $configurator = new EnvConfigurator(
+            $this->getMockBuilder('Composer\Composer')->getMock(),
+            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            new Options()
+        );
+
+        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
+
+        $env = sys_get_temp_dir().'/.env.dist';
+        @unlink($env);
+        touch($env);
+        $phpunit = sys_get_temp_dir().'/phpunit.xml';
+        $phpunitDist = $phpunit.'.dist';
+        @unlink($phpunit);
+        @unlink($phpunitDist);
+
+        copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunitDist);
+        copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunit);
+
+        $configurator->configure($recipe, [
+            '#TRUSTED_SECRET' => '%generate(32)%',
+            'APP_SECRET' => '%generate(secret)%',
+        ]);
+
+        $envContents = file_get_contents($env);
+        $this->assertRegExp('/#TRUSTED_SECRET=[a-z0-9]{64}/', $envContents);
+        $this->assertRegExp('/APP_SECRET=[a-z0-9]{32}/', $envContents);
+        @unlink($env);
+
+        foreach ([$phpunitDist, $phpunit] as $file) {
+            $fileContents = file_get_contents($file);
+
+            $this->assertRegExp('/<!-- env name="TRUSTED_SECRET" value="[a-z0-9]{64}" -->/', $fileContents);
+            $this->assertRegExp('/<env name="APP_SECRET" value="[a-z0-9]{32}"\/>/', $fileContents);
+        }
     }
 }

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -169,19 +169,22 @@ EOF
         copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunit);
 
         $configurator->configure($recipe, [
-            '#TRUSTED_SECRET' => '%generate(32)%',
+            '#TRUSTED_SECRET_1' => '%generate(secret,32)%',
+            '#TRUSTED_SECRET_2' => '%generate(secret, 32)%',
             'APP_SECRET' => '%generate(secret)%',
         ]);
 
         $envContents = file_get_contents($env);
-        $this->assertRegExp('/#TRUSTED_SECRET=[a-z0-9]{64}/', $envContents);
+        $this->assertRegExp('/#TRUSTED_SECRET_1=[a-z0-9]{64}/', $envContents);
+        $this->assertRegExp('/#TRUSTED_SECRET_2=[a-z0-9]{64}/', $envContents);
         $this->assertRegExp('/APP_SECRET=[a-z0-9]{32}/', $envContents);
         @unlink($env);
 
         foreach ([$phpunitDist, $phpunit] as $file) {
             $fileContents = file_get_contents($file);
 
-            $this->assertRegExp('/<!-- env name="TRUSTED_SECRET" value="[a-z0-9]{64}" -->/', $fileContents);
+            $this->assertRegExp('/<!-- env name="TRUSTED_SECRET_1" value="[a-z0-9]{64}" -->/', $fileContents);
+            $this->assertRegExp('/<!-- env name="TRUSTED_SECRET_2" value="[a-z0-9]{64}" -->/', $fileContents);
             $this->assertRegExp('/<env name="APP_SECRET" value="[a-z0-9]{32}"\/>/', $fileContents);
         }
     }

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -171,12 +171,14 @@ EOF
         $configurator->configure($recipe, [
             '#TRUSTED_SECRET_1' => '%generate(secret,32)%',
             '#TRUSTED_SECRET_2' => '%generate(secret, 32)%',
+            '#TRUSTED_SECRET_3' => '%generate(secret,     32)%',
             'APP_SECRET' => '%generate(secret)%',
         ]);
 
         $envContents = file_get_contents($env);
         $this->assertRegExp('/#TRUSTED_SECRET_1=[a-z0-9]{64}/', $envContents);
         $this->assertRegExp('/#TRUSTED_SECRET_2=[a-z0-9]{64}/', $envContents);
+        $this->assertRegExp('/#TRUSTED_SECRET_3=[a-z0-9]{64}/', $envContents);
         $this->assertRegExp('/APP_SECRET=[a-z0-9]{32}/', $envContents);
         @unlink($env);
 
@@ -185,6 +187,7 @@ EOF
 
             $this->assertRegExp('/<!-- env name="TRUSTED_SECRET_1" value="[a-z0-9]{64}" -->/', $fileContents);
             $this->assertRegExp('/<!-- env name="TRUSTED_SECRET_2" value="[a-z0-9]{64}" -->/', $fileContents);
+            $this->assertRegExp('/<!-- env name="TRUSTED_SECRET_3" value="[a-z0-9]{64}" -->/', $fileContents);
             $this->assertRegExp('/<env name="APP_SECRET" value="[a-z0-9]{32}"\/>/', $fileContents);
         }
     }


### PR DESCRIPTION
Currently it's only possible with _%generate(secret)%_ to generate a 16 byte random value but I also wanted to be able to generated a 32 byte one instead. So I've implemented to possibility to define the number of bytes: _%generate(32)%_. Of course it's possible to define any number there so other use cases can be supported to. To stay backwards compatible _%generate(secret)%_ will still work.

While adding the test I also found a tiny bug where unlink() in another test.