### PR TITLE
Fix: Use strict comparison

### DIFF
--- a/tests/Configurator/CopyDirectoryFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyDirectoryFromPackageConfiguratorTest.php
@@ -121,8 +121,8 @@ class CopyDirectoryFromPackageConfiguratorTest extends TestCase
         if (is_dir($dir)) {
             $objects = scandir($dir);
             foreach ($objects as $object) {
-                if ($object != "." && $object != "..") {
-                    if (filetype($dir."/".$object) == "dir") {
+                if ($object !== "." && $object !== "..") {
+                    if (filetype($dir."/".$object) === "dir") {
                         $this->rrmdir($dir."/".$object);
                     } else {
                         unlink($dir."/".$object);


### PR DESCRIPTION
This PR

* [x] uses strict comparisons where possible

Follows https://github.com/symfony/flex/pull/356/files#r184845342.