### PR TITLE
Fix: Sort out configuration for friendsofphp/php-cs-fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
+.php_cs.cache
 composer.lock

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,6 +1,9 @@
 <?php
 
+$finder = PhpCsFixer\Finder::create()->in(__DIR__);
+
 return PhpCsFixer\Config::create()
+    ->setFinder($finder)
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,

--- a/src/Command/FixRecipesCommand.php
+++ b/src/Command/FixRecipesCommand.php
@@ -76,7 +76,7 @@ class FixRecipesCommand extends BaseCommand
             $operations[] = new InstallOperation($pkg);
         }
 
-        $this->flex->update(new class extends Event {
+        $this->flex->update(new class() extends Event {
             public function __construct()
             {
             }


### PR DESCRIPTION
This PR

* [x] configures a finder 
* [x] ignores the cache file
* [x] runs `php-cs-fixer`

Spotted in #365.
Follows #364.

💁‍♂️ Running

```
$ php-cs-fixer fix
```

yields

```
Loaded config default from "/Users/am/Sites/symfony/flex/.php_cs.dist".

In Finder.php line 568:

  You must call one of in() or append() methods before iterating over a Finder.


fix [--path-mode PATH-MODE] [--allow-risky ALLOW-RISKY] [--config CONFIG] [--dry-run] [--rules RULES] [--using-cache USING-CACHE] [--cache-file CACHE-FILE] [--diff] [--diff-format DIFF-FORMAT] [--format FORMAT] [--stop-on-violation] [--show-progress SHOW-PROGRESS] [--] [<path>]...
```

which reflects the complaints by fabbot.io in #365:

![screen shot 2018-05-02 at 23 16 37](https://user-images.githubusercontent.com/605483/39549676-05646166-4e5f-11e8-86e3-4e7d58d95352.png)
