### PR TITLE
Merge new "flex-require" section with "require" on create-project & update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "1.3-dev"
         },
         "class": "Symfony\\Flex\\Flex"
     }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -25,22 +25,20 @@ class Cache extends BaseCache
     private $versionParser;
     private $symfonyRequire;
     private $symfonyConstraints;
+    private $io;
 
     public function setSymfonyRequire(string $symfonyRequire, array $versions, IOInterface $io = null)
     {
         $this->versionParser = new VersionParser();
         $this->symfonyRequire = $symfonyRequire;
         $this->symfonyConstraints = $this->versionParser->parseConstraints($symfonyRequire);
+        $this->io = $io;
 
         foreach ($versions['splits'] as $name => $vers) {
             foreach ($vers as $i => $v) {
                 $v = $this->versionParser->normalize($v);
 
                 if (!$this->symfonyConstraints->matches(new Constraint('==', $v))) {
-                    if (null !== $io) {
-                        $io->writeError(sprintf('<info>Restricting packages listed in "symfony/symfony" to "%s"</info>', $this->symfonyRequire));
-                        $io = null;
-                    }
                     unset($vers[$i]);
                 }
             }
@@ -85,6 +83,10 @@ class Cache extends BaseCache
                 }
 
                 if (!$this->symfonyConstraints->matches(new Constraint('==', $normalizedVersion))) {
+                    if (null !== $this->io) {
+                        $this->io->writeError(sprintf('<info>Restricting packages listed in "symfony/symfony" to "%s"</info>', $this->symfonyRequire));
+                        $this->io = null;
+                    }
                     unset($versions[$version]);
                 }
             }

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -27,6 +27,7 @@ class Downloader
 {
     private static $DEFAULT_ENDPOINT = 'https://flex.symfony.com';
     private static $MAX_LENGTH = 1000;
+    private static $versions;
 
     private $io;
     private $sess;
@@ -70,6 +71,11 @@ class Downloader
     public function disable()
     {
         $this->enabled = false;
+    }
+
+    public function getVersions()
+    {
+        return self::$versions ?? self::$versions = $this->get('/versions.json')->getBody();
     }
 
     /**

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -23,6 +23,7 @@ use Composer\Factory;
 use Composer\Installer;
 use Composer\Installer\InstallerEvent;
 use Composer\Installer\InstallerEvents;
+use Composer\Installer\NoopInstaller;
 use Composer\Installer\PackageEvent;
 use Composer\Installer\PackageEvents;
 use Composer\Installer\SuggestedPackagesReporter;
@@ -58,6 +59,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
     private $options;
     private $configurator;
     private $downloader;
+    private $installer;
     private $postInstallOutput = [''];
     private $operations = [];
     private $lock;
@@ -116,7 +118,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $manager->repositoryClasses = $this->repositoryClasses;
             $manager->setRepositoryClass('composer', TruncatedComposerRepository::class);
             $manager->repositories = $this->repositories;
-            $versions = $downloader->get('/versions.json')->getBody();
+            $versions = $downloader->getVersions();
             $i = 0;
             foreach (RepositoryFactory::defaultRepos(null, $this->config, $manager) as $repo) {
                 $manager->repositories[$i++] = $repo;
@@ -159,13 +161,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             }
         }
 
-        $backtrace = debug_backtrace();
-        foreach ($backtrace as $trace) {
-            if (isset($trace['object']) && $trace['object'] instanceof Installer) {
-                $trace['object']->setSuggestedPackagesReporter(new SuggestedPackagesReporter(new NullIO()));
-                break;
-            }
-        }
+        $backtrace = $this->configureInstaller();
 
         foreach ($backtrace as $trace) {
             if (!isset($trace['object']) || !isset($trace['args'][0])) {
@@ -198,10 +194,13 @@ class Flex implements PluginInterface, EventSubscriberInterface
             if ('create-project' === $command) {
                 // detect Composer >=1.7 (using the Composer::VERSION constant doesn't work with snapshot builds)
                 if (class_exists(Comparer::class)) {
-                    $input->setOption('remove-vcs', true);
+                    if ($input->hasOption('remove-vcs')) {
+                        $input->setOption('remove-vcs', true);
+                    }
                 } else {
                     $input->setInteractive(false);
                 }
+                $populateRepoCacheDir = $populateRepoCacheDir && !$input->hasOption('remove-vcs');
             } elseif ('update' === $command) {
                 $this->displayThanksReminder = 1;
             } elseif ('outdated' === $command) {
@@ -252,6 +251,20 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
+    public function configureInstaller()
+    {
+        $backtrace = debug_backtrace();
+        foreach ($backtrace as $trace) {
+            if (isset($trace['object']) && $trace['object'] instanceof Installer) {
+                $this->installer = $trace['object'];
+                $trace['object']->setSuggestedPackagesReporter(new SuggestedPackagesReporter(new NullIO()));
+                break;
+            }
+        }
+
+        return $backtrace;
+    }
+
     public function configureProject(Event $event)
     {
         if (!$this->downloader->isEnabled()) {
@@ -270,8 +283,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         // replace unbounded contraints for symfony/* packages by extra.symfony.require
         $config = json_decode($contents, true);
         if ($symfonyVersion = $config['extra']['symfony']['require'] ?? null) {
-            $response = $this->downloader->get('/versions.json');
-            $versions = $response->getBody();
+            $versions = $this->downloader->getVersions();
             foreach (['require', 'require-dev'] as $type) {
                 foreach ($config[$type] ?? [] as $package => $version) {
                     if ('*' === $version && isset($versions['splits'][$package])) {
@@ -296,16 +308,86 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    public function install(Event $event)
+    public function checkForUpdate(PackageEvent $event)
     {
-        $this->update($event);
+        if (null === $this->installer || $this->cacheDirPopulated || 'symfony/flex' !== $event->getOperation()->getPackage()->getName()) {
+            return;
+        }
+
+        $this->update();
+
+        $this->composer->getInstallationManager()->addInstaller(new NoopInstaller());
+
+        \Closure::bind(function () {
+            $this->io = new NullIO();
+            $this->writeLock = false;
+            $this->executeOperations = false;
+            $this->dumpAutoloader = false;
+            $this->runScripts = false;
+        }, $this->installer, $this->installer)();
     }
 
-    public function update(Event $event, $operations = [])
+    public function update(Event $event = null, $operations = [])
     {
         if ($operations) {
             $this->operations = $operations;
         }
+
+        $this->install($event);
+
+        $jsonPath = Factory::getComposerFile();
+        $json = file_get_contents($jsonPath);
+        $manipulator = new JsonManipulator($json);
+        $json = json_decode($json, true);
+
+        if (null === $event) {
+            // called from checkForUpdate()
+        } elseif (null === $this->installer || (!isset($json['flex-require']) && !isset($json['flex-require-dev']))) {
+            return;
+        } else {
+            $event->stopPropagation();
+        }
+
+        $sortPackages = $this->composer->getConfig()->get('sort-packages');
+
+        foreach (['require', 'require-dev'] as $type) {
+            if (isset($json['flex-'.$type])) {
+                foreach ($json['flex-'.$type] as $package => $constraint) {
+                    $manipulator->addLink($type, $package, $constraint, $sortPackages);
+                }
+
+                $manipulator->removeMainKey('flex-'.$type);
+            }
+        }
+
+        file_put_contents($jsonPath, $manipulator->getContents());
+
+        $composer = Factory::create($this->io);
+        $composer->getDownloadManager()->setOutputProgress($this->progress);
+
+        $installer = \Closure::bind(function () use ($composer, &$devMode) {
+            return Installer::create($this->io, $composer)
+                ->setPreferSource($this->preferSource)
+                ->setPreferDist($this->preferDist)
+                ->setDevMode($devMode = $this->devMode)
+                ->setIgnorePlatformRequirements($this->ignorePlatformReqs)
+                ->setSuggestedPackagesReporter($this->suggestedPackagesReporter)
+                ->setOptimizeAutoloader($this->optimizeAutoloader)
+                ->setClassMapAuthoritative($this->classMapAuthoritative)
+                ->setUpdate(true);
+        }, $this->installer, $this->installer)();
+
+        $composer->getEventDispatcher()->dispatchScript(ScriptEvents::POST_ROOT_PACKAGE_INSTALL, $devMode);
+
+        ParallelDownloader::$cacheNext = true;
+        $status = $installer->run();
+        if (0 !== $status) {
+            exit($status);
+        }
+    }
+
+    public function install(Event $event = null)
+    {
         $rootDir = $this->options->get('root-dir');
 
         if (!file_exists("$rootDir/.env") && !file_exists("$rootDir/.env.local") && file_exists("$rootDir/.env.dist") && false === strpos(file_get_contents("$rootDir/.env.dist"), '.env.local')) {
@@ -765,11 +847,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
             InstallerEvents::POST_DEPENDENCIES_SOLVING => [['populateFilesCacheDir', PHP_INT_MAX]],
             PackageEvents::PRE_PACKAGE_INSTALL => [['populateFilesCacheDir', ~PHP_INT_MAX]],
             PackageEvents::PRE_PACKAGE_UPDATE => [['populateFilesCacheDir', ~PHP_INT_MAX]],
-            PackageEvents::POST_PACKAGE_INSTALL => 'record',
+            PackageEvents::POST_PACKAGE_INSTALL => __CLASS__ === self::class ? [['record'], ['checkForUpdate']] : 'record',
             PackageEvents::POST_PACKAGE_UPDATE => [['record'], ['enableThanksReminder']],
             PackageEvents::POST_PACKAGE_UNINSTALL => 'record',
             ScriptEvents::POST_CREATE_PROJECT_CMD => 'configureProject',
             ScriptEvents::POST_INSTALL_CMD => 'install',
+            ScriptEvents::PRE_UPDATE_CMD => 'configureInstaller',
             ScriptEvents::POST_UPDATE_CMD => 'update',
             PluginEvents::PRE_FILE_DOWNLOAD => 'onFileDownload',
             'auto-scripts' => 'executeAutoScripts',

--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -22,7 +22,6 @@ class PackageResolver
 {
     private static $SYMFONY_VERSIONS = ['lts', 'previous', 'stable', 'next'];
     private static $aliases;
-    private static $versions;
     private $downloader;
 
     public function __construct(Downloader $downloader)
@@ -86,11 +85,9 @@ class PackageResolver
             return $version ? ':'.$version : '';
         }
 
-        if (null === self::$versions) {
-            self::$versions = $this->downloader->get('/versions.json')->getBody();
-        }
+        $versions = $this->downloader->getVersions();
 
-        if (!isset(self::$versions['splits'][$package])) {
+        if (!isset($versions['splits'][$package])) {
             return $version ? ':'.$version : '';
         }
 
@@ -104,9 +101,9 @@ class PackageResolver
             }
             $version = $config['extra']['symfony']['require'] ?? $config['require']['symfony/framework-bundle'];
         } elseif ('next' === $version) {
-            $version = '^'.self::$versions[$version].'@dev';
+            $version = '^'.$versions[$version].'@dev';
         } elseif (\in_array($version, self::$SYMFONY_VERSIONS, true)) {
-            $version = '^'.self::$versions[$version];
+            $version = '^'.$versions[$version];
         }
 
         return ':'.$version;

--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -214,6 +214,8 @@ class ParallelDownloader extends RemoteFilesystem
     protected function getRemoteContents($originUrl, $fileUrl, $context, array &$responseHeaders = null)
     {
         if (isset(self::$cache[$fileUrl])) {
+            self::$cacheNext = false;
+
             $result = self::$cache[$fileUrl];
 
             if (3 < \func_num_args()) {

--- a/tests/PackageResolverTest.php
+++ b/tests/PackageResolverTest.php
@@ -90,6 +90,17 @@ class PackageResolverTest extends TestCase
     private function getResolver()
     {
         $downloader = $this->getMockBuilder('Symfony\Flex\Downloader')->disableOriginalConstructor()->getMock();
+        $downloader->expects($this->any())
+            ->method('getVersions')
+            ->willReturn([
+                'lts' => '3.4',
+                'next' => '4.0',
+                'splits' => [
+                    'symfony/console' => ['3.4'],
+                    'symfony/translation' => ['3.4'],
+                    'symfony/validator' => ['3.4'],
+                ],
+            ]);
 
         $resolver = new PackageResolver($downloader);
         $p = new \ReflectionProperty($resolver, 'aliases');
@@ -99,17 +110,6 @@ class PackageResolverTest extends TestCase
             'console' => 'symfony/console',
             'translation' => 'symfony/translation',
             'validator' => 'symfony/validator',
-        ]);
-        $p = new \ReflectionProperty($resolver, 'versions');
-        $p->setAccessible(true);
-        $p->setValue($resolver, [
-            'lts' => '3.4',
-            'next' => '4.0',
-            'splits' => [
-                'symfony/console' => ['3.4'],
-                'symfony/translation' => ['3.4'],
-                'symfony/validator' => ['3.4'],
-            ],
         ]);
 
         return $resolver;


### PR DESCRIPTION
The goal of this PR is to remove the need for any skeleton-bot as used in https://github.com/symfony/skeleton/pulls?q=is%3Apr+is%3Aclosed+author%3Asymfony-skeleton-bot

As a reminder, this bot is currently needed to generate a `composer.lock`. And this file is needed because it's part of a work around to fix a combinatorial explosion when Composer solves dependencies.

This PR makes `create-project` a two steps process: first, a skeleton is installed with only flex in "require". When flex is installed and composer enables it, the plugin looks for specific entries in the composer.json file, namely "flex-require" and "flex-require-dev". It merges them with regular "require" and "require-dev", and runs a new "composer update" internally.

This also fixes the combinatorial explosion and allows downloading deps in parallel, but it also allows taking the local platform into account - while the current approach with bots forces initial resolution with the minimum supported PHP version. (fixing e.g. symfony/symfony-standard#1138 and symfony/website-skeleton#231 too).

Embeds a few fixes found meanwhile.
Fixes #450 too.