### PR TITLE
only write lock when its content has changed

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -20,6 +20,7 @@ class Lock
 {
     private $json;
     private $lock = [];
+    private $changed = false;
 
     public function __construct($lockFile)
     {
@@ -38,6 +39,7 @@ class Lock
     {
         $current = $this->lock[$name] ?? [];
         $this->lock[$name] = array_merge($current, $data);
+        $this->changed = true;
     }
 
     public function get($name)
@@ -48,15 +50,21 @@ class Lock
     public function set($name, $data)
     {
         $this->lock[$name] = $data;
+        $this->changed = true;
     }
 
     public function remove($name)
     {
         unset($this->lock[$name]);
+        $this->changed = true;
     }
 
     public function write()
     {
+        if (!$this->changed) {
+            return;
+        }
+
         if ($this->lock) {
             ksort($this->lock);
             $this->json->write($this->lock);


### PR DESCRIPTION
Fixed #379 by only writing the Lockfile when something has changed (which is not the case on `composer install`).

This seems to me the best solution for the linked issue:
* no change in the Flex behaviour on `composer install` needed (still doing the same like on `composer update`)
* only update the Lockfile when needed (even the modification timestamp will stay the same)
* working for all composer actions (because of auto detection)

Thank you for your feedback.