### PR TITLE
remove deprecated CURLPIPE_HTTP1 support flag

### DIFF
--- a/src/CurlDownloader.php
+++ b/src/CurlDownloader.php
@@ -46,7 +46,7 @@ class CurlDownloader
     public function __construct()
     {
         $this->multiHandle = $mh = curl_multi_init();
-        curl_multi_setopt($mh, CURLMOPT_PIPELINING, /*CURLPIPE_HTTP1 | CURLPIPE_MULTIPLEX*/ 3);
+        curl_multi_setopt($mh, CURLMOPT_PIPELINING, /*CURLPIPE_MULTIPLEX*/ 2);
         if (\defined('CURLMOPT_MAX_HOST_CONNECTIONS')) {
             curl_multi_setopt($mh, CURLMOPT_MAX_HOST_CONNECTIONS, 8);
         }


### PR DESCRIPTION
cref https://github.com/symfony/flex/issues/515

@ https://curl.haxx.se/libcurl/c/CURLMOPT_PIPELINING.html
```
	HTTP/1 Pipelining support was disabled in 7.62.0. 
```

here
```
	lsb_release -rd
		Description:    openSUSE Leap 15.1
		Release:        15.1

	curl -V
		curl 7.65.1 (x86_64-suse-linux-gnu) libcurl/7.65.1 OpenSSL/1.1.0i-fips zlib/1.2.11 libidn2/2.2.0 
		...
```

manually
```
	src/CurlDownloader.php

-	        curl_multi_setopt($mh, CURLMOPT_PIPELINING, /*CURLPIPE_HTTP1 | CURLPIPE_MULTIPLEX*/ 3);
+	        curl_multi_setopt($mh, CURLMOPT_PIPELINING, /*CURLPIPE_MULTIPLEX*/ 2);
```

now, check
```
	composer --version
		Composer version 1.8.6 2019-06-11 15:03:05
```