### PR TITLE
Don't output emojis when the output isn't being decorated

### DIFF
--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -72,8 +72,13 @@ class ParallelDownloader extends RemoteFilesystem
             if (!$this->downloader && method_exists(parent::class, 'getRemoteContents')) {
                 $this->io->writeError('<warning>Enable the "cURL" PHP extension for faster downloads</warning>');
             }
-            $note = '\\' === \DIRECTORY_SEPARATOR ? '' : (false !== stripos(PHP_OS, 'darwin') ? '🎵' : '🎶');
-            $note .= $this->downloader ? ('\\' !== \DIRECTORY_SEPARATOR ? ' 💨' : '') : '';
+
+            $note = '';
+            if ($this->io->isDecorated()) {
+                $note = '\\' === \DIRECTORY_SEPARATOR ? '' : (false !== stripos(PHP_OS, 'darwin') ? '🎵' : '🎶');
+                $note .= $this->downloader ? ('\\' !== \DIRECTORY_SEPARATOR ? ' 💨' : '') : '';
+            }
+
             $this->io->writeError('');
             $this->io->writeError(sprintf('<info>Prefetching %d packages</info> %s', $this->downloadCount, $note));
             $this->io->writeError('  - Downloading', false);


### PR DESCRIPTION
This should fix #528.

Before:

```
root@bafcbe268c5d:/projects/test# composer install
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 27 installs, 0 updates, 0 removals
  - Installing symfony/flex (dev-fix/disable-emojis-by-is-decorated 7e14191): Downloading (100%)

Prefetching 26 packages 🎶 💨
  - Downloading (100%)

  - Installing psr/cache (1.0.1): Loading from cache
  - Installing symfony/cache-contracts (v1.1.5): Loading from cache
  - Installing psr/container (1.0.0): Loading from cache
  - Installing symfony/service-contracts (v1.1.5): Loading from cache
  - Installing symfony/polyfill-php73 (v1.11.0): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.11.0): Loading from cache
  - Installing symfony/console (v4.3.2): Loading from cache
  - Installing symfony/dotenv (v4.3.2): Loading from cache
  - Installing symfony/event-dispatcher-contracts (v1.1.5): Loading from cache
  - Installing symfony/routing (v4.3.2): Loading from cache
  - Installing symfony/polyfill-php72 (v1.11.0): Loading from cache
  - Installing symfony/polyfill-intl-idn (v1.11.0): Loading from cache
  - Installing symfony/mime (v4.3.2): Loading from cache
  - Installing symfony/http-foundation (v4.3.2): Loading from cache
  - Installing symfony/event-dispatcher (v4.3.2): Loading from cache
  - Installing psr/log (1.1.0): Loading from cache
  - Installing symfony/debug (v4.3.2): Loading from cache
  - Installing symfony/http-kernel (v4.3.2): Loading from cache
  - Installing symfony/finder (v4.3.2): Loading from cache
  - Installing symfony/filesystem (v4.3.2): Loading from cache
  - Installing symfony/dependency-injection (v4.3.2): Loading from cache
  - Installing symfony/config (v4.3.2): Loading from cache
  - Installing symfony/var-exporter (v4.3.2): Loading from cache
  - Installing symfony/cache (v4.3.2): Loading from cache
  - Installing symfony/framework-bundle (v4.3.2): Loading from cache
  - Installing symfony/yaml (v4.3.2): Loading from cache
Generating autoload files
Executing script cache:clear [OK]
Executing script assets:install public [OK]
```

After:
```
root@bafcbe268c5d:/projects/test# composer install --no-ansi
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 27 installs, 0 updates, 0 removals
  - Installing symfony/flex (dev-fix/disable-emojis-by-is-decorated 7e14191): Downloading (100%)

Prefetching 26 packages
  - Downloading (100%)

  - Installing psr/cache (1.0.1): Loading from cache
  - Installing symfony/cache-contracts (v1.1.5): Loading from cache
  - Installing psr/container (1.0.0): Loading from cache
  - Installing symfony/service-contracts (v1.1.5): Loading from cache
  - Installing symfony/polyfill-php73 (v1.11.0): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.11.0): Loading from cache
  - Installing symfony/console (v4.3.2): Loading from cache
  - Installing symfony/dotenv (v4.3.2): Loading from cache
  - Installing symfony/event-dispatcher-contracts (v1.1.5): Loading from cache
  - Installing symfony/routing (v4.3.2): Loading from cache
  - Installing symfony/polyfill-php72 (v1.11.0): Loading from cache
  - Installing symfony/polyfill-intl-idn (v1.11.0): Loading from cache
  - Installing symfony/mime (v4.3.2): Loading from cache
  - Installing symfony/http-foundation (v4.3.2): Loading from cache
  - Installing symfony/event-dispatcher (v4.3.2): Loading from cache
  - Installing psr/log (1.1.0): Loading from cache
  - Installing symfony/debug (v4.3.2): Loading from cache
  - Installing symfony/http-kernel (v4.3.2): Loading from cache
  - Installing symfony/finder (v4.3.2): Loading from cache
  - Installing symfony/filesystem (v4.3.2): Loading from cache
  - Installing symfony/dependency-injection (v4.3.2): Loading from cache
  - Installing symfony/config (v4.3.2): Loading from cache
  - Installing symfony/var-exporter (v4.3.2): Loading from cache
  - Installing symfony/cache (v4.3.2): Loading from cache
  - Installing symfony/framework-bundle (v4.3.2): Loading from cache
  - Installing symfony/yaml (v4.3.2): Loading from cache
Generating autoload files
Executing script cache:clear [OK]
Executing script assets:install public [OK]
```