### PR TITLE
Rename install-recipes to setup-recipes

### DIFF
--- a/src/Command/SetupRecipesCommand.php
+++ b/src/Command/SetupRecipesCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Flex\Lock;
 
-class InstallRecipesCommand extends BaseCommand
+class SetupRecipesCommand extends BaseCommand
 {
     private $flex;
 
@@ -32,7 +32,7 @@ class InstallRecipesCommand extends BaseCommand
 
     protected function configure()
     {
-        $this->setName('install-recipes')
+        $this->setName('setup-recipes')
             ->setDescription('Install missing recipes.')
         ;
     }

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -184,7 +184,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $app->add(new Command\UpdateCommand($resolver));
             $app->add(new Command\RemoveCommand($resolver));
             $app->add(new Command\UnpackCommand($resolver));
-            $app->add(new Command\InstallRecipesCommand($this));
+            $app->add(new Command\SetupRecipesCommand($this));
 
             break;
         }


### PR DESCRIPTION
I'm used to running `composer ins`, but #338 breaks it.