### PR TITLE
Remove notice about deprecated --no-suggest when using Composer v2

### DIFF
--- a/src/Command/RequireCommand.php
+++ b/src/Command/RequireCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Command;
 
 use Composer\Command\RequireCommand as BaseRequireCommand;
 use Composer\Package\Version\VersionParser;
+use Composer\Plugin\PluginInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -61,7 +62,7 @@ class RequireCommand extends BaseRequireCommand
             return 1;
         }
 
-        if ($input->hasOption('no-suggest')) {
+        if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>') && $input->hasOption('no-suggest')) {
             $input->setOption('no-suggest', true);
         }
 

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -233,7 +233,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                     $input->setArgument('packages', $resolver->resolve($input->getArgument('packages'), self::$aliasResolveCommands[$command]));
                 }
 
-                if ($input->hasOption('no-suggest')) {
+                if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>') && $input->hasOption('no-suggest')) {
                     $input->setOption('no-suggest', true);
                 }
             }


### PR DESCRIPTION
Removes `You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.`