### PR TITLE
Skip parallel downloader for local files

### DIFF
--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -244,7 +244,7 @@ class ParallelDownloader extends RemoteFilesystem
             return $result;
         }
 
-        if (!$this->downloader) {
+        if (!$this->downloader || !preg_match('/^https?:/', $originUrl)) {
             return parent::getRemoteContents($originUrl, $fileUrl, $context, $responseHeaders);
         }
 


### PR DESCRIPTION
Fixes #560 

Currently Flex breaks installations of local packages via the composer built-in repository types:
- artifact repository (see #560)
- package repository (see #548)

This PR leaves the download to the original composer downloader, in case the URL of the package does not start with `http(s):`.

I found a very similar code piece in https://github.com/symfony/flex/blob/master/src/Flex.php#L605 (just for reference for maintainer).