### PR TITLE
Auto-unpack on create-project

### DIFF
--- a/src/Command/UnpackCommand.php
+++ b/src/Command/UnpackCommand.php
@@ -12,13 +12,8 @@
 namespace Symfony\Flex\Command;
 
 use Composer\Command\BaseCommand;
-use Composer\Config\JsonConfigSource;
-use Composer\Factory;
 use Composer\Installer;
-use Composer\Json\JsonFile;
-use Composer\Package\Locker;
 use Composer\Package\Version\VersionParser;
-use Composer\Plugin\PluginInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -55,10 +50,7 @@ class UnpackCommand extends BaseCommand
         $composer = $this->getComposer();
         $packages = $this->resolver->resolve($input->getArgument('packages'), true);
         $io = $this->getIO();
-        $json = new JsonFile(Factory::getComposerFile());
-        $manipulator = new JsonConfigSource($json);
-        $locker = $composer->getLocker();
-        $lockData = $locker->getLockData();
+        $lockData = $composer->getLocker()->getLockData();
         $installedRepo = $composer->getRepositoryManager()->getLocalRepository();
         $versionParser = new VersionParser();
         $dryRun = $input->hasOption('dry-run') && $input->getOption('dry-run');
@@ -97,40 +89,12 @@ class UnpackCommand extends BaseCommand
             $io->writeError(sprintf('<info>Unpacked %s dependencies</>', $pkg->getName()));
         }
 
-        foreach ($result->getUnpacked() as $package) {
-            $manipulator->removeLink('require-dev', $package->getName());
-            foreach ($lockData['packages-dev'] as $i => $pkg) {
-                if ($package->getName() === $pkg['name']) {
-                    unset($lockData['packages-dev'][$i]);
-                }
-            }
-            $manipulator->removeLink('require', $package->getName());
-            foreach ($lockData['packages'] as $i => $pkg) {
-                if ($package->getName() === $pkg['name']) {
-                    unset($lockData['packages'][$i]);
-                }
-            }
-        }
-        $lockData['packages'] = array_values($lockData['packages']);
-        $lockData['packages-dev'] = array_values($lockData['packages-dev']);
-        $lockData['content-hash'] = $locker->getContentHash(file_get_contents($json->getPath()));
-        $lockFile = new JsonFile(substr($json->getPath(), 0, -4).'lock', null, $io);
-
-        if (!$dryRun) {
-            $lockFile->write($lockData);
-        }
+        $unpacker->updateLock($result, $io);
 
         if ($input->hasOption('no-install') && $input->getOption('no-install')) {
             return 0;
         }
 
-        // force removal of files under vendor/
-        if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
-            $locker = new Locker($io, $lockFile, $composer->getRepositoryManager(), $composer->getInstallationManager(), file_get_contents($json->getPath()));
-        } else {
-            $locker = new Locker($io, $lockFile, $composer->getInstallationManager(), file_get_contents($json->getPath()));
-        }
-        $composer->setLocker($locker);
         $install = Installer::create($io, $composer);
         $install
             ->setDryRun($dryRun)


### PR DESCRIPTION
This PR ensures that packs are auto-unpacked when they are found in the `flex-require` or `flex-require-dev` sections, which happens when running e.g. `composer create-project symfony/(website-)skeleton`.

On the path to #645