### PR TITLE
Fix file_get_content exception when installing symfony 4.3-dev

### DIFF
--- a/src/Configurator/AbstractConfigurator.php
+++ b/src/Configurator/AbstractConfigurator.php
@@ -75,6 +75,10 @@ abstract class AbstractConfigurator
      */
     protected function updateData(string $file, string $data): bool
     {
+        if (!file_exists($file)) {
+            return false;
+        }
+
         $pieces = explode("\n", trim($data));
         $startMark = trim(reset($pieces));
         $endMark = trim(end($pieces));


### PR DESCRIPTION
For more information, see issue [#523](https://github.com/symfony/recipes/issues/523) from the symfony/recipes repo.