### PR TITLE
Add SYMFONY_REQUIRE env var + disable recipes when flex is not in the root composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ install:
 
 script:
   - ./vendor/bin/simple-phpunit
+  - find src/ -name '*.php' | xargs -n1 php -l

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -46,7 +46,11 @@ class Lock
 
     public function write()
     {
-        ksort($this->lock);
-        $this->json->write($this->lock);
+        if ($this->lock) {
+            ksort($this->lock);
+            $this->json->write($this->lock);
+        } elseif ($this->json->exists()) {
+            @unlink($this->json->getPath());
+        }
     }
 }

--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -83,8 +83,12 @@ class ParallelDownloader extends RemoteFilesystem
         }
         try {
             $this->getNext();
-            if (!$this->quiet) {
+            if ($this->quiet) {
+                // no-op
+            } elseif ($this->progress) {
                 $this->io->overwriteError(' (<comment>100%</comment>)');
+            } else {
+                $this->io->writeError(' (<comment>100%</comment>)');
             }
         } finally {
             if (!$this->quiet) {

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -73,7 +73,7 @@ class Recipe
 
         // symfony/translation:3.3@github.com/symfony/recipes:master
         if (!preg_match('/^([^\:]+?)\:([^\@]+)@([^\:]+)\:(.+)$/', $this->data['origin'], $matches)) {
-            // that exclude auto-generated recipes, which is what we want
+            // that excludes auto-generated recipes, which is what we want
             return '';
         }
 

--- a/src/TruncatedComposerRepository.php
+++ b/src/TruncatedComposerRepository.php
@@ -29,6 +29,11 @@ class TruncatedComposerRepository extends BaseComposerRepository
         $this->cache = new Cache($io, $config->get('cache-repo-dir').'/'.preg_replace('{[^a-z0-9.]}i', '-', $this->url), 'a-z0-9.$');
     }
 
+    public function setSymfonyRequire(string $symfonyRequire, IOInterface $io)
+    {
+        $this->cache->setSymfonyRequire($symfonyRequire, $io);
+    }
+
     protected function fetchFile($filename, $cacheKey = null, $sha256 = null, $storeLastModifiedTime = false)
     {
         $data = parent::fetchFile($filename, $cacheKey, $sha256, $storeLastModifiedTime);

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -16,6 +16,7 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\Factory;
 use Composer\Installer\PackageEvent;
 use Composer\IO\BufferIO;
+use Composer\Package\Link;
 use Composer\Package\Locker;
 use Composer\Package\Package;
 use Composer\Package\RootPackageInterface;
@@ -106,6 +107,7 @@ class FlexTest extends TestCase
 
         $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();
         $downloader->expects($this->once())->method('getRecipes')->willReturn($data);
+        $downloader->expects($this->once())->method('getEndpoint')->willReturn('dummy');
 
         $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
         $locker = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
@@ -167,6 +169,7 @@ EOF
         $composer->setConfig(Factory::createConfig($io));
         $package = $this->getMockBuilder(RootPackageInterface::class)->disableOriginalConstructor()->getMock();
         $package->method('getExtra')->will($this->returnValue(['symfony' => ['allow-contrib' => true]]));
+        $package->method('getRequires')->will($this->returnValue([new Link('dummy', 'symfony/flex')]));
         $composer->setPackage($package);
         $localRepo = $this->getMockBuilder(WritableRepositoryInterface::class)->disableOriginalConstructor()->getMock();
         $manager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
The C.I. for `symfony/symfony` is starting to fail transiently because solving the dependency graph takes too much memory.
See e.g. https://ci.appveyor.com/project/fabpot/symfony/build/1.0.39377

But thanks to recent improvements in Flex, we know why and how to fix that: skipping old tags.
This PR allows using Flex while disabling the recipes subsystem and allows configuring the minimum version of components we give to the solver.

I plan to use the next version of Flex that embeds this PR (could be v1.1.0 btw) on `symfony/symfony`.