### PR TITLE
Move away from symfony.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ dependencies.
 
 [1]: https://symfony.com/doc/current/setup/flex.html
 [2]: https://symfony.com
-[3]: https://symfony.sh
+[3]: https://flex.symfony.com

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -25,7 +25,7 @@ use Composer\Json\JsonFile;
  */
 class Downloader
 {
-    private static $DEFAULT_ENDPOINT = 'https://symfony.sh';
+    private static $DEFAULT_ENDPOINT = 'https://flex.symfony.com';
     private static $MAX_LENGTH = 1000;
 
     private $io;

--- a/src/Response.php
+++ b/src/Response.php
@@ -59,10 +59,6 @@ class Response implements \JsonSerializable
 
     public static function fromJson(array $json): self
     {
-        if (!isset($json['body']) || !isset($json['headers'])) {
-            throw new \LogicException('Old cache detected. Clear the Composer cache under "~/.composer/cache/repo/https---symfony.sh/".');
-        }
-
         $response = new self($json['body']);
         $response->headers = $json['headers'];
 


### PR DESCRIPTION
Several companies reported that they have problems with symfony.sh (blocked by their proxies). I got one more report today, so let's move away from this specific domain and move to `https://flex.symfony.com` as the default endpoint (I didn't want to do that at first because I didn't want to expose `flex` anywhere, but I suppose that purely internal and I can live with that).
