### PR TITLE
Bound constraints by copying extra.symfony.require

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -98,11 +98,11 @@ class PackageResolver
             try {
                 $config = @json_decode(file_get_contents(Factory::getComposerFile()), true);
             } finally {
-                if (!$isRequire || !isset($config['require']['symfony/framework-bundle'])) {
+                if (!$isRequire || !($config['extra']['symfony']['require'] || isset($config['require']['symfony/framework-bundle']))) {
                     return '';
                 }
             }
-            $version = $config['require']['symfony/framework-bundle'];
+            $version = $config['extra']['symfony']['require'] ?? $config['require']['symfony/framework-bundle'];
         } elseif ('next' === $version) {
             $version = '^'.self::$versions[$version].'@dev';
         } elseif (\in_array($version, self::$SYMFONY_VERSIONS, true)) {


### PR DESCRIPTION
Fixes https://github.com/symfony/flex/issues/433
Fixes https://github.com/symfony/flex/issues/421

When a new project is created, this makes flex replace `"*"` constraints by the one specified in `extra.symfony.require`.
The same logic also applies to `composer require symfony/*`