### PR TITLE
Fix proxy handling

### DIFF
--- a/src/CurlDownloader.php
+++ b/src/CurlDownloader.php
@@ -27,7 +27,6 @@ class CurlDownloader
         'http' => [
             'method' => CURLOPT_CUSTOMREQUEST,
             'content' => CURLOPT_POSTFIELDS,
-            'proxy' => CURLOPT_PROXY,
         ],
         'ssl' => [
             'cafile' => CURLOPT_CAINFO,


### PR DESCRIPTION
Fix #488.

I'm working behind a corporate proxy and since few days, I get errors like in the screenshot below whenever I use flex.

![issue](https://user-images.githubusercontent.com/5477973/56134493-f6ac6a00-5f8e-11e9-8e5c-393f284688e7.png)

Further debugging revealed that [composer replace the http scheme by tcp in the proxy url](https://github.com/composer/composer/blob/1.8.5/src/Composer/Util/StreamContextFactory.php#L78), which curl doesn't support.

As curl reads proxy conf from env by default, let's just not override it.