### PR TITLE
Changing to support next version of stimulus bridge with "fetch" mode

### DIFF
--- a/src/PackageJsonSynchronizer.php
+++ b/src/PackageJsonSynchronizer.php
@@ -112,7 +112,7 @@ class PackageJsonSynchronizer
                 if (!isset($previousControllersJson['controllers']['@'.$phpPackage][$controllerName])) {
                     $config = [];
                     $config['enabled'] = $defaultConfig['enabled'];
-                    $config['webpackMode'] = $defaultConfig['webpackMode'];
+                    $config['fetch'] = $defaultConfig['fetch'] ?? 'eager';
 
                     if (isset($defaultConfig['autoimport'])) {
                         $config['autoimport'] = $defaultConfig['autoimport'];
@@ -128,7 +128,7 @@ class PackageJsonSynchronizer
 
                 $config = [];
                 $config['enabled'] = $previousConfig['enabled'];
-                $config['webpackMode'] = $previousConfig['webpackMode'];
+                $config['fetch'] = $previousConfig['fetch'] ?? 'eager';
 
                 if (isset($defaultConfig['autoimport'])) {
                     $config['autoimport'] = [];
@@ -149,7 +149,7 @@ class PackageJsonSynchronizer
             }
         }
 
-        file_put_contents($controllersJsonPath, json_encode($newControllersJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+        file_put_contents($controllersJsonPath, json_encode($newControllersJson, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES)."\n");
     }
 
     private function resolveAssetsDir(string $phpPackage)

--- a/tests/Fixtures/packageJson/vendor/symfony/existing-package/Resources/assets/package.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/existing-package/Resources/assets/package.json
@@ -3,7 +3,7 @@
         "controllers": {
             "mock": {
                 "enabled": true,
-                "webpackMode": "eager",
+                "fetch": "eager",
                 "autoimport": {
                     "@symfony/existing-package/dist/style.css": true,
                     "@symfony/existing-package/dist/new-style.css": true

--- a/tests/Fixtures/packageJson/vendor/symfony/new-package/assets/package.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/new-package/assets/package.json
@@ -3,7 +3,7 @@
         "controllers": {
             "new": {
                 "enabled": true,
-                "webpackMode": "lazy",
+                "fetch": "lazy",
                 "autoimport": {
                     "@symfony/new-package/dist/style.css": true
                 }

--- a/tests/PackageJsonSynchronizerTest.php
+++ b/tests/PackageJsonSynchronizerTest.php
@@ -20,7 +20,7 @@ class PackageJsonSynchronizerTest extends TestCase
     private $tempDir;
     private $synchronizer;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->tempDir = sys_get_temp_dir().'/flex-package-json-'.substr(md5(uniqid('', true)), 0, 6);
         (new Filesystem())->mirror(__DIR__.'/Fixtures/packageJson', $this->tempDir);
@@ -28,7 +28,7 @@ class PackageJsonSynchronizerTest extends TestCase
         $this->synchronizer = new PackageJsonSynchronizer($this->tempDir);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         (new Filesystem())->remove($this->tempDir);
     }
@@ -79,7 +79,8 @@ class PackageJsonSynchronizerTest extends TestCase
                     '@symfony/existing-package' => [
                         'mock' => [
                             'enabled' => false,
-                            'webpackMode' => 'eager',
+                            // the "fetch" replaces the old "webpackMode"
+                            'fetch' => 'eager',
                             'autoimport' => [
                                 '@symfony/existing-package/dist/style.css' => false,
                                 '@symfony/existing-package/dist/new-style.css' => true,
@@ -116,7 +117,7 @@ class PackageJsonSynchronizerTest extends TestCase
                     '@symfony/existing-package' => [
                         'mock' => [
                             'enabled' => false,
-                            'webpackMode' => 'eager',
+                            'fetch' => 'eager',
                             'autoimport' => [
                                 '@symfony/existing-package/dist/style.css' => false,
                                 '@symfony/existing-package/dist/new-style.css' => true,
@@ -126,7 +127,7 @@ class PackageJsonSynchronizerTest extends TestCase
                     '@symfony/new-package' => [
                         'new' => [
                             'enabled' => true,
-                            'webpackMode' => 'lazy',
+                            'fetch' => 'lazy',
                             'autoimport' => [
                                 '@symfony/new-package/dist/style.css' => true,
                             ],


### PR DESCRIPTION
Partner to https://github.com/symfony/stimulus-bridge/pull/15 and https://github.com/symfony/ux/pull/53

The tricky part about this is that, if the user has `stimulus-bridge` 1.x, then their `controllers.json` file needs `webpackMode`. If they have `stimulus-bridge` "next" (we're thinking it'll be 2.0), then their `controllers.json` file needs `fetch`. This means that Flex has a "hard break" and sorta just needs to assume that the user has the "new" version.

We made the decision - to go from `webpackMode` to `fetch` because the setting no longer is truly the same as `webpackMode`. However, if we wanted to make the upgrade path easier, we could revert that and use `webpackMode` in 2.0 as well (instead of changing to `fetch`).