### PR TITLE
Add option to not override autoload file

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -668,6 +668,11 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     public function updateAutoloadFile()
     {
+        $strictPhpVersion = $this->composer->getPackage()->getExtra()['symfony']['strict-php-version'] ?? true;
+        if (!$strictPhpVersion) {
+            return;
+        }
+
         if (!$platform = $this->lock->get('php')['version'] ?? null) {
             return;
         }


### PR DESCRIPTION
The override made to the autoload file [here](https://github.com/symfony/flex/pull/576#discussion_r357552402) should be optional.
I made an option, with a default value to `true`.

It avoid the developper to re-edit the autoload file after a composer update/install/dump-autoload if he wants to use different php environnement.

The name of the option is debatable. And I don't know if it should be documented and where.