### PR TITLE
Fix: Remove trailing whitespace if value is empty

### DIFF
--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -51,7 +51,11 @@ class EnvConfigurator extends AbstractConfigurator
             foreach ($vars as $key => $value) {
                 $value = $this->evaluateValue($value);
                 if ('#' === $key[0] && is_numeric(substr($key, 1))) {
-                    $data .= '# '.$value."\n";
+                    if ('' === $value) {
+                        $data .= "#\n";
+                    } else {
+                        $data .= '# '.$value."\n";
+                    }
 
                     continue;
                 }


### PR DESCRIPTION
This is the case if someone wants to add a blank line.


```diff
# IMPORTANT: Comment
-# 
+#
# FOO_BAR=baz
```