### PR TITLE
Add a dedicated file deletion for unconfigure recipes

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -22,14 +22,16 @@ class Configurator
 {
     private $composer;
     private $io;
+    private $filesManager;
     private $options;
     private $configurators;
     private $cache;
 
-    public function __construct(Composer $composer, IOInterface $io, Options $options)
+    public function __construct(Composer $composer, IOInterface $io, FilesManager $filesManager, Options $options)
     {
         $this->composer = $composer;
         $this->io = $io;
+        $this->filesManager = $filesManager;
         $this->options = $options;
         // ordered list of configurators
         $this->configurators = [
@@ -78,6 +80,6 @@ class Configurator
 
         $class = $this->configurators[$key];
 
-        return $this->cache[$key] = new $class($this->composer, $this->io, $this->options);
+        return $this->cache[$key] = new $class($this->composer, $this->io, $this->filesManager, $this->options);
     }
 }

--- a/src/Configurator/AbstractConfigurator.php
+++ b/src/Configurator/AbstractConfigurator.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Configurator;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
+use Symfony\Flex\FilesManager;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Path;
@@ -25,13 +26,15 @@ abstract class AbstractConfigurator
 {
     protected $composer;
     protected $io;
+    protected $filesManager;
     protected $options;
     protected $path;
 
-    public function __construct(Composer $composer, IOInterface $io, Options $options)
+    public function __construct(Composer $composer, IOInterface $io, FilesManager $filesManager, Options $options)
     {
         $this->composer = $composer;
         $this->io = $io;
+        $this->filesManager = $filesManager;
         $this->options = $options;
         $this->path = new Path($options->get('root-dir'));
     }

--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -94,7 +94,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
     public function copyFile(string $source, string $target, array $options)
     {
         $overwrite = $options['force'] ?? false;
-        if (!$this->options->shouldWriteFile($target, $overwrite)) {
+        if (!$this->filesManager->shouldWriteFile($target, $overwrite)) {
             return;
         }
 

--- a/src/FilesManager.php
+++ b/src/FilesManager.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex;
+
+use Composer\IO\IOInterface;
+use Composer\Util\ProcessExecutor;
+
+/**
+ * @author Maxime Hélias <maximehelias16@gmail.com>
+ */
+class FilesManager
+{
+    private $io;
+    protected $path;
+
+    private $writtenFiles = [];
+    private $files;
+
+    public function __construct(IOInterface $io, Lock $lock, string $rootDir)
+    {
+        $this->io = $io;
+
+        $this->path = new Path($rootDir);
+        $this->files = array_count_values(
+            array_map(
+                function (string $file) {
+                    return realpath($file) ?: '';
+                }, array_reduce(
+                    array_column($lock->all(), 'files'),
+                    function (array $carry, array $package) {
+                        return array_merge($carry, $package);
+                    },
+                    []
+                )
+            )
+        );
+    }
+
+    public function shouldWriteFile(string $file, bool $overwrite): bool
+    {
+        if (isset($this->writtenFiles[$file])) {
+            return false;
+        }
+        $this->writtenFiles[$file] = true;
+
+        if (!file_exists($file)) {
+            return true;
+        }
+
+        if (!$overwrite) {
+            return false;
+        }
+
+        if (!filesize($file)) {
+            return true;
+        }
+
+        exec('git status --short --ignored --untracked-files=all -- '.ProcessExecutor::escape($file).' 2>&1', $output, $status);
+
+        if (0 !== $status) {
+            return (bool) $this->io && $this->io->askConfirmation(sprintf('Cannot determine the state of the "%s" file, overwrite anyway? [y/N] ', $file), false);
+        }
+
+        if (empty($output[0]) || preg_match('/^[ AMDRCU][ D][ \t]/', $output[0])) {
+            return true;
+        }
+
+        $name = basename($file);
+        $name = \strlen($output[0]) - \strlen($name) === strrpos($output[0], $name) ? substr($output[0], 3) : $name;
+
+        return (bool) $this->io && $this->io->askConfirmation(sprintf('File "%s" has uncommitted changes, overwrite? [y/N] ', $name), false);
+    }
+
+    public function getRemovableFilesFromRecipeAndLock(Recipe $recipe): array
+    {
+        $removableFiles = $recipe->getFiles();
+        // Compare file paths by their real path to abstract OS differences
+        foreach (array_keys($removableFiles) as $file) {
+            $file = realpath($file);
+            if (!isset($this->files[$file])) {
+                continue;
+            }
+
+            --$this->files[$file];
+
+            if ($this->files[$file] <= 0) {
+                unset($removableFiles[$file]);
+            }
+        }
+
+        return $removableFiles;
+    }
+}

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -70,6 +70,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     private $config;
     private $options;
+    private $filesManager;
     private $configurator;
     private $downloader;
     private $installer;
@@ -159,8 +160,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $composer->setRepositoryManager($manager);
         }
 
-        $this->configurator = new Configurator($composer, $io, $this->options);
         $this->lock = new Lock(getenv('SYMFONY_LOCKFILE') ?: str_replace('composer.json', 'symfony.lock', Factory::getComposerFile()));
+        $this->filesManager = new FilesManager($io, $this->lock, $this->options->get('root-dir'));
+        $this->configurator = new Configurator($composer, $io, $this->filesManager, $this->options);
 
         $disable = true;
         foreach (array_merge($composer->getPackage()->getRequires() ?? [], $composer->getPackage()->getDevRequires() ?? []) as $link) {
@@ -877,7 +879,7 @@ EOPHP
             'root-dir' => $extra['symfony']['root-dir'] ?? '.',
         ], $extra);
 
-        return new Options($options, $this->io);
+        return new Options($options);
     }
 
     private function getFlexId()

--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -26,6 +26,7 @@ class BundlesConfiguratorTest extends TestCase
         $configurator = new BundlesConfigurator(
             $this->getMockBuilder('Composer\Composer')->getMock(),
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
 
@@ -64,6 +65,7 @@ EOF
         $configurator = new BundlesConfigurator(
             $this->getMockBuilder('Composer\Composer')->getMock(),
             $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
 

--- a/tests/Configurator/ContainerConfiguratorTest.php
+++ b/tests/Configurator/ContainerConfiguratorTest.php
@@ -39,6 +39,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en'], $lock);
@@ -78,6 +79,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en'], $lock);
@@ -118,6 +120,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en'], $lock);
@@ -162,6 +165,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en', 'foobar' => 'baz'], $lock);
@@ -212,6 +216,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['locale' => 'en', 'foobar' => 'baz', 'array' => ['key1' => 'value', 'key2' => "Escape ' one quote"], 'key1' => 'Keep It'], $lock);
@@ -262,6 +267,7 @@ EOF
         $configurator = new ContainerConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['env(APP_ENV)' => ''], $lock);

--- a/tests/Configurator/CopyDirectoryFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyDirectoryFromPackageConfiguratorTest.php
@@ -17,6 +17,7 @@ use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\CopyFromPackageConfigurator;
+use Symfony\Flex\FilesManager;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
@@ -106,7 +107,7 @@ class CopyDirectoryFromPackageConfiguratorTest extends TestCase
 
     private function createConfigurator(): CopyFromPackageConfigurator
     {
-        return new CopyFromPackageConfigurator($this->composer, $this->io, new Options(['root-dir' => FLEX_TEST_DIR]));
+        return new CopyFromPackageConfigurator($this->composer, $this->io, new FilesManager($this->io, $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock(), FLEX_TEST_DIR), new Options(['root-dir' => FLEX_TEST_DIR]));
     }
 
     private function cleanUpTargetFiles()

--- a/tests/Configurator/CopyFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyFromPackageConfiguratorTest.php
@@ -18,6 +18,7 @@ use Composer\Package\PackageInterface;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\CopyFromPackageConfigurator;
+use Symfony\Flex\FilesManager;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
@@ -166,7 +167,7 @@ class CopyFromPackageConfiguratorTest extends TestCase
 
     private function createConfigurator(): CopyFromPackageConfigurator
     {
-        return new CopyFromPackageConfigurator($this->composer, $this->io, new Options(['root-dir' => FLEX_TEST_DIR], $this->io));
+        return new CopyFromPackageConfigurator($this->composer, $this->io, new FilesManager($this->io, $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock(), FLEX_TEST_DIR), new Options(['root-dir' => FLEX_TEST_DIR], $this->io));
     }
 
     private function cleanUpTargetFiles()

--- a/tests/Configurator/CopyFromRecipeConfiguratorTest.php
+++ b/tests/Configurator/CopyFromRecipeConfiguratorTest.php
@@ -15,6 +15,7 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\CopyFromRecipeConfigurator;
+use Symfony\Flex\FilesManager;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
@@ -167,7 +168,7 @@ class CopyFromRecipeConfiguratorTest extends TestCase
 
     private function createConfigurator(): CopyFromRecipeConfigurator
     {
-        return new CopyFromRecipeConfigurator($this->getMockBuilder(Composer::class)->getMock(), $this->io, new Options(['root-dir' => FLEX_TEST_DIR], $this->io));
+        return new CopyFromRecipeConfigurator($this->getMockBuilder(Composer::class)->getMock(), $this->io, new FilesManager($this->io, $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock(), FLEX_TEST_DIR), new Options(['root-dir' => FLEX_TEST_DIR], $this->io));
     }
 
     private function cleanUpTargetFiles()

--- a/tests/Configurator/DockerComposeConfiguratorTest.php
+++ b/tests/Configurator/DockerComposeConfiguratorTest.php
@@ -122,6 +122,7 @@ YAML;
         $this->configurator = new DockerComposeConfigurator(
             $composer,
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
     }

--- a/tests/Configurator/DockerfileConfiguratorTest.php
+++ b/tests/Configurator/DockerfileConfiguratorTest.php
@@ -116,6 +116,7 @@ EOF;
         $configurator = new DockerfileConfigurator(
             $composer,
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
         $configurator->configure($recipe, ['RUN docker-php-ext-install pdo_mysql'], $lock);

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -26,6 +26,7 @@ class EnvConfiguratorTest extends TestCase
         $configurator = new EnvConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['root-dir' => FLEX_TEST_DIR])
         );
         $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
@@ -155,6 +156,7 @@ EOF
         $configurator = new EnvConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['root-dir' => FLEX_TEST_DIR])
         );
         $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
@@ -202,6 +204,7 @@ EOF
         $configurator = new EnvConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['root-dir' => FLEX_TEST_DIR])
         );
 

--- a/tests/Configurator/GitignoreConfiguratorTest.php
+++ b/tests/Configurator/GitignoreConfiguratorTest.php
@@ -26,6 +26,7 @@ class GitignoreConfiguratorTest extends TestCase
         $configurator = new GitignoreConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['public-dir' => 'public', 'root-dir' => FLEX_TEST_DIR])
         );
         $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
@@ -86,6 +87,7 @@ EOF;
         $configurator = new GitignoreConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['public-dir' => 'public', 'root-dir' => FLEX_TEST_DIR])
         );
 

--- a/tests/Configurator/MakefileConfiguratorTest.php
+++ b/tests/Configurator/MakefileConfiguratorTest.php
@@ -26,6 +26,7 @@ class MakefileConfiguratorTest extends TestCase
         $configurator = new MakefileConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['root-dir' => FLEX_TEST_DIR])
         );
         $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
@@ -88,6 +89,7 @@ EOF
         $configurator = new MakefileConfigurator(
             $this->getMockBuilder(Composer::class)->getMock(),
             $this->getMockBuilder(IOInterface::class)->getMock(),
+            $this->getMockBuilder('Symfony\Flex\FilesManager')->disableOriginalConstructor()->getMock(),
             new Options(['root-dir' => FLEX_TEST_DIR])
         );
 


### PR DESCRIPTION
This is a first try for replace #615

In this way we a correct deletion of the same file imported by 2 recipes.
Factoring in this way would allow us to remove the `$lock` parameter passing in the `unconfigure` method and with a little more work in the` configure`.

WDYT @nicolas-grekas @weaverryan ?