### PR TITLE
Enable bundles auto-discovery by default

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -444,7 +444,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                         }
                         $value = strtolower($value[0]);
                         if (!\in_array($value, ['y', 'n', 'a', 'p'])) {
-                            throw new \InvalidArgumentException('Invalid choice');
+                            throw new \InvalidArgumentException('Invalid choice.');
                         }
 
                         return $value;
@@ -757,18 +757,23 @@ EOPHP
             }
 
             $noRecipe = !isset($manifests[$name]) || (isset($manifests[$name]['not_installable']) && $manifests[$name]['not_installable']);
-            if ($noRecipe && 'symfony-bundle' === $package->getType()) {
-                $manifest = [];
-                $bundle = new SymfonyBundle($this->composer, $package, $job);
+            if ($noRecipe) {
+                $bundles = [];
+
                 if (null === $devPackages) {
                     $devPackages = array_column($this->composer->getLocker()->getLockData()['packages-dev'], 'name');
                 }
                 $envs = \in_array($name, $devPackages) ? ['dev', 'test'] : ['all'];
-                foreach ($bundle->getClassNames() as $class) {
-                    $manifest['manifest']['bundles'][$class] = $envs;
+                $bundle = new SymfonyBundle($this->composer, $package, $job);
+                foreach ($bundle->getClassNames() as $bundleClass) {
+                    $bundles[$bundleClass] = $envs;
                 }
-                if ($manifest) {
-                    $manifest['origin'] = sprintf('%s:%s@auto-generated recipe', $name, $package->getPrettyVersion());
+
+                if ($bundles) {
+                    $manifest = [
+                        'origin' => sprintf('%s:%s@auto-generated recipe', $name, $package->getPrettyVersion()),
+                        'manifest' => ['bundles' => $bundles],
+                    ];
                     $recipes[$name] = new Recipe($package, $name, $job, $manifest);
                 }
             }

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Flex\Tests;
 
 use Composer\Composer;
+use Composer\Config;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\Factory;
 use Composer\Installer\PackageEvent;
@@ -37,10 +38,6 @@ class FlexTest extends TestCase
 {
     public function testPostInstall()
     {
-        $package = new Package('dummy/dummy', '1.0.0', '1.0.0');
-        $event = $this->getMockBuilder(PackageEvent::class)->disableOriginalConstructor()->getMock();
-        $event->expects($this->any())->method('getOperation')->willReturn(new InstallOperation($package));
-
         $data = [
             'manifests' => [
                 'dummy/dummy' => [
@@ -61,40 +58,14 @@ class FlexTest extends TestCase
             ],
         ];
 
-        $configurator = $this->getMockBuilder(Configurator::class)->disableOriginalConstructor()->getMock();
-        $configurator->expects($this->once())->method('install')->with($this->equalTo(new Recipe($package, 'dummy/dummy', 'install', $data['manifests']['dummy/dummy'], $data['locks']['dummy/dummy'])));
-
-        $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();
-        $downloader->expects($this->once())->method('getRecipes')->willReturn($data);
-        $downloader->expects($this->once())->method('isEnabled')->willReturn(true);
-
         $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
-        $locker = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
-        $locker->expects($this->any())->method('getLockData')->willReturn(['content-hash' => 'random']);
+        $package = new Package('dummy/dummy', '1.0.0', '1.0.0');
+        $recipe = new Recipe($package, 'dummy/dummy', 'install', $data['manifests']['dummy/dummy'], $data['locks']['dummy/dummy']);
 
-        $package = $this->getMockBuilder(RootPackageInterface::class)->disableOriginalConstructor()->getMock();
-        $package->expects($this->any())->method('getExtra')->willReturn(['symfony' => ['allow-contrib' => true]]);
-
-        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
-        $lock->expects($this->any())->method('has')->willReturn(false);
-
-        $flex = \Closure::bind(function () use ($configurator, $downloader, $io, $locker, $package, $lock) {
-            $flex = new Flex();
-            $flex->composer = new Composer();
-            $flex->composer->setLocker($locker);
-            $flex->composer->setPackage($package);
-            $flex->io = $io;
-            $flex->configurator = $configurator;
-            $flex->downloader = $downloader;
-            $flex->runningCommand = function () {
-            };
-            $flex->options = new Options(['config-dir' => 'config', 'var-dir' => 'var']);
-            $flex->lock = $lock;
-
-            return $flex;
-        }, null, Flex::class)->__invoke();
-        $flex->record($event);
-        $flex->install($this->getMockBuilder(Event::class)->disableOriginalConstructor()->getMock());
+        $rootPackage = $this->mockRootPackage(['symfony' => ['allow-contrib' => true]]);
+        $flex = $this->mockFlex($io, $rootPackage, $recipe, $data);
+        $flex->record($this->mockPackageEvent($package));
+        $flex->install($this->mockFlexEvent());
 
         $expected = [
             '',
@@ -124,22 +95,230 @@ EOF
     public function testActivateLoadsClasses()
     {
         $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
-        $composer = new Composer();
-        $composer->setConfig(Factory::createConfig($io));
-        $package = $this->getMockBuilder(RootPackageInterface::class)->disableOriginalConstructor()->getMock();
-        $package->method('getExtra')->willReturn(['symfony' => ['allow-contrib' => true]]);
+
+        $package = $this->mockRootPackage(['symfony' => ['allow-contrib' => true]]);
         $package->method('getRequires')->willReturn([new Link('dummy', 'symfony/flex')]);
-        $composer->setPackage($package);
-        $localRepo = $this->getMockBuilder(WritableRepositoryInterface::class)->disableOriginalConstructor()->getMock();
-        $manager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();
-        $manager->expects($this->once())
-            ->method('getLocalRepository')
-            ->willReturn($localRepo);
-        $composer->setRepositoryManager($manager);
+
+        $composer = $this->mockComposer($this->mockLocker(), $package, Factory::createConfig($io));
+        $composer->setRepositoryManager($this->mockManager());
 
         $flex = new Flex();
         $flex->activate($composer, $io);
 
         $this->assertTrue(class_exists(Response::class, false));
+    }
+
+    /**
+     * @dataProvider getPackagesForAutoDiscovery
+     */
+    public function testBundlesAutoDiscovery(Package $package, array $expectedManifest)
+    {
+        $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
+
+        $recipe = null;
+        if (\count($expectedManifest)) {
+            $recipe = new Recipe($package, $package->getName(), 'install', $expectedManifest);
+        }
+
+        $devPackages = $package->isDev() ? [['name' => $package->getName()]] : [];
+
+        $rootPackage = $this->mockRootPackage($package->getExtra());
+        $flex = $this->mockFlex($io, $rootPackage, $recipe, [], ['packages-dev' => $devPackages]);
+        $flex->record($this->mockPackageEvent($package));
+        $flex->install($this->mockFlexEvent());
+    }
+
+    public function getPackagesForAutoDiscovery(): array
+    {
+        $return = [];
+
+        $versions = ['1.0', '2.0-dev'];
+        $packages = self::getTestPackages();
+
+        foreach ($packages as $name => $info) {
+            foreach ($versions as $version) {
+                $package = new Package($name, $version, $version);
+                $package->setAutoload($info['autoload']);
+                if (isset($info['type'])) {
+                    $package->setType($info['type']);
+                }
+
+                $expectedManifest = [
+                    'origin' => sprintf('%s:%s@auto-generated recipe', $package->getName(),
+                        $package->getPrettyVersion()),
+                    'manifest' => ['bundles' => []],
+                ];
+
+                $envs = $package->isDev() ? ['dev', 'test'] : ['all'];
+                foreach ($info['bundles'] as $bundle) {
+                    $expectedManifest['manifest']['bundles'][$bundle] = $envs;
+                }
+
+                $return[] = [$package, $expectedManifest];
+            }
+        }
+
+        return $return;
+    }
+
+    public static function getTestPackages(): array
+    {
+        return [
+            'symfony/debug-bundle' => [
+                'autoload' => ['psr-4' => ['Symfony\\Bundle\\DebugBundle\\' => '']],
+                'bundles' => ['Symfony\\Bundle\\DebugBundle\\DebugBundle'],
+            ],
+            'symfony/dummy' => [
+                'autoload' => ['psr-4' => ['Symfony\\Bundle\\FirstDummyBundle\\' => 'FirstDummyBundle/', 'Symfony\\Bundle\\SecondDummyBundle\\' => 'SecondDummyBundle/']],
+                'bundles' => ['Symfony\\Bundle\\FirstDummyBundle\\FirstDummyBundle', 'Symfony\\Bundle\\SecondDummyBundle\\SecondDummyBundle'],
+            ],
+            'doctrine/doctrine-cache-bundle' => [
+                'autoload' => ['psr-4' => ['Doctrine\\Bundle\\DoctrineCacheBundle\\' => '']],
+                'bundles' => ['Doctrine\\Bundle\\DoctrineCacheBundle\\DoctrineCacheBundle'],
+            ],
+            'eightpoints/guzzle-bundle' => [
+                'autoload' => ['psr-0' => ['EightPoints\\Bundle\\GuzzleBundle' => '']],
+                'bundles' => ['EightPoints\\Bundle\\GuzzleBundle\\GuzzleBundle'],
+            ],
+            'easycorp/easy-security-bundle' => [
+                'autoload' => ['psr-4' => ['EasyCorp\\Bundle\\EasySecurityBundle\\' => '']],
+                'bundles' => ['EasyCorp\\Bundle\\EasySecurityBundle\\EasySecurityBundle'],
+            ],
+            'symfony-cmf/routing-bundle' => [
+                'autoload' => ['psr-4' => ['Symfony\\Cmf\\Bundle\\RoutingBundle\\' => '']],
+                'bundles' => ['Symfony\\Cmf\\Bundle\\RoutingBundle\\CmfRoutingBundle'],
+            ],
+            'easycorp/easy-deploy-bundle' => [
+                'autoload' => ['psr-4' => ['EasyCorp\\Bundle\\EasyDeployBundle\\' => 'src/']],
+                'bundles' => ['EasyCorp\\Bundle\\EasyDeployBundle\\EasyDeployBundle'],
+            ],
+            'easycorp/easy-deploy-bundle' => [
+                'autoload' => ['psr-4' => ['EasyCorp\\Bundle\\EasyDeployBundle\\' => ['src', 'tests']]],
+                'bundles' => ['EasyCorp\\Bundle\\EasyDeployBundle\\EasyDeployBundle'],
+            ],
+            'web-token/jwt-bundle' => [
+                'autoload' => ['psr-4' => ['Jose\\Bundle\\JoseFramework\\' => ['']]],
+                'bundles' => ['Jose\\Bundle\\JoseFramework\\JoseFrameworkBundle'],
+            ],
+            'sylius/shop-api-plugin' => [
+                'autoload' => ['psr-4' => ['Sylius\\ShopApiPlugin\\' => 'src/']],
+                'bundles' => ['Sylius\\ShopApiPlugin\\ShopApiPlugin'],
+                'type' => 'sylius-plugin',
+            ],
+            'dunglas/sylius-acme-plugin' => [
+                'autoload' => ['psr-4' => ['Dunglas\\SyliusAcmePlugin\\' => 'src/']],
+                'bundles' => ['Dunglas\\SyliusAcmePlugin\\DunglasSyliusAcmePlugin'],
+                'type' => 'sylius-plugin',
+            ],
+        ];
+    }
+
+    private function mockPackageEvent(Package $package): PackageEvent
+    {
+        $event = $this->getMockBuilder(PackageEvent::class, ['getOperation'])->disableOriginalConstructor()->getMock();
+        $event->expects($this->any())->method('getOperation')->willReturn(new InstallOperation($package));
+
+        return $event;
+    }
+
+    private function mockConfigurator(Recipe $recipe = null): Configurator
+    {
+        $configurator = $this->getMockBuilder(Configurator::class)->disableOriginalConstructor()->getMock();
+
+        if ($recipe) {
+            $configurator->expects($this->once())->method('install')->with($this->equalTo($recipe));
+        }
+
+        return $configurator;
+    }
+
+    private function mockDownloader(array $recipes = []): Downloader
+    {
+        $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();
+
+        $downloader->expects($this->once())->method('getRecipes')->willReturn($recipes);
+        $downloader->expects($this->once())->method('isEnabled')->willReturn(true);
+
+        return $downloader;
+    }
+
+    private function mockLocker(array $lockData = []): Locker
+    {
+        $locker = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
+
+        $lockData = array_merge(['content-hash' => 'random', 'packages-dev' => []], $lockData);
+        $locker->expects($this->any())->method('getLockData')->willReturn($lockData);
+
+        return $locker;
+    }
+
+    private function mockComposer(Locker $locker, RootPackageInterface $package, Config $config = null): Composer
+    {
+        if (null === $config) {
+            $config = $this->getMockBuilder(Config::class)->getMock();
+            $config->expects($this->any())->method('get')->willReturn(__DIR__.'/Fixtures/vendor');
+        }
+
+        $composer = new Composer();
+        $composer->setConfig($config);
+        $composer->setLocker($locker);
+        $composer->setPackage($package);
+
+        return $composer;
+    }
+
+    private function mockRootPackage(array $extraData = []): RootPackageInterface
+    {
+        $package = $this->getMockBuilder(RootPackageInterface::class)->disableOriginalConstructor()->getMock();
+
+        $package->expects($this->any())->method('getExtra')->willReturn($extraData);
+
+        return $package;
+    }
+
+    private function mockLock(): Lock
+    {
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $lock->expects($this->any())->method('has')->willReturn(false);
+
+        return $lock;
+    }
+
+    private function mockFlexEvent(): Event
+    {
+        return $this->getMockBuilder(Event::class)->disableOriginalConstructor()->getMock();
+    }
+
+    private function mockManager(): RepositoryManager
+    {
+        $manager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();
+
+        $localRepo = $this->getMockBuilder(WritableRepositoryInterface::class)->disableOriginalConstructor()->getMock();
+        $manager->expects($this->once())->method('getLocalRepository')->willReturn($localRepo);
+
+        return $manager;
+    }
+
+    private function mockFlex(BufferIO $io, RootPackageInterface $package, Recipe $recipe = null, array $recipes = [], array $lockerData = []): Flex
+    {
+        $composer = $this->mockComposer($this->mockLocker($lockerData), $package);
+
+        $configurator = $this->mockConfigurator($recipe);
+        $downloader = $this->mockDownloader($recipes);
+        $lock = $this->mockLock();
+
+        return \Closure::bind(function () use ($composer, $io, $configurator, $downloader, $lock) {
+            $flex = new Flex();
+            $flex->composer = $composer;
+            $flex->io = $io;
+            $flex->configurator = $configurator;
+            $flex->downloader = $downloader;
+            $flex->runningCommand = function () {
+            };
+            $flex->options = new Options(['config-dir' => 'config', 'var-dir' => 'var']);
+            $flex->lock = $lock;
+
+            return $flex;
+        }, null, Flex::class)->__invoke();
     }
 }

--- a/tests/SymfonyBundleTest.php
+++ b/tests/SymfonyBundleTest.php
@@ -38,64 +38,18 @@ class SymfonyBundleTest extends TestCase
 
     public function getNamespaces()
     {
-        return [
-            [
-                'symfony/debug-bundle',
-                ['psr-4' => ['Symfony\\Bundle\\DebugBundle\\' => '']],
-                ['Symfony\\Bundle\\DebugBundle\\DebugBundle'],
-            ],
-            [
-                'symfony/dummy',
-                ['psr-4' => ['Symfony\\Bundle\\FirstDummyBundle\\' => 'FirstDummyBundle/', 'Symfony\\Bundle\\SecondDummyBundle\\' => 'SecondDummyBundle/']],
-                ['Symfony\\Bundle\\FirstDummyBundle\\FirstDummyBundle', 'Symfony\\Bundle\\SecondDummyBundle\\SecondDummyBundle'],
-            ],
-            [
-                'doctrine/doctrine-cache-bundle',
-                ['psr-4' => ['Doctrine\\Bundle\\DoctrineCacheBundle\\' => '']],
-                ['Doctrine\\Bundle\\DoctrineCacheBundle\\DoctrineCacheBundle'],
-            ],
-            [
-                'eightpoints/guzzle-bundle',
-                ['psr-0' => ['EightPoints\\Bundle\\GuzzleBundle' => '']],
-                ['EightPoints\\Bundle\\GuzzleBundle\\GuzzleBundle'],
-            ],
-            [
-                'easycorp/easy-security-bundle',
-                ['psr-4' => ['EasyCorp\\Bundle\\EasySecurityBundle\\' => '']],
-                ['EasyCorp\\Bundle\\EasySecurityBundle\\EasySecurityBundle'],
-            ],
-            [
-                'symfony-cmf/routing-bundle',
-                ['psr-4' => ['Symfony\\Cmf\\Bundle\\RoutingBundle\\' => '']],
-                ['Symfony\\Cmf\\Bundle\\RoutingBundle\\CmfRoutingBundle'],
-            ],
-            [
-                'easycorp/easy-deploy-bundle',
-                ['psr-4' => ['EasyCorp\\Bundle\\EasyDeployBundle\\' => 'src/']],
-                ['EasyCorp\\Bundle\\EasyDeployBundle\\EasyDeployBundle'],
-            ],
-            [
-                'easycorp/easy-deploy-bundle',
-                ['psr-4' => ['EasyCorp\\Bundle\\EasyDeployBundle\\' => ['src', 'tests']]],
-                ['EasyCorp\\Bundle\\EasyDeployBundle\\EasyDeployBundle'],
-            ],
-            [
-                'web-token/jwt-bundle',
-                ['psr-4' => ['Jose\\Bundle\\JoseFramework\\' => ['']]],
-                ['Jose\\Bundle\\JoseFramework\\JoseFrameworkBundle'],
-            ],
-            [
-                'sylius/shop-api-plugin',
-                ['psr-4' => ['Sylius\\ShopApiPlugin\\' => 'src/']],
-                ['Sylius\\ShopApiPlugin\\ShopApiPlugin'],
-                'sylius-plugin',
-            ],
-            [
-                'dunglas/sylius-acme-plugin',
-                ['psr-4' => ['Dunglas\\SyliusAcmePlugin\\' => 'src/']],
-                ['Dunglas\\SyliusAcmePlugin\\DunglasSyliusAcmePlugin'],
-                'sylius-plugin',
-            ],
-        ];
+        $return = [];
+
+        $packages = FlexTest::getTestPackages();
+        foreach ($packages as $name => $info) {
+            $packageData = [$name, $info['autoload'], $info['bundles']];
+            if (isset($info['type'])) {
+                $packageData[] = $info['type'];
+            }
+
+            $return[] = $packageData;
+        }
+
+        return $return;
     }
 }


### PR DESCRIPTION
Bundles autodiscovery is now enabled for all the packages, but not only for `symfony-bundle` type packages. And it works in the same way as it worked before. 

PR description before @fabpot review:

> 1. Bundles autodiscovery is now enabled for all the packages, but not only for `symfony-bundle` type packages. And it works in the same way as it worked before. It is disabled only when there is `extra.symfony.bundles` configuration in the package (even if this configuration is an empty array).
> 2. New `extra.symfony.bundles` package configuration was introduced. It should contain the list of bundles and the environments where those bundles should be enabled. Example:
>     ```
>     "extra": {
>         "symfony": {
>             "bundles": {
>                 "VendorName\\BundleName1": ["all"],
>                 "VendorName\\BundleName2": ["dev", "test"]
>             }
>         }
>     }
>     ```
> 

Original PR description:
>I just do not see any reasons why `ezplatform-bundle` packages couldn't be enabled automatically after the installation (in the same way as `symfony-bundle` packages are).
>
>Tagging @andrerom here