### PR TITLE
Do nothing when uninstalling unconfigured packages

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -598,6 +598,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
             if ($operation instanceof InstallOperation && isset($locks[$name])) {
                 $this->lock->add($name, $locks[$name]);
             } elseif ($operation instanceof UninstallOperation) {
+                if (!$this->lock->has($name)) {
+                    continue;
+                }
                 $this->lock->remove($name);
             }
 


### PR DESCRIPTION
When uninstalling a package with a found recipe, Flex unconfigures it even if it was not configured before.