### PR TITLE
Fix problems with none flex auto-scripts

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -430,14 +430,21 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     public function executeAutoScripts(Event $event)
     {
-        $event->stopPropagation();
-
         // force reloading scripts as we might have added and removed during this run
         $json = new JsonFile(Factory::getComposerFile());
         $jsonContents = $json->read();
 
+        $autoScripts = $jsonContents['scripts']['auto-scripts'];
+
+        // Ignore none flex autoscripts
+        if (array_keys($autoScripts) === range(0, \count($autoScripts) - 1)) {
+            return;
+        }
+
+        $event->stopPropagation();
+
         $executor = new ScriptExecutor($this->composer, $this->io, $this->options);
-        foreach ($jsonContents['scripts']['auto-scripts'] as $cmd => $type) {
+        foreach ($autoScripts as $cmd => $type) {
             $executor->execute($type, $cmd);
         }
 


### PR DESCRIPTION
Fix problems if somebody `@php` in auto-scripts in none flex projects and flex is installed globally:

The following composer.json will be ignored by flex and composer will run it the default way:

```
    "scripts": {
        "auto-scripts": [
            "@php -r 'echo test;'",
            "@text-scripts"
        ],
        "test-scripts": [
        ]
     }
```

The following will be executed by flex and composer executor is not called:

```
    "scripts": {
        "auto-scripts": {
              "cache:clear": "symfony-cmd",
              "assets:install": "symfony-cmd"
         },
        "test-scripts": [
        ]
     }
```

related to #453, fixes #431