### PR TITLE
Improve discoverability of 'composer recipes'

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -436,11 +436,17 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $this->io->writeError('');
             $this->io->writeError('What about running <comment>composer global require symfony/thanks && composer thanks</> now?');
             $this->io->writeError(sprintf('This will spread some %s by sending a %s to the GitHub repositories of your fellow package maintainers.', $love, $star));
-            $this->io->writeError('');
         }
+
+        $this->io->writeError('');
 
         if (!$recipes) {
             $this->lock->write();
+
+            if ($this->downloader->isEnabled()) {
+                $this->io->writeError('Run <comment>composer recipes</> at any time to see the status of your Symfony recipes.');
+                $this->io->writeError('');
+            }
 
             return;
         }

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -84,6 +84,9 @@ class FlexTest extends TestCase
 
         $this->assertSame(
             <<<EOF
+
+Run composer recipes at any time to see the status of your Symfony recipes.
+
 Symfony operations: 1 recipe ()
   - Configuring dummy/dummy (>=1.0): From github.com/symfony/recipes:master
 
@@ -254,7 +257,7 @@ EOF
         $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();
 
         $downloader->expects($this->once())->method('getRecipes')->willReturn($recipes);
-        $downloader->expects($this->once())->method('isEnabled')->willReturn(true);
+        $downloader->expects($this->exactly(2))->method('isEnabled')->willReturn(true);
 
         return $downloader;
     }


### PR DESCRIPTION
Discovering the `composer recipes` command during composer install/update

Fix issue #629 and move forward #518 - 8)

![Capture d’écran 2020-06-15 à 17 05 28](https://user-images.githubusercontent.com/12966574/84673799-77b41800-af2a-11ea-9a64-751aa78fde83.png)
