### PR TITLE
Fixed not working "--force" option if you want to reinstall a recipe

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -463,7 +463,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             copy($rootDir.'/.env.dist', $rootDir.'/.env');
         }
 
-        $recipes = $this->fetchRecipes($this->operations);
+        $recipes = $this->fetchRecipes($this->operations, $this->isUpdateEventForced($event));
         $this->operations = [];     // Reset the operation after getting recipes
 
         if (2 === $this->displayThanksReminder) {
@@ -540,7 +540,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                 case 'install':
                     $this->io->writeError(sprintf('  - Configuring %s', $this->formatOrigin($recipe->getOrigin())));
                     $this->configurator->install($recipe, $this->lock, [
-                        'force' => $event instanceof UpdateEvent && $event->force(),
+                        'force' => $this->isUpdateEventForced($event),
                     ]);
                     $manifest = $recipe->getManifest();
                     if (isset($manifest['post-install-output'])) {
@@ -773,7 +773,7 @@ EOPHP
         );
     }
 
-    public function fetchRecipes(array $operations): array
+    public function fetchRecipes(array $operations, bool $force = false): array
     {
         if (!$this->downloader->isEnabled()) {
             $this->io->writeError('<warning>Symfony recipes are disabled: "symfony/flex" not found in the root composer.json</>');
@@ -814,7 +814,7 @@ EOPHP
 
             if ($operation instanceof InstallOperation && isset($locks[$name])) {
                 $ref = $this->lock->get($name)['recipe']['ref'] ?? null;
-                if ($ref && ($locks[$name]['recipe']['ref'] ?? null) === $ref) {
+                if (!$force && $ref && ($locks[$name]['recipe']['ref'] ?? null) === $ref) {
                     continue;
                 }
                 $this->lock->set($name, $locks[$name]);
@@ -998,5 +998,10 @@ EOPHP
         }
 
         return $events;
+    }
+
+    private function isUpdateEventForced(?Event $event): bool
+    {
+        return $event instanceof UpdateEvent && $event->force();
     }
 }


### PR DESCRIPTION
Sometimes it's necessary to reinstall a recipe but actually it's not possible if there is not update for a recipe. Also with the `--force` option Flex won't reinstall/execute the recipe. Only if there is a update for a recipe.

I figured out that the $recipes in [Flex.php#L466](https://github.com/symfony/flex/blob/115e67f76ba95d70946a6e0b15d4578bf04927c3/src/Flex.php#L466) are empty. It can't find/collects the recipe because the existing ref and the "reinstall" ref are same, see in [Flex.php#L817](https://github.com/symfony/flex/blob/115e67f76ba95d70946a6e0b15d4578bf04927c3/src/Flex.php#L817).

So i tried to fix it but to be honest i'm not sure it's a good solution.

---

What do you think?

---

### To reproduce:
1. Create a new directory
1. Execute `composer require symfony/flex`
1. Execute `composer require symfony/apache-pack`
1. Delete or truncate file `public/.htaccess`
1. Execute `composer recipes:install symfony/apache-pack --force`