### PR TITLE
Fix undefined index in package resolver

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -98,7 +98,7 @@ class PackageResolver
             try {
                 $config = @json_decode(file_get_contents(Factory::getComposerFile()), true);
             } finally {
-                if (!$isRequire || !($config['extra']['symfony']['require'] || isset($config['require']['symfony/framework-bundle']))) {
+                if (!$isRequire || !(isset($config['extra']['symfony']['require']) || isset($config['require']['symfony/framework-bundle']))) {
                     return '';
                 }
             }


### PR DESCRIPTION
When trying to install a symfony/* package without the `extra.symfony.require` composer option we run into an undefined index error.
Seems to be caused by db60ae8