### PR TITLE
Fix: Use class keyword instead of string literals

### DIFF
--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -16,6 +16,7 @@ require_once __DIR__.'/TmpDirMock.php';
 use Symfony\Flex\Configurator\BundlesConfigurator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Options;
+use Symfony\Flex\Recipe;
 
 class BundlesConfiguratorTest extends TestCase
 {
@@ -29,7 +30,7 @@ class BundlesConfiguratorTest extends TestCase
             new Options(['config-dir' => dirname($config)])
         );
 
-        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
 
         @unlink($config);
         $configurator->configure($recipe, [

--- a/tests/Configurator/ContainerConfiguratorTest.php
+++ b/tests/Configurator/ContainerConfiguratorTest.php
@@ -16,12 +16,15 @@ require_once __DIR__.'/TmpDirMock.php';
 use Symfony\Flex\Configurator\ContainerConfigurator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Options;
+use Symfony\Flex\Recipe;
+use Composer\Composer;
+use Composer\IO\IOInterface;
 
 class ContainerConfiguratorTest extends TestCase
 {
     public function testConfigure()
     {
-        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $config = sys_get_temp_dir().'/config/services.yaml';
         file_put_contents(
             $config,
@@ -34,8 +37,8 @@ services:
 EOF
         );
         $configurator = new ContainerConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => dirname($config)])
         );
         $configurator->configure($recipe, ['locale' => 'en']);
@@ -62,7 +65,7 @@ EOF
 
     public function testConfigureWithoutParametersKey()
     {
-        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $config = sys_get_temp_dir().'/config/services.yaml';
         file_put_contents(
             $config,
@@ -72,8 +75,8 @@ services:
 EOF
         );
         $configurator = new ContainerConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => dirname($config)])
         );
         $configurator->configure($recipe, ['locale' => 'en']);
@@ -98,7 +101,7 @@ EOF
 
     public function testConfigureWithoutDuplicated()
     {
-        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $config = sys_get_temp_dir().'/config/services.yaml';
         file_put_contents(
             $config,
@@ -111,8 +114,8 @@ services:
 EOF
         );
         $configurator = new ContainerConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => dirname($config)])
         );
         $configurator->configure($recipe, ['locale' => 'en']);
@@ -137,7 +140,7 @@ EOF
 
     public function testConfigureWithComplexContent()
     {
-        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $config = sys_get_temp_dir().'/config/services.yaml';
         file_put_contents(
             $config,
@@ -154,8 +157,8 @@ services:
 EOF
         );
         $configurator = new ContainerConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => dirname($config)])
         );
         $configurator->configure($recipe, ['locale' => 'en', 'foobar' => 'baz']);

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -16,18 +16,21 @@ require_once __DIR__.'/TmpDirMock.php';
 use Symfony\Flex\Configurator\EnvConfigurator;
 use Symfony\Flex\Options;
 use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Recipe;
+use Composer\IO\IOInterface;
+use Composer\Composer;
 
 class EnvConfiguratorTest extends TestCase
 {
     public function testConfigure()
     {
         $configurator = new EnvConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options()
         );
 
-        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
 
         $env = sys_get_temp_dir().'/.env.dist';
@@ -149,12 +152,12 @@ EOF
     public function testConfigureGeneratedSecret()
     {
         $configurator = new EnvConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options()
         );
 
-        $recipe = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
 
         $env = sys_get_temp_dir().'/.env.dist';

--- a/tests/Configurator/GitignoreConfiguratorTest.php
+++ b/tests/Configurator/GitignoreConfiguratorTest.php
@@ -16,21 +16,24 @@ require_once __DIR__.'/TmpDirMock.php';
 use Symfony\Flex\Configurator\GitignoreConfigurator;
 use Symfony\Flex\Options;
 use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Recipe;
+use Composer\IO\IOInterface;
+use Composer\Composer;
 
 class GitignoreConfiguratorTest extends TestCase
 {
     public function testConfigure()
     {
         $configurator = new GitignoreConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['public-dir' => 'public'])
         );
 
-        $recipe1 = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe1 = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe1->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
 
-        $recipe2 = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe2 = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe2->expects($this->any())->method('getName')->will($this->returnValue('BarBundle'));
 
         $gitignore = sys_get_temp_dir().'/.gitignore';

--- a/tests/Configurator/MakefileConfiguratorTest.php
+++ b/tests/Configurator/MakefileConfiguratorTest.php
@@ -16,21 +16,24 @@ require_once __DIR__.'/TmpDirMock.php';
 use Symfony\Flex\Configurator\MakefileConfigurator;
 use Symfony\Flex\Options;
 use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Recipe;
+use Composer\IO\IOInterface;
+use Composer\Composer;
 
 class MakefileConfiguratorTest extends TestCase
 {
     public function testConfigure()
     {
         $configurator = new MakefileConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options()
         );
 
-        $recipe1 = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe1 = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe1->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
 
-        $recipe2 = $this->getMockBuilder('Symfony\Flex\Recipe')->disableOriginalConstructor()->getMock();
+        $recipe2 = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe2->expects($this->any())->method('getName')->will($this->returnValue('BarBundle'));
 
         $makefile = sys_get_temp_dir().'/Makefile';


### PR DESCRIPTION
This PR

* [x] consistently uses the `class` keyword instead of string literals when referencing class names