### PR TITLE
Fix Symfony 5 - dump-env

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     },
     "require-dev": {
         "composer/composer": "^1.0.2",
-        "symfony/dotenv": "^3.4|^4.0",
-        "symfony/phpunit-bridge": "^3.4.19|^4.1.8",
-        "symfony/process": "^2.7|^3.0|^4.0"
+        "symfony/dotenv": "^3.4|^4.0|^5.0",
+        "symfony/phpunit-bridge": "^3.4.19|^4.1.8|^5.0",
+        "symfony/process": "^2.7|^3.0|^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixes #569

When using plugins, the composer autoloader use local project dependencies that match the plugin's `require`+`require-dev` dependencies.

Given flex plugin requires-dev `symfony/dotenv: ^3.4|^4.0`, composer's autoloader was not able to load the class Dotenv when in a project that requires `symfony/dotenv: ^5.0`.