### PR TITLE
Removing legacy tags significantly reduces memory and CPU usage

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex;
+
+use Composer\Cache as BaseCache;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class Cache extends BaseCache
+{
+    private static $lowestTags = [
+        'symfony/symfony' => 'v3.4.0',
+    ];
+
+    public function read($file)
+    {
+        $content = parent::read($file);
+
+        if (0 === strpos($file, 'provider-symfony$')) {
+            $content = json_encode($this->removeLegacyTags(json_decode($content, true)));
+        }
+
+        return $content;
+    }
+
+    public function removeLegacyTags(array $data): array
+    {
+        foreach (self::$lowestTags as $package => $lowestVersion) {
+            if (!isset($data['packages'][$package][$lowestVersion])) {
+                continue;
+            }
+            foreach ($data['packages'] as $package => $versions) {
+                foreach ($versions as $version => $composerJson) {
+                    if (version_compare($version, $lowestVersion, '<')) {
+                        unset($data['packages'][$package][$version]);
+                    }
+                }
+            }
+            break;
+        }
+
+        return $data;
+    }
+}

--- a/src/ComposerRepository.php
+++ b/src/ComposerRepository.php
@@ -11,7 +11,11 @@
 
 namespace Symfony\Flex;
 
+use Composer\Config;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\IO\IOInterface;
 use Composer\Repository\ComposerRepository as BaseComposerRepository;
+use Composer\Util\RemoteFilesystem;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -19,6 +23,13 @@ use Composer\Repository\ComposerRepository as BaseComposerRepository;
 class ComposerRepository extends BaseComposerRepository
 {
     private $providerFiles;
+
+    public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, RemoteFilesystem $rfs = null)
+    {
+        parent::__construct($repoConfig, $io, $config, $eventDispatcher, $rfs);
+
+        $this->cache = new Cache($io, $config->get('cache-repo-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $this->url), 'a-z0-9.$');
+    }
 
     protected function loadProviderListings($data)
     {
@@ -53,6 +64,12 @@ class ComposerRepository extends BaseComposerRepository
             return [];
         }
 
-        return parent::fetchFile($filename, $cacheKey, $sha256, $storeLastModifiedTime);
+        $data = parent::fetchFile($filename, $cacheKey, $sha256, $storeLastModifiedTime);
+
+        if (0 === strpos($filename, 'http://packagist.org/p/symfony/') || 0 === strpos($filename, 'https://packagist.org/p/symfony/')) {
+            $data = $this->cache->removeLegacyTags($data);
+        }
+
+        return $data;
     }
 }


### PR DESCRIPTION
Before:
> Memory usage: 272.59MB (peak: 606.6MB), time: 5.79s

After:
> Memory usage: 145.56MB (peak: 158.56MB), time: 1.86s

