### PR TITLE
avoid >100% progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
 /build/
+.phpunit.result.cache
 .php_cs.cache
 composer.lock

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -7,8 +7,9 @@ return PhpCsFixer\Config::create()
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
+        'fopen_flags' => false,
         '@PHPUnit48Migration:risky' => true,
-        'array_syntax' => array('syntax' => 'short'),
+        'array_syntax' => ['syntax' => 'short'],
         'ordered_imports' => true,
         'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
         'protected_to_private' => false,


### PR DESCRIPTION
Fixes #468 
This change skips tracking the progress of downloads where `Content-Length` header is missing. Curl returns `-1` which resulted in wrong progress calculation (total file size was not added to the total bytes to download).

As soon as such file is downloaded, the progress is updated. This means that downloading one big file might cause progress to stuck until the download is done.