### PR TITLE
Display stdout too when dump-env fails

### DIFF
--- a/src/Command/DumpEnvCommand.php
+++ b/src/Command/DumpEnvCommand.php
@@ -127,7 +127,7 @@ EOPHP;
         $process->run();
 
         if (!$process->isSuccessful()) {
-            throw new \RuntimeException($process->getErrorOutput());
+            throw new \RuntimeException($process->getErrorOutput().$process->getOutput());
         }
 
         if (!$env = $process->getOutput()) {


### PR DESCRIPTION
Sometimes the useful info is on stdout.