### PR TITLE
compare data before marking lock as changed

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -49,14 +49,18 @@ class Lock
 
     public function set($name, $data)
     {
-        $this->lock[$name] = $data;
-        $this->changed = true;
+        if (!\array_key_exists($name, $this->lock) || $data !== $this->lock[$name]) {
+            $this->lock[$name] = $data;
+            $this->changed = true;
+        }
     }
 
     public function remove($name)
     {
-        unset($this->lock[$name]);
-        $this->changed = true;
+        if (\array_key_exists($name, $this->lock)) {
+            unset($this->lock[$name]);
+            $this->changed = true;
+        }
     }
 
     public function write()


### PR DESCRIPTION
In https://github.com/symfony/flex/pull/479 I tried to fix the issue https://github.com/symfony/flex/issues/379 by introducing a _changed_ flag to the Lock.

This patch worked for a few months. However, introducing https://github.com/symfony/flex/pull/576 broke the patch by [always calling](https://github.com/symfony/flex/pull/576/files#diff-46b78198ae7ea525f04268205dd782c3R273) `set` ending in the same situation as before.

Blame on me for not checking if anything differs before setting the _changed_ flag. This PR tries to do better.