### PR TITLE
Improve regex for container configurator

### DIFF
--- a/src/Configurator/ContainerConfigurator.php
+++ b/src/Configurator/ContainerConfigurator.php
@@ -32,7 +32,7 @@ class ContainerConfigurator extends AbstractConfigurator
         $lines = [];
         foreach (file($target) as $line) {
             foreach (array_keys($parameters) as $key) {
-                if (preg_match("/^\s+$key\:/", $line)) {
+                if (preg_match(sprintf('/^\s+%s\:/', preg_quote($key, '/')), $line)) {
                     continue 2;
                 }
             }
@@ -62,7 +62,7 @@ class ContainerConfigurator extends AbstractConfigurator
                 continue;
             }
             foreach ($parameters as $key => $value) {
-                if (preg_match("/^\s+$key\:/", $line)) {
+                if (preg_match(sprintf('/^\s+%s\:/', preg_quote($key, '/')), $line)) {
                     unset($parameters[$key]);
                 }
             }

--- a/tests/Configurator/ContainerConfiguratorTest.php
+++ b/tests/Configurator/ContainerConfiguratorTest.php
@@ -192,4 +192,47 @@ services:
 EOF
         , file_get_contents($config));
     }
+
+    public function testConfigureWithEnvVariable()
+    {
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $config = FLEX_TEST_DIR.'/config/services.yaml';
+        file_put_contents(
+            $config,
+            <<<EOF
+# comment
+parameters:
+    env(APP_ENV): ''
+
+services:
+
+EOF
+        );
+        $configurator = new ContainerConfigurator(
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
+        );
+        $configurator->configure($recipe, ['env(APP_ENV)' => ''], $lock);
+        $this->assertEquals(<<<EOF
+# comment
+parameters:
+    env(APP_ENV): ''
+
+services:
+
+EOF
+            , file_get_contents($config));
+
+        $configurator->unconfigure($recipe, ['env(APP_ENV)' => ''], $lock);
+        $this->assertEquals(<<<EOF
+# comment
+parameters:
+
+services:
+
+EOF
+            , file_get_contents($config));
+    }
 }


### PR DESCRIPTION
Escapes the regex of the container configurator because for the case of the variables "env()" this one are broken.
Example with the mercure or doctrine/mongodb-odm-bundle recipe if you remove the dependence.