### PR TITLE
fix wrong bypass of parallel downloads

### DIFF
--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -244,7 +244,7 @@ class ParallelDownloader extends RemoteFilesystem
             return $result;
         }
 
-        if (!$this->downloader || !preg_match('/^https?:/', $originUrl)) {
+        if (!$this->downloader || !preg_match('/^https?:/', $fileUrl)) {
             return parent::getRemoteContents($originUrl, $fileUrl, $context, $responseHeaders);
         }
 


### PR DESCRIPTION
On a big work project I noticed that with an empty composer cache the pre-fetching of packages has become really slow lately.

Here a comparison between flex and `hirak/prestissimo`:

flex:
https://blackfire.io/profiles/eb7cfd59-6d88-4035-b210-661a5f0de666/graph

prestissimo:
https://blackfire.io/profiles/07b46d2e-3912-41c5-b25c-5b39a3103de9/graph

In my case curl was not used at all :stuck_out_tongue: 

This PR aims to fix the wrong bypass condition that was added within https://github.com/symfony/flex/pull/561.

Thanks @nicolas-grekas for the help.

