### PR TITLE
Handle package versions with slashes

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -33,10 +33,14 @@ class PackageResolver
     {
         $versionParser = new VersionParser();
 
-        // first pass split on : and = to separate package names and versions
+        // first pass split on ':', '=' or ' ' to separate package names and versions
         $explodedArguments = [];
         foreach ($arguments as $argument) {
-            if ((false !== $pos = strpos($argument, ':')) || (false !== $pos = strpos($argument, '='))) {
+            if (
+                (false !== $pos = strpos($argument, ':')) ||
+                (false !== $pos = strpos($argument, '=')) ||
+                (false !== $pos = strpos($argument, ' '))
+            ) {
                 $explodedArguments[] = substr($argument, 0, $pos);
                 $explodedArguments[] = substr($argument, $pos + 1);
             } else {

--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -32,6 +32,9 @@ class PackageResolver
     public function resolve(array $arguments = [], bool $isRequire = false): array
     {
         $versionParser = new VersionParser();
+        if (null === self::$aliases) {
+            self::$aliases = $this->downloader->get('/aliases.json')->getBody();
+        }
 
         // first pass split on ':', '=' or ' ' to separate package names and versions
         $explodedArguments = [];
@@ -52,9 +55,6 @@ class PackageResolver
         $packages = [];
         foreach ($explodedArguments as $i => $argument) {
             if (false === strpos($argument, '/') && !preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument) && !\in_array($argument, ['mirrors', 'nothing'])) {
-                if (null === self::$aliases) {
-                    self::$aliases = $this->downloader->get('/aliases.json')->getBody();
-                }
 
                 if (isset(self::$aliases[$argument])) {
                     $argument = self::$aliases[$argument];

--- a/tests/PackageResolverTest.php
+++ b/tests/PackageResolverTest.php
@@ -51,6 +51,18 @@ class PackageResolverTest extends TestCase
                 ['ext-mongodb'],
                 ['ext-mongodb'],
             ],
+            [
+                ['test/test:dev-patch'],
+                ['test/test:dev-patch'],
+            ],
+            [
+                ['test/test:dev-patch/hotfix'],
+                ['test/test:dev-patch/hotfix'],
+            ],
+            [
+                ['test/test=dev-patch/hotfix', 'cli lts', 'validator:3.2'],
+                ['test/test:dev-patch/hotfix', 'symfony/console:^3.4', 'symfony/validator:3.2'],
+            ],
         ];
     }
 

--- a/tests/PackageResolverTest.php
+++ b/tests/PackageResolverTest.php
@@ -36,11 +36,11 @@ class PackageResolverTest extends TestCase
                 ['symfony/console', 'symfony/validator', 'symfony/translation'],
             ],
             [
-                ['cli', 'lts', 'validator', '3.2', 'translation'],
+                ['cli lts', 'validator 3.2', 'translation'],
                 ['symfony/console:^3.4', 'symfony/validator:3.2', 'symfony/translation'],
             ],
             [
-                ['cli:lts', 'validator=3.2', 'translation', 'next'],
+                ['cli:lts', 'validator=3.2', 'translation next'],
                 ['symfony/console:^3.4', 'symfony/validator:3.2', 'symfony/translation:^4.0@dev'],
             ],
             [


### PR DESCRIPTION
This PR fixes a flaw in the parsing of packages that require a branch alias version which contains a slash, by treating each argument in the resolver as package with version. This matches the documentation from [`compose require [packages]`](https://github.com/composer/composer/blob/master/src/Composer/Command/RequireCommand.php/#L48)

This means that if you require packages split by a space through the CLI, you'll need to quote them. Instead of `composer require guzzlehttp/guzzle ^6.0`, you'll need to use `composer require "guzzlehttp/guzzle ^6.0"` so that it's treated as one argument, and matches the composer documentation.

Solves #559 