### PR TITLE
Enable support for inline recipes (local recipe inside the package itself)

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -711,7 +711,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
             $noRecipe = !isset($manifests[$name]) || (isset($manifests[$name]['not_installable']) && $manifests[$name]['not_installable']);
             if ($noRecipe && 'symfony-bundle' === $package->getType()) {
-                $inlineRecipe = $this->composer->getInstallationManager()->getInstallPath($package) . '/manifest.json';
+                $inlineRecipe = $this->composer->getInstallationManager()->getInstallPath($package).'/manifest.json';
                 if (file_exists($inlineRecipe)) {
                     $manifest['origin'] = sprintf('%s:%s@inline recipe', $name, $package->getPrettyVersion());
                     $manifest['path'] = $inlineRecipe;

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -48,8 +48,8 @@ class Recipe
 
     public function getManifest(): array
     {
-        if (\array_key_exists('path', $this->data)) {
-            return json_decode(file_get_contents($this->data['path']), true);
+        if (\array_key_exists('recipe', $this->data)) {
+            return array_merge($this->data['recipe'], isset($this->data['manifest']) ? $this->data['manifest'] : []);
         }
 
         if (!isset($this->data['manifest'])) {

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -48,8 +48,8 @@ class Recipe
 
     public function getManifest(): array
     {
-        if (array_key_exists('path', $this->data)) {
-          return json_decode(file_get_contents($this->data['path']), true);
+        if (\array_key_exists('path', $this->data)) {
+            return json_decode(file_get_contents($this->data['path']), true);
         }
 
         if (!isset($this->data['manifest'])) {

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -48,6 +48,10 @@ class Recipe
 
     public function getManifest(): array
     {
+        if (array_key_exists('path', $this->data)) {
+          return json_decode(file_get_contents($this->data['path']), true);
+        }
+
         if (!isset($this->data['manifest'])) {
             throw new \LogicException(sprintf('Manifest is not available for recipe "%s".', $this->name));
         }


### PR DESCRIPTION
This PR:

* [x] Relates to #206 
* [x] Does not have tests yet
* [x] Does not break the actual behavior of the plugin
* [x] Needs some feedback
* [x] Needs some polishing

This PR enable support for recipe inside a package.

Basically when you install a package that doesn't have an official recipe and if the `composer.json` has ['extra']['recipe'], then that property will be used as recipe.

I personally really would like to see this in because I don't like so much the actual process of submitting new recipes and based on comments from #206, I think it would be a nice feature.