### PR TITLE
Fix computing the intersection of Symfony components with extra.symfony.require

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -117,12 +117,22 @@ class Cache extends BaseCache
 
         $versions = $this->downloader->getVersions();
         $this->downloader = null;
+        $okVersions = [];
 
         foreach ($versions['splits'] as $name => $vers) {
             foreach ($vers as $i => $v) {
-                $v = $this->versionParser->normalize($v);
+                if (!isset($okVersions[$v])) {
+                    $okVersions[$v] = false;
 
-                if (!$this->symfonyConstraints->matches(new Constraint('==', $v))) {
+                    for ($j = 0; $j < 60; ++$j) {
+                        if ($this->symfonyConstraints->matches(new Constraint('==', $v.'.'.$j.'.0'))) {
+                            $okVersions[$v] = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!$okVersions[$v]) {
                     unset($vers[$i]);
                 }
             }


### PR DESCRIPTION
A constraint like `">5.0.0,<5.1"` in `SYMFONY_REQUIRE` doesn't work right now, this fixes it.