### PR TITLE
Avoid filtering out aliases of valid packages

### DIFF
--- a/src/PackageFilter.php
+++ b/src/PackageFilter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Flex;
 
 use Composer\IO\IOInterface;
+use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\VersionParser;
@@ -54,20 +55,25 @@ class PackageFilter
         $oneSymfony = false;
         foreach ($data as $package) {
             $name = $package->getName();
-            $version = $package->getVersion();
+            $versions = [$package->getVersion()];
+            if ($package instanceof AliasPackage) {
+                $versions[] = $package->getAliasOf()->getVersion();
+            }
             if ('symfony/symfony' !== $name && !isset($knownVersions['splits'][$name])) {
                 $filteredPackages[] = $package;
                 continue;
             }
 
-            if (null !== $alias = $package->getExtra()['branch-alias'][$version] ?? null) {
-                $version = $this->versionParser->normalize($alias);
+            if (null !== $alias = $package->getExtra()['branch-alias'][$package->getVersion()] ?? null) {
+                $versions[] = $this->versionParser->normalize($alias);
             }
 
-            if ($this->symfonyConstraints->matches(new Constraint('==', $version))) {
-                $filteredPackages[] = $package;
-                $oneSymfony = $oneSymfony || 'symfony/symfony' === $name;
-                continue;
+            foreach ($versions as $version) {
+                if ($this->symfonyConstraints->matches(new Constraint('==', $version))) {
+                    $filteredPackages[] = $package;
+                    $oneSymfony = $oneSymfony || 'symfony/symfony' === $name;
+                    continue 2;
+                }
             }
 
             if ('symfony/symfony' === $name) {


### PR DESCRIPTION
It'd be good to add tests for this ... and I am not sure if the branch-alias check at line 67/68 is still needed if aliases are handled properly, might be or might not be.. I don't fully grasp the scope of what flex does here. 