### PR TITLE
Fix: Do not invoke static method dynamically

### DIFF
--- a/src/Command/UnpackCommand.php
+++ b/src/Command/UnpackCommand.php
@@ -108,7 +108,7 @@ class UnpackCommand extends BaseCommand
         }
         $lockData['packages'] = array_values($lockData['packages']);
         $lockData['packages-dev'] = array_values($lockData['packages-dev']);
-        $lockData['content-hash'] = $locker->getContentHash(file_get_contents($json->getPath()));
+        $lockData['content-hash'] = $locker::getContentHash(file_get_contents($json->getPath()));
         $lockFile = new JsonFile(substr($json->getPath(), 0, -4).'lock', null, $io);
         $lockFile->write($lockData);
 


### PR DESCRIPTION
This PR

* [x] invokes a `static` method `statically`