### PR TITLE
Fix docker configurator with many mark in volumes section

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -99,7 +99,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
         }
 
         foreach ($config as $key => $value) {
-            if (0 === preg_match(sprintf('{^%s:[ \t\r\n]*([ \t]+\w)}m', $key), $contents, $matches)) {
+            if (0 === preg_match(sprintf('{^%s:[ \t\r\n]*([ \t]+\w|#)}m', $key), $contents, $matches)) {
                 $contents = preg_replace(sprintf('{\n?^%s:[ \t\r\n]*}sm', $key), '', $contents, -1, $count);
             }
         }

--- a/tests/Configurator/DockerfileConfiguratorTest.php
+++ b/tests/Configurator/DockerfileConfiguratorTest.php
@@ -21,6 +21,16 @@ use Symfony\Flex\Recipe;
 
 class DockerfileConfiguratorTest extends TestCase
 {
+    public function setUp()
+    {
+        @mkdir(FLEX_TEST_DIR);
+    }
+
+    protected function tearDown()
+    {
+        @unlink(FLEX_TEST_DIR.'/Dockerfile');
+    }
+
     public function testConfigure()
     {
         $originalContent = <<<'EOF'
@@ -94,7 +104,6 @@ EOF;
         $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
         $recipe->method('getName')->willReturn('doctrine/doctrine-bundle');
 
-        @mkdir(FLEX_TEST_DIR);
         $config = FLEX_TEST_DIR.'/Dockerfile';
         file_put_contents($config, $originalContent);
 


### PR DESCRIPTION
When you delete a recipe from the volumes section when there are only recipes, the "volumes" keywords are deleted.

cc @dunglas 