### PR TITLE
Lock copied files to prevent removing files needed by other recipes

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -44,22 +44,22 @@ class Configurator
         ];
     }
 
-    public function install(Recipe $recipe, array $options = [])
+    public function install(Recipe $recipe, Lock $lock, array $options = [])
     {
         $manifest = $recipe->getManifest();
         foreach (array_keys($this->configurators) as $key) {
             if (isset($manifest[$key])) {
-                $this->get($key)->configure($recipe, $manifest[$key], $options);
+                $this->get($key)->configure($recipe, $manifest[$key], $lock, $options);
             }
         }
     }
 
-    public function unconfigure(Recipe $recipe)
+    public function unconfigure(Recipe $recipe, Lock $lock)
     {
         $manifest = $recipe->getManifest();
         foreach (array_keys($this->configurators) as $key) {
             if (isset($manifest[$key])) {
-                $this->get($key)->unconfigure($recipe, $manifest[$key]);
+                $this->get($key)->unconfigure($recipe, $manifest[$key], $lock);
             }
         }
     }

--- a/src/Configurator/AbstractConfigurator.php
+++ b/src/Configurator/AbstractConfigurator.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Configurator;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
+use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Path;
 use Symfony\Flex\Recipe;
@@ -35,9 +36,9 @@ abstract class AbstractConfigurator
         $this->path = new Path($options->get('root-dir'));
     }
 
-    abstract public function configure(Recipe $recipe, $config, array $options = []);
+    abstract public function configure(Recipe $recipe, $config, Lock $lock, array $options = []);
 
-    abstract public function unconfigure(Recipe $recipe, $config);
+    abstract public function unconfigure(Recipe $recipe, $config, Lock $lock);
 
     protected function write($messages)
     {

--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Flex\Configurator;
 
+use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Flex\Recipe;
  */
 class BundlesConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $bundles, array $options = [])
+    public function configure(Recipe $recipe, $bundles, Lock $lock, array $options = [])
     {
         $this->write('Enabling the package as a Symfony bundle');
         $file = $this->getConfFile();
@@ -38,7 +39,7 @@ class BundlesConfigurator extends AbstractConfigurator
         $this->dump($file, $registered);
     }
 
-    public function unconfigure(Recipe $recipe, $bundles)
+    public function unconfigure(Recipe $recipe, $bundles, Lock $lock)
     {
         $this->write('Disabling the Symfony bundle');
         $file = $this->getConfFile();

--- a/src/Configurator/ComposerScriptsConfigurator.php
+++ b/src/Configurator/ComposerScriptsConfigurator.php
@@ -14,6 +14,7 @@ namespace Symfony\Flex\Configurator;
 use Composer\Factory;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
+use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 
 /**
@@ -21,7 +22,7 @@ use Symfony\Flex\Recipe;
  */
 class ComposerScriptsConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $scripts, array $options = [])
+    public function configure(Recipe $recipe, $scripts, Lock $lock, array $options = [])
     {
         $json = new JsonFile(Factory::getComposerFile());
 
@@ -35,7 +36,7 @@ class ComposerScriptsConfigurator extends AbstractConfigurator
         file_put_contents($json->getPath(), $manipulator->getContents());
     }
 
-    public function unconfigure(Recipe $recipe, $scripts)
+    public function unconfigure(Recipe $recipe, $scripts, Lock $lock)
     {
         $json = new JsonFile(Factory::getComposerFile());
 

--- a/src/Configurator/ContainerConfigurator.php
+++ b/src/Configurator/ContainerConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Flex\Configurator;
 
+use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 
 /**
@@ -18,13 +19,13 @@ use Symfony\Flex\Recipe;
  */
 class ContainerConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $parameters, array $options = [])
+    public function configure(Recipe $recipe, $parameters, Lock $lock, array $options = [])
     {
         $this->write('Setting parameters');
         $this->addParameters($parameters);
     }
 
-    public function unconfigure(Recipe $recipe, $parameters)
+    public function unconfigure(Recipe $recipe, $parameters, Lock $lock)
     {
         $this->write('Unsetting parameters');
         $target = $this->options->get('root-dir').'/'.$this->options->expandTargetDir('%CONFIG_DIR%/services.yaml');

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Flex\Configurator;
 
+use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Flex\Recipe;
  */
 class EnvConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $vars, array $options = [])
+    public function configure(Recipe $recipe, $vars, Lock $lock, array $options = [])
     {
         $this->write('Added environment variable defaults');
 
@@ -28,7 +29,7 @@ class EnvConfigurator extends AbstractConfigurator
         }
     }
 
-    public function unconfigure(Recipe $recipe, $vars)
+    public function unconfigure(Recipe $recipe, $vars, Lock $lock)
     {
         $this->unconfigureEnvFiles($recipe, $vars);
         $this->unconfigurePhpUnit($recipe, $vars);

--- a/src/Configurator/GitignoreConfigurator.php
+++ b/src/Configurator/GitignoreConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Flex\Configurator;
 
+use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Flex\Recipe;
  */
 class GitignoreConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $vars, array $options = [])
+    public function configure(Recipe $recipe, $vars, Lock $lock, array $options = [])
     {
         $this->write('Added entries to .gitignore');
 
@@ -39,7 +40,7 @@ class GitignoreConfigurator extends AbstractConfigurator
         }
     }
 
-    public function unconfigure(Recipe $recipe, $vars)
+    public function unconfigure(Recipe $recipe, $vars, Lock $lock)
     {
         $file = $this->options->get('root-dir').'/.gitignore';
         if (!file_exists($file)) {

--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Flex\Configurator;
 
+use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Flex\Recipe;
  */
 class MakefileConfigurator extends AbstractConfigurator
 {
-    public function configure(Recipe $recipe, $definitions, array $options = [])
+    public function configure(Recipe $recipe, $definitions, Lock $lock, array $options = [])
     {
         $this->write('Added Makefile entries');
 
@@ -53,7 +54,7 @@ EOF
         }
     }
 
-    public function unconfigure(Recipe $recipe, $vars)
+    public function unconfigure(Recipe $recipe, $vars, Lock $lock)
     {
         if (!file_exists($makefile = $this->options->get('root-dir').'/Makefile')) {
             return;

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -368,7 +368,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             switch ($recipe->getJob()) {
                 case 'install':
                     $this->io->writeError(sprintf('  - Configuring %s', $this->formatOrigin($recipe->getOrigin())));
-                    $this->configurator->install($recipe, [
+                    $this->configurator->install($recipe, $this->lock, [
                         'force' => $event instanceof UpdateEvent && $event->force(),
                     ]);
                     $manifest = $recipe->getManifest();
@@ -383,7 +383,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                     break;
                 case 'uninstall':
                     $this->io->writeError(sprintf('  - Unconfiguring %s', $this->formatOrigin($recipe->getOrigin())));
-                    $this->configurator->unconfigure($recipe);
+                    $this->configurator->unconfigure($recipe, $this->lock);
                     break;
             }
         }
@@ -605,7 +605,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                 if ($ref && ($locks[$name]['recipe']['ref'] ?? null) === $ref) {
                     continue;
                 }
-                $this->lock->add($name, $locks[$name]);
+                $this->lock->set($name, $locks[$name]);
             } elseif ($operation instanceof UninstallOperation) {
                 if (!$this->lock->has($name)) {
                     continue;

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -34,12 +34,18 @@ class Lock
         return array_key_exists($name, $this->lock);
     }
 
+    public function add($name, $data)
+    {
+        $current = $this->lock[$name] ?? [];
+        $this->lock[$name] = array_merge($current, $data);
+    }
+
     public function get($name)
     {
         return $this->lock[$name] ?? null;
     }
 
-    public function add($name, $data)
+    public function set($name, $data)
     {
         $this->lock[$name] = $data;
     }
@@ -57,5 +63,10 @@ class Lock
         } elseif ($this->json->exists()) {
             @unlink($this->json->getPath());
         }
+    }
+
+    public function all(): array
+    {
+        return $this->lock;
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -80,4 +80,9 @@ class Options
 
         return (bool) $this->io && $this->io->askConfirmation(\sprintf('File "%s" has uncommitted changes, overwrite? [y/N] ', $name), false);
     }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
 }

--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Tests\Configurator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\BundlesConfigurator;
+use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
 
@@ -29,12 +30,13 @@ class BundlesConfiguratorTest extends TestCase
         );
 
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
 
         @unlink($config);
         $configurator->configure($recipe, [
             'FooBundle' => ['dev', 'test'],
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all'],
-        ]);
+        ], $lock);
         $this->assertEquals(<<<EOF
 <?php
 

--- a/tests/Configurator/ContainerConfiguratorTest.php
+++ b/tests/Configurator/ContainerConfiguratorTest.php
@@ -15,6 +15,7 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\ContainerConfigurator;
+use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
 
@@ -23,6 +24,7 @@ class ContainerConfiguratorTest extends TestCase
     public function testConfigure()
     {
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
         $config = FLEX_TEST_DIR.'/config/services.yaml';
         file_put_contents(
             $config,
@@ -39,7 +41,7 @@ EOF
             $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
-        $configurator->configure($recipe, ['locale' => 'en']);
+        $configurator->configure($recipe, ['locale' => 'en'], $lock);
         $this->assertEquals(<<<EOF
 # comment
 parameters:
@@ -50,7 +52,7 @@ services:
 EOF
         , file_get_contents($config));
 
-        $configurator->unconfigure($recipe, ['locale' => 'en']);
+        $configurator->unconfigure($recipe, ['locale' => 'en'], $lock);
         $this->assertEquals(<<<EOF
 # comment
 parameters:
@@ -64,6 +66,7 @@ EOF
     public function testConfigureWithoutParametersKey()
     {
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
         $config = FLEX_TEST_DIR.'/config/services.yaml';
         file_put_contents(
             $config,
@@ -77,7 +80,7 @@ EOF
             $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
-        $configurator->configure($recipe, ['locale' => 'en']);
+        $configurator->configure($recipe, ['locale' => 'en'], $lock);
         $this->assertEquals(<<<EOF
 parameters:
     locale: 'en'
@@ -87,7 +90,7 @@ services:
 EOF
         , file_get_contents($config));
 
-        $configurator->unconfigure($recipe, ['locale' => 'en']);
+        $configurator->unconfigure($recipe, ['locale' => 'en'], $lock);
         $this->assertEquals(<<<EOF
 parameters:
 
@@ -100,6 +103,7 @@ EOF
     public function testConfigureWithoutDuplicated()
     {
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
         $config = FLEX_TEST_DIR.'/config/services.yaml';
         file_put_contents(
             $config,
@@ -116,7 +120,7 @@ EOF
             $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
-        $configurator->configure($recipe, ['locale' => 'en']);
+        $configurator->configure($recipe, ['locale' => 'en'], $lock);
         $this->assertEquals(<<<EOF
 parameters:
     locale: es
@@ -126,7 +130,7 @@ services:
 EOF
         , file_get_contents($config));
 
-        $configurator->unconfigure($recipe, ['locale' => 'en']);
+        $configurator->unconfigure($recipe, ['locale' => 'en'], $lock);
         $this->assertEquals(<<<EOF
 parameters:
 
@@ -139,6 +143,7 @@ EOF
     public function testConfigureWithComplexContent()
     {
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
         $config = FLEX_TEST_DIR.'/config/services.yaml';
         file_put_contents(
             $config,
@@ -159,7 +164,7 @@ EOF
             $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
-        $configurator->configure($recipe, ['locale' => 'en', 'foobar' => 'baz']);
+        $configurator->configure($recipe, ['locale' => 'en', 'foobar' => 'baz'], $lock);
         $this->assertEquals(<<<EOF
 parameters:
     # comment 1
@@ -174,7 +179,7 @@ services:
 EOF
         , file_get_contents($config));
 
-        $configurator->unconfigure($recipe, ['locale' => 'en', 'foobar' => 'baz']);
+        $configurator->unconfigure($recipe, ['locale' => 'en', 'foobar' => 'baz'], $lock);
         $this->assertEquals(<<<EOF
 parameters:
     # comment 1

--- a/tests/Configurator/CopyDirectoryFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyDirectoryFromPackageConfiguratorTest.php
@@ -17,6 +17,7 @@ use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\CopyFromPackageConfigurator;
+use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
 
@@ -45,7 +46,10 @@ class CopyDirectoryFromPackageConfiguratorTest extends TestCase
         foreach ($this->targetFiles as $targetFile) {
             $this->assertFileNotExists($targetFile);
         }
-        $this->createConfigurator()->configure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath]);
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $this->createConfigurator()->configure($this->recipe, [
+            $this->sourceFileRelativePath => $this->targetFileRelativePath,
+        ], $lock);
         foreach ($this->targetFiles as $targetFile) {
             $this->assertFileExists($targetFile);
         }

--- a/tests/Configurator/CopyFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyFromPackageConfiguratorTest.php
@@ -18,6 +18,7 @@ use Composer\Package\PackageInterface;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\CopyFromPackageConfigurator;
+use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
 
@@ -39,7 +40,8 @@ class CopyFromPackageConfiguratorTest extends TestCase
         }
         file_put_contents($this->targetFile, '');
         $this->io->expects($this->exactly(1))->method('writeError')->with(['    Setting configuration and copying files']);
-        $this->createConfigurator()->configure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath]);
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $this->createConfigurator()->configure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath], $lock);
     }
 
     public function testConfigureAndOverwriteFiles()
@@ -52,6 +54,7 @@ class CopyFromPackageConfiguratorTest extends TestCase
         }
         file_put_contents($this->sourceFile, 'somecontent');
         file_put_contents($this->targetFile, '-');
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
 
         $this->io->expects($this->at(0))->method('writeError')->with(['    Setting configuration and copying files']);
         $this->io->expects($this->at(2))->method('writeError')->with(['    Created <fg=green>"./public/file"</>']);
@@ -61,6 +64,7 @@ class CopyFromPackageConfiguratorTest extends TestCase
         $this->createConfigurator()->configure(
             $this->recipe,
             [$this->sourceFileRelativePath => $this->targetFileRelativePath],
+            $lock,
             ['force' => true]
         );
         $this->assertFileExists($this->targetFile);
@@ -73,7 +77,8 @@ class CopyFromPackageConfiguratorTest extends TestCase
         $this->io->expects($this->at(1))->method('writeError')->with(['    Created <fg=green>"./public/"</>']);
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(sprintf('File "%s" does not exist!', $this->sourceFile));
-        $this->createConfigurator()->configure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath]);
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $this->createConfigurator()->configure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath], $lock);
     }
 
     public function testConfigure()
@@ -90,7 +95,8 @@ class CopyFromPackageConfiguratorTest extends TestCase
         $this->io->expects($this->at(2))->method('writeError')->with(['    Created <fg=green>"./public/file"</>']);
 
         $this->assertFileNotExists($this->targetFile);
-        $this->createConfigurator()->configure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath]);
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $this->createConfigurator()->configure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath], $lock);
         $this->assertFileExists($this->targetFile);
     }
 
@@ -104,7 +110,8 @@ class CopyFromPackageConfiguratorTest extends TestCase
         }
         file_put_contents($this->targetFile, '');
         $this->assertFileExists($this->targetFile);
-        $this->createConfigurator()->unconfigure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath]);
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $this->createConfigurator()->unconfigure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath], $lock);
         $this->assertFileNotExists($this->targetFile);
     }
 
@@ -112,7 +119,8 @@ class CopyFromPackageConfiguratorTest extends TestCase
     {
         $this->assertFileNotExists($this->targetFile);
         $this->io->expects($this->exactly(1))->method('writeError')->with(['    Removing configuration and files']);
-        $this->createConfigurator()->unconfigure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath]);
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $this->createConfigurator()->unconfigure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath], $lock);
     }
 
     protected function setUp()

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -15,6 +15,7 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\EnvConfigurator;
+use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
 
@@ -27,6 +28,7 @@ class EnvConfiguratorTest extends TestCase
             $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['root-dir' => FLEX_TEST_DIR])
         );
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
 
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
@@ -52,7 +54,7 @@ class EnvConfiguratorTest extends TestCase
             '#2' => 'Comment 3',
             '#TRUSTED_SECRET' => 's3cretf0rt3st"<>',
             'APP_SECRET' => 's3cretf0rt3st"<>',
-        ]);
+        ], $lock);
 
         $envContents = <<<EOF
 
@@ -118,7 +120,7 @@ EOF;
             '#2' => 'Comment 3',
             '#TRUSTED_SECRET' => 's3cretf0rt3st',
             'APP_SECRET' => 's3cretf0rt3st',
-        ]);
+        ], $lock);
 
         $this->assertStringEqualsFile($env, $envContents);
         $this->assertStringEqualsFile($phpunitDist, $xmlContents);
@@ -131,7 +133,7 @@ EOF;
             '#2' => 'Comment 3',
             '#TRUSTED_SECRET' => 's3cretf0rt3st',
             'APP_SECRET' => 's3cretf0rt3st',
-        ]);
+        ], $lock);
 
         $this->assertStringEqualsFile(
             $env,
@@ -155,6 +157,7 @@ EOF
             $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['root-dir' => FLEX_TEST_DIR])
         );
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
 
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->expects($this->any())->method('getName')->will($this->returnValue('FooBundle'));
@@ -175,7 +178,7 @@ EOF
             '#TRUSTED_SECRET_2' => '%generate(secret, 32)%',
             '#TRUSTED_SECRET_3' => '%generate(secret,     32)%',
             'APP_SECRET' => '%generate(secret)%',
-        ]);
+        ], $lock);
 
         $envContents = file_get_contents($env);
         $this->assertRegExp('/#TRUSTED_SECRET_1=[a-z0-9]{64}/', $envContents);
@@ -298,9 +301,11 @@ EOT;
 
 EOT;
 
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+
         $configurator->configure($recipe, [
             'FOO' => 'bar',
-        ]);
+        ], $lock);
 
         file_put_contents($env, "\n# new content\n", \FILE_APPEND);
         file_put_contents($phpunit, str_replace(
@@ -321,7 +326,7 @@ EOT;
         $configurator->configure($recipe, [
             'FOO' => 'bar',
             'OOF' => 'rab',
-        ], [
+        ], $lock, [
             'force' => true,
         ]);
 


### PR DESCRIPTION
This PR modifies the `CopyFromRecipeConfigurator` so that it will store a list of copied files in symfony.lock and when a recipe is about to be unconfigured, it will check the list of locked files to prevent removal. This should fix #428 

## How to reproduce the issue

```
composer create-project symfony/skeleton example
cd example
composer remove console
```

This will remove both files installed through the recipe `bin/console` and `config/bootstrap.php`. As `symfony/framework-bundle` relies on the bootstrap-file as well, when trying to access the website, you will get an error due to the missing file.

## How to verify the fix

Create a new project based on `symfony/skeleton` and replace flex inside the example project with a local copy of this branch:

```
composer create-project symfony/skeleton example
cd example
rm -rf vendor/symfony/flex
ln -s path/to/local/flex vendor/symfony/flex
```

Since the `symfony.lock` was created during setup of the project it will not yet keep track of the copied files and needs to be updated first. An easy way to do this, is to remove the current file and run `composer fix-recipes` to create a new one:

```
rm symfony.lock
composer fix-recipes
```

Alternatively removing a recipe and then requiring it again will update the lock as well, but it needs to be done for each recipe, as otherwise the list of locked files would be incomplete.

Now when we remove the console again, opening the page in the browser should still work and the file `config/bootstrap.php` should still exist as it is locked by the framework-bundle.

## BC Breaks

None, as far as I can tell. For newly required recipes the files will be tracked. The new key for files in `symfony.lock` was not previously used and should not interfere with existing behavior.

## Known limitations

Unfortunately if any of the previously installed recipes has conflicting files, this will not be recognized unless the recipe is removed and then installed again.