### PR TITLE
Copy extra.symfony.require when unpacking

### DIFF
--- a/src/Command/RequireCommand.php
+++ b/src/Command/RequireCommand.php
@@ -47,7 +47,7 @@ class RequireCommand extends BaseRequireCommand
                 $op->addPackage($package['name'], $package['version'] ?? '', $input->getOption('dev'));
             }
 
-            $unpacker = new Unpacker($this->getComposer());
+            $unpacker = new Unpacker($this->getComposer(), $this->resolver);
             $result = $unpacker->unpack($op);
             $io = $this->getIO();
             foreach ($result->getUnpacked() as $pkg) {

--- a/src/Command/UnpackCommand.php
+++ b/src/Command/UnpackCommand.php
@@ -79,7 +79,7 @@ class UnpackCommand extends BaseCommand
             $op->addPackage($pkg->getName(), $pkg->getVersion(), $dev);
         }
 
-        $unpacker = new Unpacker($composer);
+        $unpacker = new Unpacker($composer, $this->resolver);
         $result = $unpacker->unpack($op);
 
         // remove the packages themselves

--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -80,7 +80,7 @@ class PackageResolver
         return array_unique($requires);
     }
 
-    private function parseVersion(string $package, string $version, bool $isRequire): string
+    public function parseVersion(string $package, string $version, bool $isRequire): string
     {
         if (0 !== strpos($package, 'symfony/')) {
             return $version ? ':'.$version : '';
@@ -94,7 +94,7 @@ class PackageResolver
             return $version ? ':'.$version : '';
         }
 
-        if (!$version) {
+        if (!$version || '*' === $version) {
             try {
                 $config = @json_decode(file_get_contents(Factory::getComposerFile()), true);
             } finally {


### PR DESCRIPTION
eg when unpacking the test pack:

```diff
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,14 @@
         "php": "^7.1.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "symfony/browser-kit": "4.2.*",
         "symfony/console": "4.2.*",
+        "symfony/css-selector": "4.2.*",
         "symfony/dotenv": "4.2.*",
         "symfony/flex": "^1.1",
         "symfony/framework-bundle": "4.2.*",
-        "symfony/test-pack": "^1.0",
+        "symfony/panther": "*",
+        "symfony/phpunit-bridge": "4.2.*",
         "symfony/yaml": "4.2.*"
     },
```