### PR TITLE
Add http2 support

### DIFF
--- a/src/CurlDownloader.php
+++ b/src/CurlDownloader.php
@@ -89,6 +89,14 @@ class CurlDownloader
         curl_setopt($ch, CURLOPT_WRITEHEADER, $hd);
         curl_setopt($ch, CURLOPT_FILE, $fd);
         curl_setopt($ch, CURLOPT_SHARE, $this->shareHandle);
+        
+        // feature detect http2 support in the php client/curl version.
+        if (defined('CURL_VERSION_HTTP2') && defined('CURL_HTTP_VERSION_2_0')) {
+            $curlVersion = curl_version();
+            if ($curlVersion["features"] & CURL_VERSION_HTTP2 !== 0) {
+                curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+            }
+        }
 
         foreach (self::$options as $type => $options) {
             foreach ($options as $name => $curlopt) {


### PR DESCRIPTION
adding http2 support, as packagist.org supports it now
https://twitter.com/seldaek/status/1022179344091893760

composer will use repo.packagist.org in the future for package metadata
see https://github.com/composer/composer/commit/c5fa3bdde0e042b64e32102c21edb2e12e474746