### PR TITLE
[COMPOSER] Fix strpos(): Empty needle when using bash variables

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -119,7 +119,7 @@ class PackageResolver
         $alternatives = [];
         foreach (self::$aliases as $alias => $package) {
             $lev = levenshtein($argument, $alias);
-            if ($lev <= \strlen($argument) / 3 || false !== strpos($alias, $argument)) {
+            if ($lev <= \strlen($argument) / 3 || ('' !== $argument && false !== strpos($alias, $argument))) {
                 $alternatives[$package][] = $alias;
             }
         }

--- a/tests/PackageResolverTest.php
+++ b/tests/PackageResolverTest.php
@@ -79,10 +79,13 @@ class PackageResolverTest extends TestCase
                 ['cli', '2.3', 'consale'],
                 "\"consale\" is not a valid alias. Did you mean this:\n  \"symfony/console\", supported aliases: \"console\"",
             ],
-
             [
                 ['qwerty'],
                 '"qwerty" is not a valid alias.',
+            ],
+            [
+                ['lts:'],
+                'Could not parse version constraint "".',
             ],
         ];
     }


### PR DESCRIPTION
**Context**
I discovered this issue from a personal specific script, when a bash variable was not set properly.
I get this PHP error from flex:
```
[ErrorException]        
strpos(): Empty needle
```

**How to reproduce**
```
symfony new test --version=lts
cd test
composer require symfony/yaml:$VERSION
```