### PR TITLE
Add compatibility with updated RemoteFilesystem::getRemoteContents() signature

### DIFF
--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -71,8 +71,8 @@ class ParallelDownloader extends RemoteFilesystem
             if (!$this->downloader && method_exists(parent::class, 'getRemoteContents')) {
                 $this->io->writeError('<warning>Enable the "cURL" PHP extension for faster downloads</warning>');
             }
-            $note = '\\' === DIRECTORY_SEPARATOR ? '' : (false !== stripos(PHP_OS, 'darwin') ? '🎵' : '🎶');
-            $note .= $this->downloader ? ('\\' !== DIRECTORY_SEPARATOR ? ' 💨' : '') : '';
+            $note = '\\' === \DIRECTORY_SEPARATOR ? '' : (false !== stripos(PHP_OS, 'darwin') ? '🎵' : '🎶');
+            $note .= $this->downloader ? ('\\' !== \DIRECTORY_SEPARATOR ? ' 💨' : '') : '';
             $this->io->writeError('');
             $this->io->writeError(sprintf('<info>Prefetching %d packages</info> %s', $this->downloadCount, $note));
             $this->io->writeError('  - Downloading', false);
@@ -209,28 +209,51 @@ class ParallelDownloader extends RemoteFilesystem
     /**
      * {@inheritdoc}
      */
-    protected function getRemoteContents($originUrl, $fileUrl, $context)
+    protected function getRemoteContents($originUrl, $fileUrl, $context, array &$responseHeaders = null)
     {
         if (isset(self::$cache[$fileUrl])) {
-            return self::$cache[$fileUrl];
+            $result = self::$cache[$fileUrl];
+
+            if (3 < \func_num_args()) {
+                list($responseHeaders, $result) = $result;
+            }
+
+            return $result;
         }
 
         if (self::$cacheNext) {
             self::$cacheNext = false;
 
-            return self::$cache[$fileUrl] = $this->getRemoteContents($originUrl, $fileUrl, $context);
+            if (3 < \func_num_args()) {
+                $result = $this->getRemoteContents($originUrl, $fileUrl, $context, $responseHeaders);
+                self::$cache[$fileUrl] = [$responseHeaders, $result];
+            } else {
+                $result = $this->getRemoteContents($originUrl, $fileUrl, $context);
+                self::$cache[$fileUrl] = $result;
+            }
+
+            return $result;
         }
 
         if (!$this->downloader) {
-            return parent::getRemoteContents($originUrl, $fileUrl, $context);
+            return parent::getRemoteContents($originUrl, $fileUrl, $context, $responseHeaders);
         }
 
         try {
-            return $this->downloader->get($originUrl, $fileUrl, $context, $this->fileName);
+            $result = $this->downloader->get($originUrl, $fileUrl, $context, $this->fileName);
+
+            if (3 < \func_num_args()) {
+                list($responseHeaders, $result) = $result;
+            }
+
+            return $result;
         } catch (TransportException $e) {
             $this->io->writeError('Retrying download: '.$e->getMessage(), true, IOInterface::DEBUG);
 
-            return parent::getRemoteContents($originUrl, $fileUrl, $context);
+            return parent::getRemoteContents($originUrl, $fileUrl, $context, $responseHeaders);
+        } catch (\Throwable $e) {
+            $responseHeaders = [];
+            throw $e;
         }
     }
 

--- a/src/Unpacker.php
+++ b/src/Unpacker.php
@@ -15,7 +15,6 @@ use Composer\Composer;
 use Composer\Factory;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
-use Composer\Package\Package;
 use Symfony\Flex\Unpack\Operation;
 use Symfony\Flex\Unpack\Result;
 

--- a/tests/Configurator/ContainerConfiguratorTest.php
+++ b/tests/Configurator/ContainerConfiguratorTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Flex\Tests\Configurator;
 
 require_once __DIR__.'/TmpDirMock.php';
 
+use Composer\Composer;
+use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\ContainerConfigurator;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
-use Composer\Composer;
-use Composer\IO\IOInterface;
 
 class ContainerConfiguratorTest extends TestCase
 {

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Flex\Tests\Configurator;
 
 require_once __DIR__.'/TmpDirMock.php';
 
+use Composer\Composer;
+use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\EnvConfigurator;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
-use Composer\IO\IOInterface;
-use Composer\Composer;
 
 class EnvConfiguratorTest extends TestCase
 {

--- a/tests/Configurator/GitignoreConfiguratorTest.php
+++ b/tests/Configurator/GitignoreConfiguratorTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Flex\Tests\Configurator;
 
 require_once __DIR__.'/TmpDirMock.php';
 
+use Composer\Composer;
+use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\GitignoreConfigurator;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
-use Composer\IO\IOInterface;
-use Composer\Composer;
 
 class GitignoreConfiguratorTest extends TestCase
 {

--- a/tests/Configurator/MakefileConfiguratorTest.php
+++ b/tests/Configurator/MakefileConfiguratorTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Flex\Tests\Configurator;
 
 require_once __DIR__.'/TmpDirMock.php';
 
+use Composer\Composer;
+use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\MakefileConfigurator;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
-use Composer\IO\IOInterface;
-use Composer\Composer;
 
 class MakefileConfiguratorTest extends TestCase
 {

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Flex\Tests;
 
 use Composer\Composer;
-use Composer\Config;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\Factory;
 use Composer\Installer\PackageEvent;


### PR DESCRIPTION
Required after https://github.com/composer/composer/pull/7495

Code is compatible with both signatures.