### PR TITLE
 Allow configuring the "extra.symfony.root-dir" of the Symfony app 

### DIFF
--- a/src/Configurator/AbstractConfigurator.php
+++ b/src/Configurator/AbstractConfigurator.php
@@ -32,7 +32,7 @@ abstract class AbstractConfigurator
         $this->composer = $composer;
         $this->io = $io;
         $this->options = $options;
-        $this->path = new Path(getcwd());
+        $this->path = new Path($options->get('root-dir'));
     }
 
     abstract public function configure(Recipe $recipe, $config, array $options = []);

--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -100,6 +100,6 @@ class BundlesConfigurator extends AbstractConfigurator
 
     private function getConfFile(): string
     {
-        return $this->options->expandTargetDir('%CONFIG_DIR%/bundles.php');
+        return $this->options->get('root-dir').'/'.$this->options->expandTargetDir('%CONFIG_DIR%/bundles.php');
     }
 }

--- a/src/Configurator/ContainerConfigurator.php
+++ b/src/Configurator/ContainerConfigurator.php
@@ -27,7 +27,7 @@ class ContainerConfigurator extends AbstractConfigurator
     public function unconfigure(Recipe $recipe, $parameters)
     {
         $this->write('Unsetting parameters');
-        $target = $this->options->expandTargetDir('%CONFIG_DIR%/services.yaml');
+        $target = $this->options->get('root-dir').'/'.$this->options->expandTargetDir('%CONFIG_DIR%/services.yaml');
         $lines = [];
         foreach (file($target) as $line) {
             foreach (array_keys($parameters) as $key) {
@@ -42,7 +42,7 @@ class ContainerConfigurator extends AbstractConfigurator
 
     private function addParameters(array $parameters)
     {
-        $target = $this->options->expandTargetDir('%CONFIG_DIR%/services.yaml');
+        $target = $this->options->get('root-dir').'/'.$this->options->expandTargetDir('%CONFIG_DIR%/services.yaml');
         $endAt = 0;
         $isParameters = false;
         $lines = [];

--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -23,14 +23,14 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
     {
         $this->write('Setting configuration and copying files');
         $packageDir = $this->composer->getInstallationManager()->getInstallPath($recipe->getPackage());
-        $this->copyFiles($config, $packageDir, getcwd(), $options['force'] ?? false);
+        $this->copyFiles($config, $packageDir, $this->options->get('root-dir'), $options['force'] ?? false);
     }
 
     public function unconfigure(Recipe $recipe, $config)
     {
         $this->write('Removing configuration and files');
         $packageDir = $this->composer->getInstallationManager()->getInstallPath($recipe->getPackage());
-        $this->removeFiles($config, $packageDir, getcwd());
+        $this->removeFiles($config, $packageDir, $this->options->get('root-dir'));
     }
 
     private function copyFiles(array $manifest, string $from, string $to, bool $overwrite = false)
@@ -97,7 +97,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
             throw new LogicException(sprintf('File "%s" does not exist!', $source));
         }
 
-        copy($source, $target);
+        file_put_contents($target, $this->options->expandTargetDir(file_get_contents($source)));
         @chmod($target, fileperms($target) | (fileperms($source) & 0111));
         $this->write(sprintf('Created <fg=green>"%s"</>', $this->path->relativize($target)));
     }

--- a/src/Configurator/CopyFromRecipeConfigurator.php
+++ b/src/Configurator/CopyFromRecipeConfigurator.php
@@ -21,13 +21,13 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
     public function configure(Recipe $recipe, $config, array $options = [])
     {
         $this->write('Setting configuration and copying files');
-        $this->copyFiles($config, $recipe->getFiles(), getcwd(), $options['force'] ?? false);
+        $this->copyFiles($config, $recipe->getFiles(), $this->options->get('root-dir'), $options['force'] ?? false);
     }
 
     public function unconfigure(Recipe $recipe, $config)
     {
         $this->write('Removing configuration and files');
-        $this->removeFiles($config, $recipe->getFiles(), getcwd());
+        $this->removeFiles($config, $recipe->getFiles(), $this->options->get('root-dir'));
     }
 
     private function copyFiles(array $manifest, array $files, string $to, bool $overwrite = false)
@@ -62,7 +62,7 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
             mkdir(\dirname($to), 0777, true);
         }
 
-        file_put_contents($to, $contents);
+        file_put_contents($to, $this->options->expandTargetDir($contents));
         if ($executable) {
             @chmod($to, fileperms($to) | 0111);
         }

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -23,7 +23,7 @@ class EnvConfigurator extends AbstractConfigurator
         $this->write('Added environment variable defaults');
 
         $this->configureEnvDist($recipe, $vars);
-        if (!file_exists(getcwd().'/.env.test')) {
+        if (!file_exists($this->options->get('root-dir').'/.env.test')) {
             $this->configurePhpUnit($recipe, $vars);
         }
     }
@@ -37,7 +37,7 @@ class EnvConfigurator extends AbstractConfigurator
     private function configureEnvDist(Recipe $recipe, $vars)
     {
         foreach (['.env.dist', '.env'] as $file) {
-            $env = getcwd().'/'.$file;
+            $env = $this->options->get('root-dir').'/'.$file;
             if (!is_file($env)) {
                 continue;
             }
@@ -69,7 +69,7 @@ class EnvConfigurator extends AbstractConfigurator
     private function configurePhpUnit(Recipe $recipe, $vars)
     {
         foreach (['phpunit.xml.dist', 'phpunit.xml'] as $file) {
-            $phpunit = getcwd().'/'.$file;
+            $phpunit = $this->options->get('root-dir').'/'.$file;
             if (!is_file($phpunit)) {
                 continue;
             }
@@ -110,7 +110,7 @@ class EnvConfigurator extends AbstractConfigurator
     private function unconfigureEnvFiles(Recipe $recipe, $vars)
     {
         foreach (['.env', '.env.dist'] as $file) {
-            $env = getcwd().'/'.$file;
+            $env = $this->options->get('root-dir').'/'.$file;
             if (!file_exists($env)) {
                 continue;
             }
@@ -128,7 +128,7 @@ class EnvConfigurator extends AbstractConfigurator
     private function unconfigurePhpUnit(Recipe $recipe, $vars)
     {
         foreach (['phpunit.xml.dist', 'phpunit.xml'] as $file) {
-            $phpunit = getcwd().'/'.$file;
+            $phpunit = $this->options->get('root-dir').'/'.$file;
             if (!is_file($phpunit)) {
                 continue;
             }

--- a/src/Configurator/GitignoreConfigurator.php
+++ b/src/Configurator/GitignoreConfigurator.php
@@ -22,7 +22,7 @@ class GitignoreConfigurator extends AbstractConfigurator
     {
         $this->write('Added entries to .gitignore');
 
-        $gitignore = getcwd().'/.gitignore';
+        $gitignore = $this->options->get('root-dir').'/.gitignore';
         if ($this->isFileMarked($recipe, $gitignore)) {
             return;
         }
@@ -37,7 +37,7 @@ class GitignoreConfigurator extends AbstractConfigurator
 
     public function unconfigure(Recipe $recipe, $vars)
     {
-        $file = getcwd().'/.gitignore';
+        $file = $this->options->get('root-dir').'/.gitignore';
         if (!file_exists($file)) {
             return;
         }

--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -22,16 +22,17 @@ class MakefileConfigurator extends AbstractConfigurator
     {
         $this->write('Added Makefile entries');
 
-        $makefile = getcwd().'/Makefile';
+        $makefile = $this->options->get('root-dir').'/Makefile';
         if ($this->isFileMarked($recipe, $makefile)) {
             return;
         }
 
-        $data = $this->markData($recipe, implode("\n", $definitions));
+        $data = $this->options->expandTargetDir(implode("\n", $definitions));
+        $data = $this->markData($recipe, $data);
 
         if (!file_exists($makefile)) {
             file_put_contents(
-                getcwd().'/Makefile',
+                $this->options->get('root-dir').'/Makefile',
                 <<<EOF
 ifndef APP_ENV
 	include .env
@@ -45,12 +46,12 @@ help:
 EOF
             );
         }
-        file_put_contents(getcwd().'/Makefile', "\n".ltrim($data, "\r\n"), FILE_APPEND);
+        file_put_contents($this->options->get('root-dir').'/Makefile', "\n".ltrim($data, "\r\n"), FILE_APPEND);
     }
 
     public function unconfigure(Recipe $recipe, $vars)
     {
-        if (!file_exists($makefile = getcwd().'/Makefile')) {
+        if (!file_exists($makefile = $this->options->get('root-dir').'/Makefile')) {
             return;
         }
 

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -292,10 +292,10 @@ class Flex implements PluginInterface, EventSubscriberInterface
         if ($operations) {
             $this->operations = $operations;
         }
-        $cwd = getcwd();
+        $rootDir = $this->options->get('root-dir');
 
-        if (!file_exists("$cwd/.env") && !file_exists("$cwd/.env.local") && file_exists("$cwd/.env.dist") && false === strpos(file_get_contents("$cwd/.env.dist"), '.env.local')) {
-            copy(getcwd().'/.env.dist', getcwd().'/.env');
+        if (!file_exists("$rootDir/.env") && !file_exists("$rootDir/.env.local") && file_exists("$rootDir/.env.dist") && false === strpos(file_get_contents("$rootDir/.env.dist"), '.env.local')) {
+            copy($rootDir.'/.env.dist', $rootDir.'/.env');
         }
 
         list($recipes, $vulnerabilities) = $this->fetchRecipes();
@@ -629,6 +629,8 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     private function initOptions(): Options
     {
+        $extra = $this->composer->getPackage()->getExtra();
+
         $options = array_merge([
             'bin-dir' => 'bin',
             'conf-dir' => 'conf',
@@ -636,7 +638,8 @@ class Flex implements PluginInterface, EventSubscriberInterface
             'src-dir' => 'src',
             'var-dir' => 'var',
             'public-dir' => 'public',
-        ], $this->composer->getPackage()->getExtra());
+            'root-dir' => $extra['symfony']['root-dir'] ?? '.',
+        ], $extra);
 
         return new Options($options, $this->io);
     }

--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -99,7 +99,7 @@ class ScriptExecutor
             return null;
         }
 
-        $console = ProcessExecutor::escape($this->options->get('bin-dir').'/console');
+        $console = ProcessExecutor::escape($this->options->get('root-dir').'/'.$this->options->get('bin-dir').'/console');
         if ($this->io->isDecorated()) {
             $console .= ' --ansi';
         }

--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -20,12 +20,12 @@ class BundlesConfiguratorTest extends TestCase
 {
     public function testConfigure()
     {
-        $config = getcwd().'/config/bundles.php';
+        $config = FLEX_TEST_DIR.'/config/bundles.php';
 
         $configurator = new BundlesConfigurator(
             $this->getMockBuilder('Composer\Composer')->getMock(),
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
-            new Options(['config-dir' => \dirname($config)])
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
 
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();

--- a/tests/Configurator/ContainerConfiguratorTest.php
+++ b/tests/Configurator/ContainerConfiguratorTest.php
@@ -23,7 +23,7 @@ class ContainerConfiguratorTest extends TestCase
     public function testConfigure()
     {
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
-        $config = getcwd().'/config/services.yaml';
+        $config = FLEX_TEST_DIR.'/config/services.yaml';
         file_put_contents(
             $config,
             <<<EOF
@@ -37,7 +37,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
-            new Options(['config-dir' => \dirname($config)])
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en']);
         $this->assertEquals(<<<EOF
@@ -64,7 +64,7 @@ EOF
     public function testConfigureWithoutParametersKey()
     {
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
-        $config = getcwd().'/config/services.yaml';
+        $config = FLEX_TEST_DIR.'/config/services.yaml';
         file_put_contents(
             $config,
             <<<EOF
@@ -75,7 +75,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
-            new Options(['config-dir' => \dirname($config)])
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en']);
         $this->assertEquals(<<<EOF
@@ -100,7 +100,7 @@ EOF
     public function testConfigureWithoutDuplicated()
     {
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
-        $config = getcwd().'/config/services.yaml';
+        $config = FLEX_TEST_DIR.'/config/services.yaml';
         file_put_contents(
             $config,
             <<<EOF
@@ -114,7 +114,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
-            new Options(['config-dir' => \dirname($config)])
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en']);
         $this->assertEquals(<<<EOF
@@ -139,7 +139,7 @@ EOF
     public function testConfigureWithComplexContent()
     {
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
-        $config = getcwd().'/config/services.yaml';
+        $config = FLEX_TEST_DIR.'/config/services.yaml';
         file_put_contents(
             $config,
             <<<EOF
@@ -157,7 +157,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
-            new Options(['config-dir' => \dirname($config)])
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en', 'foobar' => 'baz']);
         $this->assertEquals(<<<EOF

--- a/tests/Configurator/CopyDirectoryFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyDirectoryFromPackageConfiguratorTest.php
@@ -55,14 +55,14 @@ class CopyDirectoryFromPackageConfiguratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->sourceDirectory = getcwd().'/package/files';
+        $this->sourceDirectory = FLEX_TEST_DIR.'/package/files';
         $this->sourceFileRelativePath = 'package/files/';
         $this->sourceFiles = [
             $this->sourceDirectory.'/file1',
             $this->sourceDirectory.'/file2',
         ];
 
-        $this->targetDirectory = getcwd().'/public/files';
+        $this->targetDirectory = FLEX_TEST_DIR.'/public/files';
         $this->targetFileRelativePath = 'public/files/';
         $this->targetFiles = [
             $this->targetDirectory.'/file1',
@@ -79,7 +79,7 @@ class CopyDirectoryFromPackageConfiguratorTest extends TestCase
         $installationManager->expects($this->exactly(1))
             ->method('getInstallPath')
             ->with($package)
-            ->willReturn(getcwd())
+            ->willReturn(FLEX_TEST_DIR)
         ;
         $this->composer = $this->getMockBuilder(Composer::class)->getMock();
         $this->composer->expects($this->exactly(1))
@@ -102,13 +102,13 @@ class CopyDirectoryFromPackageConfiguratorTest extends TestCase
 
     private function createConfigurator(): CopyFromPackageConfigurator
     {
-        return new CopyFromPackageConfigurator($this->composer, $this->io, new Options());
+        return new CopyFromPackageConfigurator($this->composer, $this->io, new Options(['root-dir' => FLEX_TEST_DIR]));
     }
 
     private function cleanUpTargetFiles()
     {
-        $this->rrmdir(getcwd().'/package');
-        $this->rrmdir(getcwd().'/public');
+        $this->rrmdir(FLEX_TEST_DIR.'/package');
+        $this->rrmdir(FLEX_TEST_DIR.'/public');
     }
 
     /**

--- a/tests/Configurator/CopyFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyFromPackageConfiguratorTest.php
@@ -119,11 +119,11 @@ class CopyFromPackageConfiguratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->sourceDirectory = getcwd().'/package';
+        $this->sourceDirectory = FLEX_TEST_DIR.'/package';
         $this->sourceFileRelativePath = 'package/file';
         $this->sourceFile = $this->sourceDirectory.'/file';
 
-        $this->targetDirectory = getcwd().'/public';
+        $this->targetDirectory = FLEX_TEST_DIR.'/public';
         $this->targetFileRelativePath = 'public/file';
         $this->targetFile = $this->targetDirectory.'/file';
 
@@ -137,7 +137,7 @@ class CopyFromPackageConfiguratorTest extends TestCase
         $installationManager->expects($this->exactly(1))
             ->method('getInstallPath')
             ->with($package)
-            ->willReturn(getcwd())
+            ->willReturn(FLEX_TEST_DIR)
         ;
         $this->composer = $this->getMockBuilder(Composer::class)->getMock();
         $this->composer->expects($this->exactly(1))
@@ -158,13 +158,13 @@ class CopyFromPackageConfiguratorTest extends TestCase
 
     private function createConfigurator(): CopyFromPackageConfigurator
     {
-        return new CopyFromPackageConfigurator($this->composer, $this->io, new Options([], $this->io));
+        return new CopyFromPackageConfigurator($this->composer, $this->io, new Options(['root-dir' => FLEX_TEST_DIR], $this->io));
     }
 
     private function cleanUpTargetFiles()
     {
         @unlink($this->targetFile);
-        @rmdir(getcwd().'/package');
-        @rmdir(getcwd().'/public');
+        @rmdir(FLEX_TEST_DIR.'/package');
+        @rmdir(FLEX_TEST_DIR.'/public');
     }
 }

--- a/tests/Configurator/CopyFromRecipeConfiguratorTest.php
+++ b/tests/Configurator/CopyFromRecipeConfiguratorTest.php
@@ -98,11 +98,11 @@ class CopyFromRecipeConfiguratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->sourceDirectory = getcwd().'/source';
+        $this->sourceDirectory = FLEX_TEST_DIR.'/source';
         $this->sourceFileRelativePath = 'source/file';
         $this->sourceFile = $this->targetDirectory.'/file';
 
-        $this->targetDirectory = getcwd().'/config';
+        $this->targetDirectory = FLEX_TEST_DIR.'/config';
         $this->targetFileRelativePath = 'config/file';
         $this->targetFile = $this->targetDirectory.'/file';
 
@@ -127,7 +127,7 @@ class CopyFromRecipeConfiguratorTest extends TestCase
 
     private function createConfigurator(): CopyFromRecipeConfigurator
     {
-        return new CopyFromRecipeConfigurator($this->getMockBuilder(Composer::class)->getMock(), $this->io, new Options([], $this->io));
+        return new CopyFromRecipeConfigurator($this->getMockBuilder(Composer::class)->getMock(), $this->io, new Options(['root-dir' => FLEX_TEST_DIR], $this->io));
     }
 
     private function cleanUpTargetFiles()

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -25,17 +25,17 @@ class EnvConfiguratorTest extends TestCase
         $configurator = new EnvConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
-            new Options()
+            new Options(['root-dir' => FLEX_TEST_DIR])
         );
 
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
 
-        $env = getcwd().'/.env.dist';
+        $env = FLEX_TEST_DIR.'/.env.dist';
         @unlink($env);
         touch($env);
 
-        $phpunit = getcwd().'/phpunit.xml';
+        $phpunit = FLEX_TEST_DIR.'/phpunit.xml';
         $phpunitDist = $phpunit.'.dist';
         @unlink($phpunit);
         @unlink($phpunitDist);
@@ -152,16 +152,16 @@ EOF
         $configurator = new EnvConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
-            new Options()
+            new Options(['root-dir' => FLEX_TEST_DIR])
         );
 
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
 
-        $env = getcwd().'/.env.dist';
+        $env = FLEX_TEST_DIR.'/.env.dist';
         @unlink($env);
         touch($env);
-        $phpunit = getcwd().'/phpunit.xml';
+        $phpunit = FLEX_TEST_DIR.'/phpunit.xml';
         $phpunitDist = $phpunit.'.dist';
         @unlink($phpunit);
         @unlink($phpunitDist);

--- a/tests/Configurator/GitignoreConfiguratorTest.php
+++ b/tests/Configurator/GitignoreConfiguratorTest.php
@@ -25,7 +25,7 @@ class GitignoreConfiguratorTest extends TestCase
         $configurator = new GitignoreConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
-            new Options(['public-dir' => 'public'])
+            new Options(['public-dir' => 'public', 'root-dir' => FLEX_TEST_DIR])
         );
 
         $recipe1 = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
@@ -34,7 +34,7 @@ class GitignoreConfiguratorTest extends TestCase
         $recipe2 = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe2->expects($this->any())->method('getName')->will($this->returnValue('BarBundle'));
 
-        $gitignore = getcwd().'/.gitignore';
+        $gitignore = FLEX_TEST_DIR.'/.gitignore';
         @unlink($gitignore);
         touch($gitignore);
 

--- a/tests/Configurator/MakefileConfiguratorTest.php
+++ b/tests/Configurator/MakefileConfiguratorTest.php
@@ -25,7 +25,7 @@ class MakefileConfiguratorTest extends TestCase
         $configurator = new MakefileConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
-            new Options()
+            new Options(['root-dir' => FLEX_TEST_DIR])
         );
 
         $recipe1 = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
@@ -34,7 +34,7 @@ class MakefileConfiguratorTest extends TestCase
         $recipe2 = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe2->expects($this->any())->method('getName')->will($this->returnValue('BarBundle'));
 
-        $makefile = getcwd().'/Makefile';
+        $makefile = FLEX_TEST_DIR.'/Makefile';
         @unlink($makefile);
         touch($makefile);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,22 +1,10 @@
 <?php
 
-namespace Symfony\Flex\Configurator;
-
-function getcwd()
-{
-    return \dirname(__DIR__).'/build';
-}
-
-namespace Symfony\Flex\Tests\Configurator;
-
-function getcwd()
-{
-    return \dirname(__DIR__).'/build';
-}
-
 require __DIR__.'/../vendor/autoload.php';
 
-if (is_dir($buildDir = getcwd())) {
+define('FLEX_TEST_DIR', dirname(__DIR__).'/build');
+
+if (is_dir($buildDir = FLEX_TEST_DIR)) {
     $files = new \RecursiveIteratorIterator(
         new \RecursiveDirectoryIterator($buildDir, \RecursiveDirectoryIterator::SKIP_DOTS),
         \RecursiveIteratorIterator::CHILD_FIRST


### PR DESCRIPTION
Fixes https://github.com/symfony/flex/issues/243
and makes path management a bit more flexible.