### PR TITLE
Handle composer special aliases "mirrors" and "nothing"

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -48,7 +48,7 @@ class PackageResolver
         // second pass to resolve package names
         $packages = [];
         foreach ($explodedArguments as $i => $argument) {
-            if (false === strpos($argument, '/') && !preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument)) {
+            if (false === strpos($argument, '/') && !preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument) && !\in_array($argument, ['mirrors', 'nothing'])) {
                 if (null === self::$aliases) {
                     self::$aliases = $this->downloader->get('/aliases.json')->getBody();
                 }


### PR DESCRIPTION
Fixes #394

The recipe validation server should also have a rule to fail when an alias on "mirrors" or "nothing" is submitted.

Composer also handles "lock" as a special alias, but we already have the lock component, let's take priority.