### PR TITLE
Fix using of @php scripts in autoscripts

### DIFF
--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -43,6 +43,11 @@ class ScriptExecutor
      */
     public function execute(string $type, string $cmd)
     {
+        if (0 === strpos($type,'@php ')) {
+            $cmd = explode(' ', $type, 2)[1];
+            $type = 'php-script';
+        }
+
         $parsedCmd = $this->options->expandTargetDir($cmd);
         if (null === $expandedCmd = $this->expandCmd($type, $parsedCmd)) {
             return;

--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -43,7 +43,7 @@ class ScriptExecutor
      */
     public function execute(string $type, string $cmd)
     {
-        if (0 === strpos($type,'@php ')) {
+        if (0 === strpos($type, '@php ')) {
             $cmd = explode(' ', $type, 2)[1];
             $type = 'php-script';
         }
@@ -53,7 +53,7 @@ class ScriptExecutor
             return;
         }
 
-        $cmdOutput = new StreamOutput(fopen('php://temp', 'rw'), OutputInterface::VERBOSITY_VERBOSE, $this->io->isDecorated());
+        $cmdOutput = new StreamOutput(fopen('php://temp', 'rwb'), OutputInterface::VERBOSITY_VERBOSE, $this->io->isDecorated());
         $outputHandler = function ($type, $buffer) use ($cmdOutput) {
             $cmdOutput->write($buffer, false, OutputInterface::OUTPUT_RAW);
         };


### PR DESCRIPTION
This will **not** fix other @ commands like reference calls:

```json
    "scripts": {
        "auto-scripts": [
            "@test-scripts"
        ],
        "test-scripts": [
        ],
     }
```

and also **not** fixing running `@composer` commands:

```json
    "scripts": {
        "auto-scripts": [
            "@composer something"
        ]
     }
```


fixes parts of #431