### PR TITLE
Don't filter packages that have empty intersection with symfony/symfony when matching extra.symfony.require

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,4 +20,10 @@
   <php>
     <ini name="error_reporting" value="-1" />
   </php>
+
+  <filter>
+      <whitelist>
+          <directory>./src/</directory>
+      </whitelist>
+  </filter>
 </phpunit>

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -26,7 +26,7 @@ class Cache extends BaseCache
     private $symfonyConstraints;
     private $io;
 
-    public function setSymfonyRequire(string $symfonyRequire, IOInterface $io)
+    public function setSymfonyRequire(string $symfonyRequire, IOInterface $io = null)
     {
         $this->versionParser = new VersionParser();
         $this->symfonyRequire = $symfonyRequire;
@@ -50,24 +50,49 @@ class Cache extends BaseCache
         if (!$this->symfonyConstraints || !isset($data['packages']['symfony/symfony'])) {
             return $data;
         }
-        $symfonyVersions = $data['packages']['symfony/symfony'];
+
+        $symfonyPackages = [];
+        $symfonySymfony = $data['packages']['symfony/symfony'];
+
+        foreach ($symfonySymfony as $version => $composerJson) {
+            if ('dev-master' === $version) {
+                $normalizedVersion = $this->versionParser->normalize($composerJson['extra']['branch-alias']['dev-master']);
+            } else {
+                $normalizedVersion = $composerJson['version_normalized'];
+            }
+
+            if ($this->symfonyConstraints->matches(new Constraint('==', $normalizedVersion))) {
+                $symfonyPackages += $composerJson['replace'];
+            } else {
+                if ($this->io) {
+                    $this->io->writeError(sprintf('<info>Restricting packages listed in "symfony/symfony" to "%s"</info>', $this->symfonyRequire));
+                    $this->io = null;
+                }
+                unset($symfonySymfony[$version]);
+            }
+        }
+
+        if (!$symfonySymfony) {
+            // ignore requirements: their intersection with versions of symfony/symfony is empty
+            return $data;
+        }
+
+        $data['packages']['symfony/symfony'] = $symfonySymfony;
+        unset($symfonySymfony['dev-master']);
 
         foreach ($data['packages'] as $name => $versions) {
-            foreach ($versions as $version => $package) {
-                if ('symfony/symfony' !== $name && 'self.version' !== ($symfonyVersions[preg_replace('/^(\d++\.\d++)\..*/', '$1.x-dev', $version)]['replace'][$name] ?? null)) {
-                    continue;
-                }
-                $normalizedVersion = $package['extra']['branch-alias'][$version] ?? null;
-                $normalizedVersion = $normalizedVersion ? $this->versionParser->normalize($normalizedVersion) : $package['version_normalized'];
-                $provider = new Constraint('==', $normalizedVersion);
+            if (!isset($symfonyPackages[$name]) || null === $devMasterAlias = $versions['dev-master']['extra']['branch-alias']['dev-master'] ?? null) {
+                continue;
+            }
+            $devMaster = $versions['dev-master'];
+            $versions = array_intersect_key($versions, $symfonySymfony);
 
-                if (!$this->symfonyConstraints->matches($provider)) {
-                    if ($this->io) {
-                        $this->io->writeError(sprintf('<info>Restricting packages listed in "symfony/symfony" to "%s"</info>', $this->symfonyRequire));
-                        $this->io = null;
-                    }
-                    unset($data['packages'][$name][$version]);
-                }
+            if ($this->symfonyConstraints->matches(new Constraint('==', $this->versionParser->normalize($devMasterAlias)))) {
+                $versions['dev-master'] = $devMaster;
+            }
+
+            if ($versions) {
+                $data['packages'][$name] = $versions;
             }
         }
 

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Cache;
+
+class CacheTest extends TestCase
+{
+    /**
+     * @dataProvider provideRemoveLegacyTags
+     */
+    public function testRemoveLegacyTags(array $expected, array $packages, string $symfonyRequire)
+    {
+        $cache = (new \ReflectionClass(Cache::class))->newInstanceWithoutConstructor();
+        $cache->setSymfonyRequire($symfonyRequire);
+
+        $this->assertSame(['packages' => $expected], $cache->removeLegacyTags(['packages' => $packages]));
+    }
+
+    public function provideRemoveLegacyTags()
+    {
+        yield 'no-symfony/symfony' => [[123], [123], '~1'];
+
+        $branchAlias = function ($versionAlias) {
+            return [
+                'extra' => [
+                    'branch-alias' => [
+                        'dev-master' => $versionAlias.'-dev',
+                    ],
+                ],
+            ];
+        };
+
+        $packages = [
+            'foo/unrelated' => [
+                '1.0.0' => [],
+            ],
+            'symfony/symfony' => [
+                '3.3.0' => [
+                    'version_normalized' => '3.3.0.0',
+                    'replace' => ['symfony/foo' => 'self.version'],
+                ],
+                '3.4.0' => [
+                    'version_normalized' => '3.4.0.0',
+                    'replace' => ['symfony/foo' => 'self.version'],
+                ],
+                'dev-master' => $branchAlias('3.5') + [
+                    'replace' => ['symfony/foo' => 'self.version'],
+                ],
+            ],
+            'symfony/foo' => [
+                '3.3.0' => ['version_normalized' => '3.3.0.0'],
+                '3.4.0' => ['version_normalized' => '3.4.0.0'],
+                'dev-master' => $branchAlias('3.5'),
+            ],
+        ];
+
+        yield 'empty-intersection-ignores' => [$packages, $packages, '~2.0'];
+        yield 'empty-intersection-ignores' => [$packages, $packages, '~4.0'];
+
+        $expected = $packages;
+        unset($expected['symfony/symfony']['3.3.0']);
+        unset($expected['symfony/foo']['3.3.0']);
+
+        yield 'non-empty-intersection-filters' => [$expected, $packages, '~3.4'];
+
+        unset($expected['symfony/symfony']['3.4.0']);
+        unset($expected['symfony/foo']['3.4.0']);
+
+        yield 'master-only' => [$expected, $packages, '~3.5'];
+
+        $packages = [
+            'symfony/symfony' => [
+                '2.8.0' => [
+                    'version_normalized' => '2.8.0.0',
+                    'replace' => [
+                        'symfony/legacy' => 'self.version',
+                        'symfony/foo' => 'self.version',
+                    ],
+                ],
+            ],
+            'symfony/legacy' => [
+                '2.8.0' => ['version_normalized' => '2.8.0.0'],
+                'dev-master' => $branchAlias('2.8'),
+            ],
+        ];
+
+        yield 'legacy-are-not-filtered' => [$packages, $packages, '~3.0'];
+
+        $packages = [
+            'symfony/symfony' => [
+                '2.8.0' => [
+                    'version_normalized' => '2.8.0.0',
+                    'replace' => [
+                        'symfony/foo' => 'self.version',
+                        'symfony/new' => 'self.version',
+                    ],
+                ],
+                'dev-master' => $branchAlias('3.0') + [
+                    'replace' => [
+                        'symfony/foo' => 'self.version',
+                        'symfony/new' => 'self.version',
+                    ],
+                ],
+            ],
+            'symfony/foo' => [
+                '2.8.0' => ['version_normalized' => '2.8.0.0'],
+                'dev-master' => $branchAlias('3.0'),
+            ],
+            'symfony/new' => [
+                'dev-master' => $branchAlias('3.0'),
+            ],
+        ];
+
+        $expected = $packages;
+        unset($expected['symfony/symfony']['dev-master']);
+        unset($expected['symfony/foo']['dev-master']);
+
+        yield 'master-is-filtered-only-when-in-range' => [$expected, $packages, '~2.8'];
+    }
+}


### PR DESCRIPTION
Fixes #410
ping @pamil, please confirm.