### PR TITLE
Change the EnvConfigurator to only handle the .env file

### DIFF
--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -33,16 +33,10 @@ class EnvConfiguratorTest extends TestCase
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
 
-        $env = sys_get_temp_dir().'/.env.dist';
+        $env = sys_get_temp_dir().'/.env';
         @unlink($env);
         touch($env);
 
-        $phpunit = sys_get_temp_dir().'/phpunit.xml';
-        $phpunitDist = $phpunit.'.dist';
-        @unlink($phpunit);
-        @unlink($phpunitDist);
-        copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunitDist);
-        copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunit);
         $configurator->configure($recipe, [
             'APP_ENV' => 'test bar',
             'APP_DEBUG' => '0',
@@ -72,46 +66,8 @@ APP_SECRET="s3cretf0rt3st\"<>"
 ###< FooBundle ###
 
 EOF;
-        $xmlContents = <<<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-
-<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-        <env name="KERNEL_CLASS" value="App\Kernel" />
-
-        <!-- ###+ FooBundle ### -->
-        <env name="APP_ENV" value="test bar"/>
-        <env name="APP_DEBUG" value="0"/>
-        <env name="APP_PARAGRAPH" value="foo&#10;&quot;bar&quot;\\t"/>
-        <env name="DATABASE_URL" value="mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&amp;serverVersion=5.7"/>
-        <env name="MAILER_URL" value="null://localhost"/>
-        <env name="MAILER_USER" value="fabien"/>
-        <!-- Comment 1 -->
-        <!-- Comment 3 -->
-        <!-- env name="TRUSTED_SECRET" value="s3cretf0rt3st&quot;&lt;&gt;" -->
-        <env name="APP_SECRET" value="s3cretf0rt3st&quot;&lt;&gt;"/>
-        <!-- ###- FooBundle ### -->
-    </php>
-
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-</phpunit>
-
-EOF;
 
         $this->assertStringEqualsFile($env, $envContents);
-        $this->assertStringEqualsFile($phpunitDist, $xmlContents);
-        $this->assertStringEqualsFile($phpunit, $xmlContents);
 
         $configurator->configure($recipe, [
             'APP_ENV' => 'test',
@@ -123,8 +79,6 @@ EOF;
         ]);
 
         $this->assertStringEqualsFile($env, $envContents);
-        $this->assertStringEqualsFile($phpunitDist, $xmlContents);
-        $this->assertStringEqualsFile($phpunit, $xmlContents);
 
         $configurator->unconfigure($recipe, [
             'APP_ENV' => 'test',
@@ -142,11 +96,7 @@ EOF;
 
 EOF
         );
-
-        $this->assertFileEquals(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunitDist);
-        $this->assertFileEquals(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunit);
-
-        @unlink($phpunit, $env);
+        @unlink($env);
     }
 
     public function testConfigureGeneratedSecret()
@@ -160,16 +110,9 @@ EOF
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
 
-        $env = sys_get_temp_dir().'/.env.dist';
+        $env = sys_get_temp_dir().'/.env';
         @unlink($env);
         touch($env);
-        $phpunit = sys_get_temp_dir().'/phpunit.xml';
-        $phpunitDist = $phpunit.'.dist';
-        @unlink($phpunit);
-        @unlink($phpunitDist);
-
-        copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunitDist);
-        copy(__DIR__.'/../Fixtures/phpunit.xml.dist', $phpunit);
 
         $configurator->configure($recipe, [
             '#TRUSTED_SECRET_1' => '%generate(secret,32)%',
@@ -184,14 +127,5 @@ EOF
         $this->assertRegExp('/#TRUSTED_SECRET_3=[a-z0-9]{64}/', $envContents);
         $this->assertRegExp('/APP_SECRET=[a-z0-9]{32}/', $envContents);
         @unlink($env);
-
-        foreach ([$phpunitDist, $phpunit] as $file) {
-            $fileContents = file_get_contents($file);
-
-            $this->assertRegExp('/<!-- env name="TRUSTED_SECRET_1" value="[a-z0-9]{64}" -->/', $fileContents);
-            $this->assertRegExp('/<!-- env name="TRUSTED_SECRET_2" value="[a-z0-9]{64}" -->/', $fileContents);
-            $this->assertRegExp('/<!-- env name="TRUSTED_SECRET_3" value="[a-z0-9]{64}" -->/', $fileContents);
-            $this->assertRegExp('/<env name="APP_SECRET" value="[a-z0-9]{32}"\/>/', $fileContents);
-        }
     }
 }


### PR DESCRIPTION
Companion PR for symfony/recipes#466 and symfony/symfony#28533.

As explained in https://github.com/symfony/recipes/pull/466#discussion_r219453664, it will require to tag a v2 to prevent problems with previous installation.

In a next PR, we may want to allow recipes to add values in specific environment env files (such as `.env.test`. It will require to tweak a bit the Flex server. I'm not sure that it's really needed.