### PR TITLE
Fork Interval classes from composer/semver

### DIFF
--- a/src/Semver/FullConstraint.php
+++ b/src/Semver/FullConstraint.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Semver;
+
+use Composer\Semver\Constraint\Bound;
+use Composer\Semver\Constraint\ConstraintInterface;
+
+class FullConstraint implements ConstraintInterface
+{
+    protected $prettyString;
+
+    public function matches(ConstraintInterface $provider)
+    {
+        return false;
+    }
+
+    public function compile($operator)
+    {
+        return 'false';
+    }
+
+    public function setPrettyString($prettyString)
+    {
+        $this->prettyString = $prettyString;
+    }
+
+    public function getPrettyString()
+    {
+        if ($this->prettyString) {
+            return $this->prettyString;
+        }
+
+        return (string) $this;
+    }
+
+    public function __toString()
+    {
+        return '[]';
+    }
+
+    public function getUpperBound()
+    {
+        return new Bound('0.0.0.0-dev', false);
+    }
+
+    public function getLowerBound()
+    {
+        return new Bound('0.0.0.0-dev', false);
+    }
+}

--- a/src/Semver/Interval.php
+++ b/src/Semver/Interval.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is forked from composer/semver.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * https://github.com/composer/semver/blob/master/LICENSE
+ */
+
+namespace Symfony\Flex\Semver;
+
+use Composer\Semver\Constraint\Constraint;
+
+/**
+ * @internal
+ */
+class Interval
+{
+    /** @var Constraint */
+    private $start;
+    /** @var Constraint */
+    private $end;
+
+    public function __construct(Constraint $start, Constraint $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    /**
+     * @return Constraint
+     */
+    public function getStart()
+    {
+        return $this->start;
+    }
+
+    /**
+     * @return Constraint
+     */
+    public function getEnd()
+    {
+        return $this->end;
+    }
+
+    /**
+     * @return Constraint
+     */
+    public static function fromZero()
+    {
+        static $zero;
+
+        if (null === $zero) {
+            $zero = new Constraint('>=', '0.0.0.0-dev');
+        }
+
+        return $zero;
+    }
+
+    /**
+     * @return Constraint
+     */
+    public static function untilPositiveInfinity()
+    {
+        static $positiveInfinity;
+
+        if (null === $positiveInfinity) {
+            $positiveInfinity = new Constraint('<', PHP_INT_MAX.'.0.0.0');
+        }
+
+        return $positiveInfinity;
+    }
+
+    /**
+     * @return self
+     */
+    public static function any()
+    {
+        return new self(self::fromZero(), self::untilPositiveInfinity());
+    }
+
+    /**
+     * @return array{'names': string[], 'exclude': bool}
+     */
+    public static function anyDev()
+    {
+        // any == exclude nothing
+        return array('names' => array(), 'exclude' => true);
+    }
+
+    /**
+     * @return array{'names': string[], 'exclude': bool}
+     */
+    public static function noDev()
+    {
+        // nothing == no names included
+        return array('names' => array(), 'exclude' => false);
+    }
+}

--- a/src/Semver/Intervals.php
+++ b/src/Semver/Intervals.php
@@ -1,0 +1,515 @@
+<?php
+
+/*
+ * This file is forked from composer/semver.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * https://github.com/composer/semver/blob/master/LICENSE
+ */
+
+namespace Symfony\Flex\Semver;
+
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\Constraint\ConstraintInterface;
+use Composer\Semver\Constraint\EmptyConstraint;
+use Composer\Semver\Constraint\MatchAllConstraint;
+use Composer\Semver\Constraint\MatchNoneConstraint;
+use Composer\Semver\Constraint\MultiConstraint;
+
+/**
+ * Helper class generating intervals from constraints
+ *
+ * This contains utilities for:
+ *
+ *  - compacting an existing constraint which can be used to combine several into one
+ * by creating a MultiConstraint out of the many constraints you have.
+ *
+ *  - checking whether one subset is a subset of another.
+ *
+ * Note: You should call clear to free memoization memory  usage when you are done using this class
+ *
+ * @internal
+ */
+class Intervals
+{
+    /**
+     * @phpstan-var array<string, array{'numeric': Interval[], 'branches': array{'names': string[], 'exclude': bool}}>
+     */
+    private static $intervalsCache = array();
+
+    /**
+     * @phpstan-var array<string, int>
+     */
+    private static $opSortOrder = array(
+        '>=' => -3,
+        '<' => -2,
+        '>' => 2,
+        '<=' => 3,
+    );
+
+    /**
+     * Clears the memoization cache once you are done
+     *
+     * @return void
+     */
+    public static function clear()
+    {
+        self::$intervalsCache = array();
+    }
+
+    /**
+     * Checks whether $candidate is a subset of $constraint
+     *
+     * @return bool
+     */
+    public static function isSubsetOf(ConstraintInterface $candidate, ConstraintInterface $constraint)
+    {
+        if ($constraint instanceof EmptyConstraint) {
+            return true;
+        }
+
+        if ($constraint instanceof FullConstraint) {
+            return false;
+        }
+
+        if ($constraint instanceof MatchAllConstraint) {
+            return true;
+        }
+
+        if ($candidate instanceof MatchNoneConstraint || $constraint instanceof MatchNoneConstraint) {
+            return false;
+        }
+
+        $intersectionIntervals = self::get(new MultiConstraint(array($candidate, $constraint), true));
+        $candidateIntervals = self::get($candidate);
+        if (\count($intersectionIntervals['numeric']) !== \count($candidateIntervals['numeric'])) {
+            return false;
+        }
+
+        foreach ($intersectionIntervals['numeric'] as $index => $interval) {
+            if (!isset($candidateIntervals['numeric'][$index])) {
+                return false;
+            }
+
+            if ((string) $candidateIntervals['numeric'][$index]->getStart() !== (string) $interval->getStart()) {
+                return false;
+            }
+
+            if ((string) $candidateIntervals['numeric'][$index]->getEnd() !== (string) $interval->getEnd()) {
+                return false;
+            }
+        }
+
+        if ($intersectionIntervals['branches']['exclude'] !== $candidateIntervals['branches']['exclude']) {
+            return false;
+        }
+        if (\count($intersectionIntervals['branches']['names']) !== \count($candidateIntervals['branches']['names'])) {
+            return false;
+        }
+        foreach ($intersectionIntervals['branches']['names'] as $index => $name) {
+            if ($name !== $candidateIntervals['branches']['names'][$index]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks whether $a and $b have any intersection, equivalent to $a->matches($b)
+     *
+     * @return bool
+     */
+    public static function haveIntersections(ConstraintInterface $a, ConstraintInterface $b)
+    {
+        if ($a instanceof EmptyConstraint || $b instanceof EmptyConstraint) {
+            return true;
+        }
+
+        if ($a instanceof FullConstraint || $b instanceof FullConstraint) {
+            return false;
+        }
+
+        if ($a instanceof MatchAllConstraint || $b instanceof MatchAllConstraint) {
+            return true;
+        }
+
+        if ($a instanceof MatchNoneConstraint || $b instanceof MatchNoneConstraint) {
+            return false;
+        }
+
+        $intersectionIntervals = self::generateIntervals(new MultiConstraint(array($a, $b), true), true);
+
+        return \count($intersectionIntervals['numeric']) > 0 || $intersectionIntervals['branches']['exclude'] || \count($intersectionIntervals['branches']['names']) > 0;
+    }
+
+    /**
+     * Attempts to optimize a MultiConstraint
+     *
+     * When merging MultiConstraints together they can get very large, this will
+     * compact it by looking at the real intervals covered by all the constraints
+     * and then creates a new constraint containing only the smallest amount of rules
+     * to match the same intervals.
+     *
+     * @return ConstraintInterface
+     */
+    public static function compactConstraint(ConstraintInterface $constraint)
+    {
+        if (!$constraint instanceof MultiConstraint) {
+            return $constraint;
+        }
+
+        $intervals = self::generateIntervals($constraint);
+        $constraints = array();
+        $hasNumericMatchAll = false;
+
+        if (\count($intervals['numeric']) === 1 && (string) $intervals['numeric'][0]->getStart() === (string) Interval::fromZero() && (string) $intervals['numeric'][0]->getEnd() === (string) Interval::untilPositiveInfinity()) {
+            $constraints[] = $intervals['numeric'][0]->getStart();
+            $hasNumericMatchAll = true;
+        } else {
+            $unEqualConstraints = array();
+            for ($i = 0, $count = \count($intervals['numeric']); $i < $count; $i++) {
+                $interval = $intervals['numeric'][$i];
+                [$startOp, $startVersion] = explode(' ', $interval->getStart()->__toString(), 2);
+                [$endOp, $endVersion] = explode(' ', $interval->getEnd()->__toString(), 2);
+
+                // if current interval ends with < N and next interval begins with > N we can swap this out for != N
+                // but this needs to happen as a conjunctive expression together with the start of the current interval
+                // and end of next interval, so [>=M, <N] || [>N, <P] => [>=M, !=N, <P] but M/P can be skipped if
+                // they are zero/+inf
+                if ($endOp === '<' && $i+1 < $count) {
+                    $nextInterval = $intervals['numeric'][$i+1];
+                    [$nextStartOp, $nextStartVersion] = explode(' ', $nextInterval->getStart()->__toString(), 2);
+                    if ($endVersion === $nextStartVersion && $nextStartOp === '>') {
+                        // only add a start if we didn't already do so, can be skipped if we're looking at second
+                        // interval in [>=M, <N] || [>N, <P] || [>P, <Q] where unEqualConstraints currently contains
+                        // [>=M, !=N] already and we only want to add !=P right now
+                        if (\count($unEqualConstraints) === 0 && (string) $interval->getStart() !== (string) Interval::fromZero()) {
+                            $unEqualConstraints[] = $interval->getStart();
+                        }
+                        $unEqualConstraints[] = new Constraint('!=', $endVersion);
+                        continue;
+                    }
+                }
+
+                if (\count($unEqualConstraints) > 0) {
+                    // this is where the end of the following interval of a != constraint is added as explained above
+                    if ((string) $interval->getEnd() !== (string) Interval::untilPositiveInfinity()) {
+                        $unEqualConstraints[] = $interval->getEnd();
+                    }
+
+                    // count is 1 if entire constraint is just one != expression
+                    if (\count($unEqualConstraints) > 1) {
+                        $constraints[] = new MultiConstraint($unEqualConstraints, true);
+                    } else {
+                        $constraints[] = $unEqualConstraints[0];
+                    }
+
+                    $unEqualConstraints = array();
+                    continue;
+                }
+
+                // convert back >= x - <= x intervals to == x
+                if ($startVersion === $endVersion && $startOp === '>=' && $endOp === '<=') {
+                    $constraints[] = new Constraint('==', $startVersion);
+                    continue;
+                }
+
+                if ((string) $interval->getStart() === (string) Interval::fromZero()) {
+                    $constraints[] = $interval->getEnd();
+                } elseif ((string) $interval->getEnd() === (string) Interval::untilPositiveInfinity()) {
+                    $constraints[] = $interval->getStart();
+                } else {
+                    $constraints[] = new MultiConstraint(array($interval->getStart(), $interval->getEnd()), true);
+                }
+            }
+        }
+
+        $devConstraints = array();
+
+        if (0 === \count($intervals['branches']['names'])) {
+            if ($intervals['branches']['exclude']) {
+                if ($hasNumericMatchAll && !class_exists(MatchAllConstraint::class)) {
+                    return new EmptyConstraint;
+                }
+
+                if ($hasNumericMatchAll) {
+                    return new MatchAllConstraint;
+                }
+                // otherwise constraint should contain a != operator and already cover this
+            }
+        } else {
+            foreach ($intervals['branches']['names'] as $branchName) {
+                if ($intervals['branches']['exclude']) {
+                    $devConstraints[] = new Constraint('!=', $branchName);
+                } else {
+                    $devConstraints[] = new Constraint('==', $branchName);
+                }
+            }
+
+            // excluded branches, e.g. != dev-foo are conjunctive with the interval, so
+            // > 2.0 != dev-foo must return a conjunctive constraint
+            if ($intervals['branches']['exclude']) {
+                if (\count($constraints) > 1) {
+                    return new MultiConstraint(array_merge(
+                            array(new MultiConstraint($constraints, false)),
+                            $devConstraints
+                        ), true);
+                }
+
+                if (\count($constraints) === 1 && (string)$constraints[0] === (string)Interval::fromZero()) {
+                    if (\count($devConstraints) > 1) {
+                        return new MultiConstraint($devConstraints, true);
+                    }
+                    return $devConstraints[0];
+                }
+
+                return new MultiConstraint(array_merge($constraints, $devConstraints), true);
+            }
+
+            // otherwise devConstraints contains a list of == operators for branches which are disjunctive with the
+            // rest of the constraint
+            $constraints = array_merge($constraints, $devConstraints);
+        }
+
+        if (\count($constraints) > 1) {
+            return new MultiConstraint($constraints, false);
+        }
+
+        if (\count($constraints) === 1) {
+            return $constraints[0];
+        }
+
+        if (!class_exists(MatchNoneConstraint::class)) {
+            return new FullConstraint;
+        }
+
+        return new MatchNoneConstraint;
+    }
+
+    /**
+     * Creates an array of numeric intervals and branch constraints representing a given constraint
+     *
+     * if the returned numeric array is empty it means the constraint matches nothing in the numeric range (0 - +inf)
+     * if the returned branches array is empty it means no dev-* versions are matched
+     * if a constraint matches all possible dev-* versions, branches will contain Interval::anyDev()
+     *
+     * @return array
+     * @phpstan-return array{'numeric': Interval[], 'branches': array{'names': string[], 'exclude': bool}}
+     */
+    public static function get(ConstraintInterface $constraint)
+    {
+        $key = $constraint instanceof EmptyConstraint ? '*' : (string) $constraint;
+
+        if (!isset(self::$intervalsCache[$key])) {
+            self::$intervalsCache[$key] = self::generateIntervals($constraint);
+        }
+
+        return self::$intervalsCache[$key];
+    }
+
+    /**
+     * @phpstan-return array{'numeric': Interval[], 'branches': array{'names': string[], 'exclude': bool}}
+     */
+    private static function generateIntervals(ConstraintInterface $constraint, $stopOnFirstValidInterval = false)
+    {
+        if ($constraint instanceof MatchAllConstraint || $constraint instanceof EmptyConstraint) {
+            return array('numeric' => array(new Interval(Interval::fromZero(), Interval::untilPositiveInfinity())), 'branches' => Interval::anyDev());
+        }
+
+        if ($constraint instanceof MatchNoneConstraint || $constraint instanceof FullConstraint) {
+            return array('numeric' => array(), 'branches' => array('names' => array(), 'exclude' => false));
+        }
+
+        if ($constraint instanceof Constraint) {
+            return self::generateSingleConstraintIntervals($constraint);
+        }
+
+        if (!$constraint instanceof MultiConstraint) {
+            throw new \UnexpectedValueException('The constraint passed in should be an MatchAllConstraint, Constraint or MultiConstraint instance, got '.\get_class($constraint).'.');
+        }
+
+        $constraints = MultiConstraintHelper::accessConstraints($constraint);
+
+        $numericGroups = array();
+        $constraintBranches = array();
+        foreach ($constraints as $c) {
+            $res = self::get($c);
+            $numericGroups[] = $res['numeric'];
+            $constraintBranches[] = $res['branches'];
+        }
+
+        if (!MultiConstraintHelper::accessConjunctive($constraint)) {
+            $branches = Interval::noDev();
+            foreach ($constraintBranches as $b) {
+                if ($b['exclude']) {
+                    if ($branches['exclude']) {
+                        // disjunctive constraint, so only exclude what's excluded in all constraints
+                        // !=a,!=b || !=b,!=c => !=b
+                        $branches['names'] = array_intersect($branches['names'], $b['names']);
+                    } else {
+                        // disjunctive constraint so exclude all names which are not explicitly included in the alternative
+                        // (==b || ==c) || !=a,!=b => !=a
+                        $branches['exclude'] = true;
+                        $branches['names'] = array_diff($b['names'], $branches['names']);
+                    }
+                } else {
+                    if ($branches['exclude']) {
+                        // disjunctive constraint so exclude all names which are not explicitly included in the alternative
+                        // !=a,!=b || (==b || ==c) => !=a
+                        $branches['names'] = array_diff($branches['names'], $b['names']);
+                    } else {
+                        // disjunctive constraint, so just add all the other branches
+                        // (==a || ==b) || ==c => ==a || ==b || ==c
+                        $branches['names'] = array_merge($branches['names'], $b['names']);
+                    }
+                }
+            }
+        } else {
+            $branches = Interval::anyDev();
+            foreach ($constraintBranches as $b) {
+                if ($b['exclude']) {
+                    if ($branches['exclude']) {
+                        // conjunctive, so just add all branch names to be excluded
+                        // !=a && !=b => !=a,!=b
+                        $branches['names'] = array_merge($branches['names'], $b['names']);
+                    } else {
+                        // conjunctive, so only keep included names which are not excluded
+                        // (==a||==c) && !=a,!=b => ==c
+                        $branches['names'] = array_diff($branches['names'], $b['names']);
+                    }
+                } else {
+                    if ($branches['exclude']) {
+                        // conjunctive, so only keep included names which are not excluded
+                        // !=a,!=b && (==a||==c) => ==c
+                        $branches['names'] = array_diff($b['names'], $branches['names']);
+                        $branches['exclude'] = false;
+                    } else {
+                        // conjunctive, so only keep names that are included in both
+                        // (==a||==b) && (==a||==c) => ==a
+                        $branches['names'] = array_intersect($branches['names'], $b['names']);
+                    }
+                }
+            }
+        }
+
+        $branches['names'] = array_unique($branches['names']);
+
+        if (\count($numericGroups) === 1) {
+            return array('numeric' => $numericGroups[0], 'branches' => $branches);
+        }
+
+        $borders = array();
+        foreach ($numericGroups as $group) {
+            foreach ($group as $interval) {
+                [$startOp, $startVersion] = explode(' ', $interval->getStart()->__toString(), 2);
+                [$endOp, $endVersion] = explode(' ', $interval->getEnd()->__toString(), 2);
+
+                $borders[] = array('version' => $startVersion, 'operator' => $startOp, 'side' => 'start');
+                $borders[] = array('version' => $endVersion, 'operator' => $endOp, 'side' => 'end');
+            }
+        }
+
+        $opSortOrder = self::$opSortOrder;
+        usort($borders, function ($a, $b) use ($opSortOrder) {
+            $order = version_compare($a['version'], $b['version']);
+            if ($order === 0) {
+                return $opSortOrder[$a['operator']] - $opSortOrder[$b['operator']];
+            }
+
+            return $order;
+        });
+
+        $activeIntervals = 0;
+        $intervals = array();
+        $index = 0;
+        $activationThreshold = MultiConstraintHelper::accessConjunctive($constraint) ? \count($numericGroups) : 1;
+        $active = false;
+        $start = null;
+        foreach ($borders as $border) {
+            if ($border['side'] === 'start') {
+                $activeIntervals++;
+            } else {
+                $activeIntervals--;
+            }
+            if (!$active && $activeIntervals >= $activationThreshold) {
+                $start = new Constraint($border['operator'], $border['version']);
+                $active = true;
+            }
+            if ($active && $activeIntervals < $activationThreshold) {
+                $active = false;
+                [$op, $version] = explode(' ', $start->__toString(), 2);
+
+                // filter out invalid intervals like > x - <= x, or >= x - < x
+                if (
+                    version_compare($version, $border['version'], '=')
+                    && (
+                        ($op === '>' && $border['operator'] === '<=')
+                        || ($op === '>=' && $border['operator'] === '<')
+                    )
+                ) {
+                    unset($intervals[$index]);
+                } else {
+                    $intervals[$index] = new Interval($start, new Constraint($border['operator'], $border['version']));
+                    $index++;
+
+                    if ($stopOnFirstValidInterval) {
+                        break;
+                    }
+                }
+
+                $start = null;
+            }
+        }
+
+        return array('numeric' => $intervals, 'branches' => $branches);
+    }
+
+    /**
+     * @phpstan-return array{'numeric': Interval[], 'branches': array{'names': string[], 'exclude': bool}}}
+     */
+    private static function generateSingleConstraintIntervals(Constraint $constraint)
+    {
+        [$op, $version] = explode(' ', $constraint->__toString(), 2);
+
+        // handle branch constraints first
+        if (substr($version, 0, 4) === 'dev-') {
+            $intervals = array();
+            $branches = array('names' => array(), 'exclude' => false);
+
+            // != dev-foo means any numeric version may match, we treat >/< like != they are not really defined for branches
+            if ($op === '!=') {
+                $intervals[] = new Interval(Interval::fromZero(), Interval::untilPositiveInfinity());
+                $branches = array('names' => array($version), 'exclude' => true);
+            } elseif ($op === '==') {
+                $branches['names'][] = $version;
+            }
+
+            return array(
+                'numeric' => $intervals,
+                'branches' => $branches,
+            );
+        }
+
+        if ($op[0] === '>') { // > & >=
+            return array('numeric' => array(new Interval($constraint, Interval::untilPositiveInfinity())), 'branches' => Interval::noDev());
+        }
+        if ($op[0] === '<') { // < & <=
+            return array('numeric' => array(new Interval(Interval::fromZero(), $constraint)), 'branches' => Interval::noDev());
+        }
+        if ($op === '!=') {
+            // convert !=x to intervals of 0 - <x && >x - +inf + dev*
+            return array('numeric' => array(
+                new Interval(Interval::fromZero(), new Constraint('<', $version)),
+                new Interval(new Constraint('>', $version), Interval::untilPositiveInfinity()),
+            ), 'branches' => Interval::anyDev());
+        }
+
+        // convert ==x to an interval of >=x - <=x
+        return array('numeric' => array(
+            new Interval(new Constraint('>=', $version), new Constraint('<=', $version)),
+        ), 'branches' => Interval::noDev());
+    }
+}

--- a/src/Semver/MultiConstraintHelper.php
+++ b/src/Semver/MultiConstraintHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Semver;
+
+use Composer\Semver\Constraint\MultiConstraint;
+
+class MultiConstraintHelper extends MultiConstraint
+{
+    public static function accessConjunctive(parent $constraint)
+    {
+        return $constraint->conjunctive;
+    }
+
+    public static function accessConstraints(parent $constraint)
+    {
+        return $constraint->constraints;
+    }
+}

--- a/src/Semver/VersionParser.php
+++ b/src/Semver/VersionParser.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Semver;
+
+use Composer\Semver\VersionParser as BaseVersionParser;
+
+class VersionParser extends BaseVersionParser
+{
+    public function normalize($version, $fullVersion = null)
+    {
+        $normalizedVersion = trim($version);
+
+        // strip off aliasing
+        if (preg_match('{^([^,\s]++) ++as ++([^,\s]++)$}', $normalizedVersion, $match)) {
+            // verify that the alias is a version without constraint
+            $this->normalize($match[2]);
+
+            $normalizedVersion = $match[1];
+        }
+
+        // match master-like branches
+        if (preg_match('{^(?:dev-)?(master|trunk|default)$}i', $normalizedVersion, $match)) {
+            return 'dev-' . $match[1];
+        }
+
+        return parent::normalize($version, $fullVersion);
+    }
+}

--- a/tests/Semver/IntervalsTest.php
+++ b/tests/Semver/IntervalsTest.php
@@ -1,0 +1,806 @@
+<?php
+
+/*
+ * This file is forked from composer/semver.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * https://github.com/composer/semver/blob/master/LICENSE
+ */
+
+namespace Symfony\Flex\Tests\Semver;
+
+use PHPUnit\Framework\TestCase;
+use Composer\Semver\Constraint\MultiConstraint;
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\Constraint\MatchNoneConstraint;
+use Symfony\Flex\Semver\FullConstraint;
+use Symfony\Flex\Semver\Interval;
+use Symfony\Flex\Semver\Intervals;
+use Symfony\Flex\Semver\VersionParser;
+
+class IntervalsTest extends TestCase
+{
+    const INTERVAL_ANY = '*/dev*';
+    const INTERVAL_ANY_NODEV = '*';
+    const INTERVAL_NONE = '';
+
+    const COMPACT_NONE = '';
+
+    /**
+     * @dataProvider compactProvider
+     */
+    public function testCompactConstraint($expected, $toCompact, $conjunctive)
+    {
+        $parser = new VersionParser;
+
+        $parts = array();
+        foreach ($toCompact as $part) {
+            $parts[] = $parser->parseConstraints($part);
+        }
+
+        if ($expected === self::COMPACT_NONE) {
+            $expected = class_exists(MatchNoneConstraint::class) ? new MatchNoneConstraint : new FullConstraint;
+        } else {
+            $expected = $parser->parseConstraints($expected);
+        }
+
+        $new = Intervals::compactConstraint(new MultiConstraint($parts, $conjunctive));
+        $this->assertSame((string) $expected, (string) $new);
+    }
+
+    public function compactProvider()
+    {
+        return array(
+            'simple disjunctive multi' => array(
+                '1.0 - 1.2 || ^1.5',
+                array('1.0 - 1.2 || ^1.5', '1.8 - 1.9 || ^1.12'),
+                false
+            ),
+            'simple conjunctive multi' => array(
+                '1.8 - 1.9 || ^1.12',
+                array('1.0 - 1.2 || ^1.5', '1.8 - 1.9 || ^1.12'),
+                true
+            ),
+            'dev constraints propagate, disjunctive' => array(
+                '1.8 - 1.9 || ^1.12 || dev-master || dev-foo',
+                array('1.8 - 1.9 || ^1.12', 'dev-master', 'dev-foo'),
+                false
+            ),
+            'dev constraints + numeric constraint, conjunctive results in match-none' => array(
+                self::COMPACT_NONE,
+                array('1.8 - 1.9 || ^1.12', 'dev-master', 'dev-foo'),
+                true
+            ),
+            'conflicting numeric constraint, conjunctive results in match-none' => array(
+                self::COMPACT_NONE,
+                array('1.0', '2.0'),
+                true
+            ),
+            'simple disjunctive results in same output' => array(
+                '1.0 || 2.0',
+                array('1.0', '2.0'),
+                false
+            ),
+            'simple conjunctive results in same output' => array(
+                '!= 1.2, != 1.6',
+                array('!= 1.2', '!= 1.6'),
+                true
+            ),
+            'simple conjunctive results in same output/2' => array(
+                '!= 1.0, != 2.0',
+                array('!= 1.0', '!= 2.0'),
+                true
+            ),
+            'switches to conjunctive if more than != x is present' => array(
+                '>1.5, != 2.0',
+                array('!= 2.0', '> 1.5'),
+                true
+            ),
+            'complex conjunctive with dev' => array(
+                '!= 1.0, != 2.0',
+                array('!= 1.0', '!= 2.0'),
+                true
+            ),
+            'simple disjunctive with negation' => array(
+                '!= 1.0',
+                array('!= 1.0', '!= 1.0'),
+                false
+            ),
+            'disjunctive with complex negation' => array(
+                '*',
+                array('!= 1.0', '!= 1.0', '!= dev-foo', '1.0.5.*'),
+                false
+            ),
+            'conjunctive with complex negation' => array(
+                '1.0.5.*',
+                array('!= 1.0', '!= 1.0', '!= dev-foo', '1.0.5.*'),
+                true
+            ),
+            'conjunctive with complex negation/2' => array(
+                '>= 1.0-dev, != 1.2-stable, <2',
+                array('!= 1.2', '!= dev-foo', '!= dev-bar', '1.*'),
+                true
+            ),
+            'conjunctive with complex negation/3' => array(
+                '!= 1.2, != dev-foo, != dev-bar',
+                array('!= 1.2', '!= dev-foo', '!= dev-bar'),
+                true
+            ),
+            'disjunctive with complex negation/3' => array(
+                '*',
+                array('!= 1.2', '!= dev-foo', '!= dev-bar'),
+                false
+            ),
+            'conjunctive with complex negation/4' => array(
+                '== dev-foo',
+                array('!= 1.2', '== dev-foo', '!= dev-bar'),
+                true
+            ),
+            'disjunctive with complex negation and dev ==' => array(
+                '*',
+                array('!= 1.0', '!= 1.0', '!= dev-foo', '1.0.5.*', '== dev-bla'),
+                false
+            ),
+            'conjunctive with complex negation and dev ==' => array(
+                'dev-bla',
+                array('!= 1.0', '!= 1.0', '!= dev-foo', '== dev-bla'),
+                true
+            ),
+            'complex conjunctive which can not match anything' => array(
+                self::COMPACT_NONE,
+                array('!= 1.0', '!= 1.0', '!= dev-foo', '1.0.5.*', '== dev-bla'),
+                true
+            ),
+            'conjunctive with more than one dev negation' => array(
+                '!= dev-master, != dev-foo',
+                array('!= dev-master', '!= dev-foo'),
+                true
+            ),
+            'conjunctive with mix of devs' => array(
+                '== dev-foo',
+                array('!= dev-master', '== dev-foo'),
+                true
+            ),
+            'disjunctive with mix of devs' => array(
+                '!= dev-master',
+                array('!= dev-master', '== dev-foo'),
+                false
+            ),
+            'conjunctive with more than one dev negation, and numeric constraint' => array(
+                '> 5',
+                array('!= dev-master', '!= dev-foo', '> 5'),
+                true
+            ),
+            'conjunctive with more than one of the same dev negation' => array(
+                '!= dev-foo',
+                array('!= dev-foo', '!= dev-foo'),
+                true
+            ),
+            'switches to conjunctive when excluding versions and complex' => array(
+                '!= 3-stable, <5 || >=6, <9',
+                array('!= 3, <5', '>=6, <9'),
+                false
+            ),
+            'conjunctive with multiple numeric negations and a disjunctive exact match for dev versions' => array(
+                '== dev-foo || == dev-bar',
+                array('!= 1.0', '!= 2.0', '==dev-foo || ==dev-bar'),
+                true,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider intervalsProvider
+     */
+    public function testGetIntervals($expected, $constraint)
+    {
+        if (is_string($constraint)) {
+            $parser = new VersionParser;
+            $constraint = $parser->parseConstraints($constraint);
+        }
+
+        $result = Intervals::get($constraint);
+        if (is_array($result)) {
+            array_walk_recursive($result, function (&$c) {
+                if ($c instanceof Interval) {
+                    $c = array('start' => (string) $c->getStart(), 'end' => (string) $c->getEnd());
+                }
+            });
+        }
+
+        if ($expected === self::INTERVAL_ANY) {
+            $expected = array('numeric' => array(
+                array(
+                    'start' => '>= 0.0.0.0-dev',
+                    'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                ),
+            ), 'branches' => Interval::anyDev());
+        }
+
+        if ($expected === self::INTERVAL_ANY_NODEV) {
+            $expected = array('numeric' => array(
+                array(
+                    'start' => '>= 0.0.0.0-dev',
+                    'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                ),
+            ), 'branches' => Interval::noDev());
+        }
+
+        if ($expected === self::INTERVAL_NONE) {
+            $expected = array('numeric' => array(), 'branches' => Interval::noDev());
+        }
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function intervalsProvider()
+    {
+        return array(
+            'simple case' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^1.0'
+            ),
+            'simple case/2' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '> 1.0.0.0',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '> 1.0'
+            ),
+            'intervals should be sorted' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.9.0.0-dev',
+                        'end' => '< 1.0.0.0-dev',
+                    ),
+                    array(
+                        'start' => '>= 1.2.3.0',
+                        'end' => '<= 1.2.3.0',
+                    ),
+                    array(
+                        'start' => '>= 1.3.4.0',
+                        'end' => '<= 1.3.4.0',
+                    ),
+                    array(
+                        'start' => '> 2.3.0.0',
+                        'end' => '< 2.5.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '1.3.4 || 1.2.3 || >2.3,<2.5 || <1,>=0.9'
+            ),
+            'intervals should be sorted and consecutive ones merged' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                    array(
+                        'start' => '>= 3.0.0.0-dev',
+                        'end' => '< 5.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^4.0 || ^1.0 || ^3.0'
+            ),
+            'consecutive intervals should be merged even if one has no end' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 4.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^4.0 || >= 5'
+            ),
+            'consecutive intervals should be merged even if one has no start' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< 6.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '>= 5,< 6 || < 5'
+            ),
+            'consecutive intervals representing everything should become *' => array(
+                self::INTERVAL_ANY_NODEV,
+                '>= 5 || < 5'
+            ),
+            'intervals should be sorted and overlapping ones merged' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.1.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                    array(
+                        'start' => '>= 3.0.0.0-dev',
+                        'end' => '< 5.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^4.0 || ^1.1 || ^3.0 || ^1.2'
+            ),
+            'intervals should be sorted and overlapping ones merged/2' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 1.5.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '1.2 - 1.4 || 1.0 - 1.3'
+            ),
+            'overlapping intervals should be merged even if the last has no end' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 4.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^4.0 || >= 4.5'
+            ),
+            'overlapping intervals should be merged even if the first has no start' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< 6.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '>= 5,< 6 || < 5.3'
+            ),
+            'overlapping intervals representing everything should become *' => array(
+                self::INTERVAL_ANY_NODEV,
+                '>= 5 || <= 5'
+            ),
+            'equal intervals should be merged' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^1.0 || ^1.0'
+            ),
+            'weird input order should still be a good result' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '< 2.0 || < 1.2'
+            ),
+            'weird input order should still be a good result, matches everything' => array(
+                self::INTERVAL_ANY_NODEV,
+                '< 2.0 || >= 1'
+            ),
+            'weird input order should still be a good result, conjunctive' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '< 2.0, >= 1'
+            ),
+            'conjunctive constraints result in no interval if conflicting' => array(
+                self::INTERVAL_NONE,
+                '^1.0, ^2.0'
+            ),
+            'conjunctive constraints result in no interval if conflicting/2' => array(
+                self::INTERVAL_NONE,
+                '^1.0, ^3.0'
+            ),
+            'conjunctive constraints result in no interval if conflicting/3' => array(
+                self::INTERVAL_NONE,
+                '== 1.0, != 1.0'
+            ),
+            'conjunctive constraints result in no interval if conflicting/4' => array(
+                self::INTERVAL_NONE,
+                '> 1.0, dev-master'
+            ),
+            'conjunctive constraints result in no branches interval if numeric is provided' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '> 5.0.0.0',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '!= dev-master, != dev-foo, > 5'
+            ),
+            'conjunctive constraints result in no branches interval if numeric is provided, even if one matches dev*' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '> 5.0.0.0',
+                        'end' => '< 6.0.0.0',
+                    ),
+                    array(
+                        'start' => '> 6.0.0.0',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '!= 6, > 5'
+            ),
+            'disjunctive constraints keeps branch intervals if numeric is provided' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-master', 'dev-foo'), 'exclude' => true)),
+                '!= dev-master, != dev-foo || > 5'
+            ),
+            'conjunctive constraints should be intersected' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.2.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^1.0, ^1.2'
+            ),
+            'conjunctive constraints should be intersected/2' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.5.0.0-dev',
+                        'end' => '< 1.7.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^1.0, ^1.2, 1.4 - 1.8, 1.5 - 1.6, 1.5 - 2'
+            ),
+            'conjunctive constraints should be intersected, not flattened by version parser' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.5.0.0-dev',
+                        'end' => '< 1.7.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                new MultiConstraint(array(
+                    new MultiConstraint(array(
+                        new Constraint('>=', '1.0.0.0-dev'),
+                        new Constraint('<', '2.0.0.0-dev'),
+                    ), true),
+                    new MultiConstraint(array(
+                        new Constraint('>=', '1.2.0.0-dev'),
+                        new Constraint('<', '2.0.0.0-dev'),
+                    ), true),
+                    new MultiConstraint(array(
+                        new Constraint('>=', '1.4.0.0-dev'),
+                        new Constraint('<', '1.9.0.0-dev'),
+                    ), true),
+                    new MultiConstraint(array(
+                        new Constraint('>=', '1.5.0.0-dev'),
+                        new Constraint('<', '1.7.0.0-dev'),
+                    ), true),
+                    new MultiConstraint(array(
+                        new Constraint('>=', '1.5.0.0-dev'),
+                        new Constraint('<', '3.0.0.0-dev'),
+                    ), true),
+                ), true),
+            ),
+            'conjunctive constraints with disjunctive subcomponents should be intersected, not flattened by version parser' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.8.0.0-dev',
+                        'end' => '< 1.10.0.0-dev',
+                    ),
+                    array(
+                        'start' => '>= 1.12.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                new MultiConstraint(array(
+                    new MultiConstraint(array( // 1.0 - 1.2 || ^1.5
+                        new MultiConstraint(array(
+                            new Constraint('>=', '1.0.0.0-dev'),
+                            new Constraint('<', '1.3.0.0-dev'),
+                        ), true),
+                        new MultiConstraint(array(
+                            new Constraint('>=', '1.5.0.0-dev'),
+                            new Constraint('<', '2.0.0.0-dev'),
+                        ), true),
+                    ), false),
+                    new MultiConstraint(array( // 1.8 - 1.9 || ^1.12
+                        new MultiConstraint(array(
+                            new Constraint('>=', '1.8.0.0-dev'),
+                            new Constraint('<', '1.10.0.0-dev'),
+                        ), true),
+                        new MultiConstraint(array(
+                            new Constraint('>=', '1.12.0.0-dev'),
+                            new Constraint('<', '2.0.0.0-dev'),
+                        ), true),
+                    ), false),
+                ), true),
+            ),
+            'conjunctive constraints with equal constraints' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.3.2.0-dev',
+                        'end' => '<= 1.3.2.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                new MultiConstraint(array(
+                    new MultiConstraint(array(
+                        new Constraint('==', '1.3.1.0-dev'),
+                        new Constraint('==', '1.3.2.0-dev'),
+                        new Constraint('==', '1.3.3.0-dev'),
+                    ), false),
+                    new Constraint('==', '1.3.2.0-dev'),
+                ), true),
+            ),
+            'conjunctive constraints simple' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.5.0.0-dev',
+                        'end' => '< 3.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '1.5 - 2'
+            ),
+            'conjunctive constraints with dev exclusions' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 1.2.3.0',
+                    ),
+                    array(
+                        'start' => '> 1.2.3.0',
+                        'end' => '< 1.4.5.0',
+                    ),
+                    array(
+                        'start' => '> 1.4.5.0',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '!= 1.4.5, ^1.0, != 1.2.3, != 2.3, != dev-foo, != dev-master'
+            ),
+            'conjunctive constraints with dev exact versions suppresses the number scope matches' => array(
+                self::INTERVAL_NONE,
+                '!= 1.4.5, ^1.0, != 1.2.3, != 2.3, == dev-foo, == dev-foo'
+            ),
+            'conjunctive constraints with dev exact versions suppresses the number scope matches, but keeps dev- match if number constraints allowed dev*' => array(
+                array('numeric' => array(
+                ), 'branches' => array('names' => array('dev-foo'), 'exclude' => false)),
+                '!= 1.2.3, != 2.3, == dev-foo, == dev-foo'
+            ),
+            'disjunctive constraints with exclusions in dev constraints makes the number scope match *' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-foo'), 'exclude' => true)),
+                '^1.0 || != dev-foo'
+            ),
+            'disjunctive constraints with exclusions in dev constraints makes number scope match *' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-foo'), 'exclude' => true)),
+                '^1.0 || != dev-foo'
+            ),
+            'disjunctive constraints with exclusions, if matches * in number scope and dev scope, then * is returned' => array(
+                self::INTERVAL_ANY,
+                '!= 1.4.5 || ^1.0 || != dev-foo || != dev-master || == dev-master'
+            ),
+            'disjunctive constraints with exclusions, if dev constraints match *, then * is returned for everything' => array(
+                self::INTERVAL_ANY,
+                '^1.0 || != dev-master || == dev-master'
+            ),
+            'disjunctive constraints with exclusions, if dev constraints match * except in dev scope, then * is returned for number scope' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-foo'), 'exclude' => true)),
+                '^1.0 || != dev-foo || == dev-master'
+            ),
+            'disjunctive constraints with exact dev matches returns number scope as it should and unique dev constraints' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => array('names' => array('dev-foo', 'dev-master'), 'exclude' => false)),
+                '^1.0 || == dev-foo || == dev-master || == dev-master'
+            ),
+            'conjunctive constraints with exact versions' => array(
+                self::INTERVAL_NONE,
+                'dev-master, ^1.0'
+            ),
+            'conjunctive constraints with exact versions, dev only, diff version should result in no interval and no constraints' => array(
+                self::INTERVAL_NONE,
+                'dev-master, dev-foo'
+            ),
+            'conjunctive constraints with exact versions, dev only, same version should pass through' => array(
+                array('numeric' => array(), 'branches' => array('names' => array('dev-master'), 'exclude' => false)),
+                'dev-master, dev-master'
+            ),
+            'conjunctive constraints with same dev exclusion, should result in * with dev exclusion' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-master'), 'exclude' => true)),
+                '!= dev-master, != dev-master'
+            ),
+            'conjunctive constraints with different dev exclusion, should result in * with dev exclusions' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-master', 'dev-foo'), 'exclude' => true)),
+                '!= dev-master, != dev-foo'
+            ),
+            'disjunctive constraints with exact versions' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => array('names' => array('dev-master', 'dev-foo'), 'exclude' => false)),
+                'dev-master || ^1.0 || dev-foo || dev-master'
+            ),
+            'conjunctive constraints with * should skip it' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 1.0.0.0-dev',
+                        'end' => '< 2.0.0.0-dev',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '^1.0, *'
+            ),
+            'disjunctive constraints with * should result in *' => array(
+                self::INTERVAL_ANY,
+                '^1.0 || *'
+            ),
+            'conjunctive constraints with only * should result in *' => array(
+                self::INTERVAL_ANY,
+                '*, *'
+            ),
+            'conjunctive constraints equivalent of * should result in *' => array(
+                self::INTERVAL_ANY_NODEV,
+                new MultiConstraint(array(new Constraint('>=', '0.0.0.0-dev'), new Constraint('<', PHP_INT_MAX.'.0.0.0'))),
+            ),
+            'disjunctive constraints with * and dev exclusion should not return the dev exclusion' => array(
+                self::INTERVAL_ANY,
+                '!= dev-foo || *'
+            ),
+            'conjunctive constraints with various dev constraints/2' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '> 5.0.0.0',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '> 5, *'
+            ),
+            'conjunctive constraints with various dev constraints/3' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '> 5.0.0.0',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => Interval::noDev()),
+                '!= dev-foo, > 5'
+            ),
+            'conjunctive constraints with various dev constraints/4' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-foo'), 'exclude' => true)),
+                '!= dev-foo, != dev-foo'
+            ),
+            'conjunctive constraints with various dev constraints/5' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-foo', 'dev-bar'), 'exclude' => true)),
+                '!= dev-foo, != dev-bar'
+            ),
+            'conjunctive constraints with various dev constraints/6' => array(
+                array('numeric' => array(), 'branches' => array('names' => array('dev-bar'), 'exclude' => false)),
+                '!= dev-foo, == dev-bar'
+            ),
+            'conjunctive constraints with various dev constraints/7' => array(
+                self::INTERVAL_NONE,
+                'dev-foo, > 5'
+            ),
+            'complex conjunctive which can not match anything' => array(
+                self::INTERVAL_NONE,
+                '!= 1.0, != 1.0, != dev-foo, 1.0.5.*, == dev-bla'
+            ),
+            'conjunctive with more than one dev negation' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-master', 'dev-foo'), 'exclude' => true)),
+                '!= dev-master, != dev-foo'
+            ),
+            'disjunctive constraints with various dev constraints' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-foo'), 'exclude' => true)),
+                '!= dev-foo, != dev-bar || != dev-foo'
+            ),
+            'disjunctive constraints with various dev constraints/2' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-foo', 'dev-bar'), 'exclude' => true)),
+                '!= dev-foo, != dev-bar || != dev-foo, != dev-bar'
+            ),
+            'disjunctive constraints with various dev constraints/3' => array(
+                self::INTERVAL_ANY,
+                new MultiConstraint(array(new Constraint('!=', 'dev-foo'), new Constraint('!=', 'dev-bar')), false),
+            ),
+            'disjunctive constraints with various dev constraints/4' => array(
+                array('numeric' => array(),
+                    'branches' => array('names' => array('dev-foo', 'dev-bar'), 'exclude' => false),
+                ),
+                '== dev-foo || == dev-bar'
+            ),
+            'disjunctive constraints with various dev constraints/5' => array(
+                self::INTERVAL_ANY,
+                '== dev-foo || != dev-foo'
+            ),
+            'disjunctive constraints with various dev constraints/6' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-bar'), 'exclude' => true)),
+                '== dev-foo || != dev-bar'
+            ),
+            'disjunctive constraints with various dev constraints/7' => array(
+                array('numeric' => array(
+                    array(
+                        'start' => '>= 0.0.0.0-dev',
+                        'end' => '< '.PHP_INT_MAX.'.0.0.0',
+                    ),
+                ), 'branches' => array('names' => array('dev-bar'), 'exclude' => true)),
+                '== dev-foo || != dev-bar || != dev-bar'
+            ),
+            'disjunctive constraints with various dev constraints/8' => array(
+                self::INTERVAL_ANY,
+                '== dev-foo || != dev-bar || != dev-foo'
+            ),
+            'match-none constraints result in no interval' => array(
+                self::INTERVAL_NONE,
+                class_exists(MatchNoneConstraint::class) ? new MatchNoneConstraint : new FullConstraint,
+            ),
+            'match-none constraint inside conjunctive multi results in no interval' => array(
+                self::INTERVAL_NONE,
+                new MultiConstraint(array(
+                    new MultiConstraint(array(
+                        new Constraint('==', '1.3.1.0-dev'),
+                        new Constraint('==', '1.3.2.0-dev'),
+                        new Constraint('==', '1.3.3.0-dev'),
+                    ), false),
+                    class_exists(MatchNoneConstraint::class) ? new MatchNoneConstraint : new FullConstraint,
+                ), true),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
This is a copy/paste from https://github.com/composer/semver/ v3.

We're going to need this logic to implement #645

Forking is required because composer/semver v3 is shipped with Composer 2 but not with Composer 1.

/cc @Seldaek FYI