### PR TITLE
Fix: Provide missing description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
     - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
     - SYMFONY_PHPUNIT_VERSION="6.1"
     - COMPOSER_FLAGS=''
+    
+before_install:
+  - composer validate
 
 install:
   - composer update $COMPOSER_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "symfony/flex",
     "type": "composer-plugin",
+    "description": "Composer plugin for Symfony",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
This PR

* [x] runs `composer validate` in `before_install` section on Travis
* [x] provides an otherwise missing description in `composer.json`

💁‍♂️ Running

``` 
$ composer validate
```

yields

```
/composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
```