### PR TITLE
Skip up-to-date recipes when using sync-recipes --force

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -588,6 +588,10 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $job = $operation->getJobType();
 
             if ($operation instanceof InstallOperation && isset($locks[$name])) {
+                $ref = $this->lock->get($name)['recipe']['ref'] ?? null;
+                if ($ref && ($locks[$name]['recipe']['ref'] ?? null) === $ref) {
+                    continue;
+                }
                 $this->lock->add($name, $locks[$name]);
             } elseif ($operation instanceof UninstallOperation) {
                 $this->lock->remove($name);

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -34,6 +34,11 @@ class Lock
         return array_key_exists($name, $this->lock);
     }
 
+    public function get($name)
+    {
+        return $this->lock[$name] ?? null;
+    }
+
     public function add($name, $data)
     {
         $this->lock[$name] = $data;


### PR DESCRIPTION
Fixes #461 in a pragmatic way, without any of the complexity that is described in the issue :)
Should cover 80% of the need for 5% of the effort.