### PR TITLE
Compare paths by their realpath when checking locks

### DIFF
--- a/src/Configurator/CopyFromRecipeConfigurator.php
+++ b/src/Configurator/CopyFromRecipeConfigurator.php
@@ -46,8 +46,12 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
         );
 
         $removableFiles = $recipe->getFiles();
-        foreach ($lockedFiles as $file) {
-            if (isset($removableFiles[$file])) {
+
+        $lockedFiles = array_map('realpath', $lockedFiles);
+
+        // Compare file paths by their real path to abstract OS differences
+        foreach (array_keys($removableFiles) as $file) {
+            if (\in_array(realpath($file), $lockedFiles)) {
                 unset($removableFiles[$file]);
             }
         }

--- a/tests/Configurator/CopyFromRecipeConfiguratorTest.php
+++ b/tests/Configurator/CopyFromRecipeConfiguratorTest.php
@@ -104,7 +104,7 @@ class CopyFromRecipeConfiguratorTest extends TestCase
         $this->assertFileExists($this->sourceFile);
 
         $lock = new Lock(FLEX_TEST_DIR.'/test.lock');
-        $lock->set('other-recipe', ['files' => [$this->targetFileRelativePath]]);
+        $lock->set('other-recipe', ['files' => ['./'.$this->targetFileRelativePath]]);
 
         $this->createConfigurator()->unconfigure($this->recipe, [$this->targetFileRelativePath], $lock);
 


### PR DESCRIPTION
Use `realpath` to compare locked files before removal.

Fixes #513

To test:
```
composer create-project symfony/skeleton example
cd example/vendor/symfony/
rm -rf flex
git clone https://github.com/leongersen/flex --branch issue-513 --single-branch
cd ../../
composer require symfony/test-pack
composer remove symfony/test-pack
```
