### PR TITLE
Allow specifying the name of the .env file to be dumped

### DIFF
--- a/src/Command/DumpEnvCommand.php
+++ b/src/Command/DumpEnvCommand.php
@@ -42,6 +42,7 @@ class DumpEnvCommand extends BaseCommand
                 new InputArgument('env', InputArgument::OPTIONAL, 'The application environment to dump .env files for - e.g. "prod".'),
             ])
             ->addOption('empty', null, InputOption::VALUE_NONE, 'Ignore the content of .env files')
+            ->addOption('env-file', null, InputOption::VALUE_REQUIRED, 'The name of the .env files to be dumped, relative to the project root dir.', '.env')
         ;
     }
 
@@ -51,7 +52,8 @@ class DumpEnvCommand extends BaseCommand
             $_SERVER['APP_ENV'] = $env;
         }
 
-        $path = $this->options->get('root-dir').'/.env';
+        $envFile = $input->getOption('env-file');
+        $path = $this->options->get('root-dir').'/'.$envFile;
 
         if (!$env || !$input->getOption('empty')) {
             $vars = $this->loadEnv($path, $env);
@@ -73,7 +75,7 @@ return $vars;
 EOF;
         file_put_contents($path.'.local.php', $vars, LOCK_EX);
 
-        $this->getIO()->writeError('Successfully dumped .env files in <info>.env.local.php</>');
+        $this->getIO()->writeError('Successfully dumped '.$envFile.' files in <info>'.$envFile.'.local.php</>');
 
         return 0;
     }

--- a/tests/Command/DumpEnvCommandTest.php
+++ b/tests/Command/DumpEnvCommandTest.php
@@ -164,6 +164,36 @@ EOF;
         unlink($envLocalPhp);
     }
 
+    public function testEnvFileCanBeSpecified()
+    {
+        @mkdir(FLEX_TEST_DIR);
+        $env = FLEX_TEST_DIR.'/.env.custom';
+        $envLocalPhp = FLEX_TEST_DIR.'/.env.custom.local.php';
+        @unlink($envLocalPhp);
+
+        $envContent = <<<EOF
+APP_ENV=prod
+APP_SECRET=abcdefgh1234567
+EOF;
+        file_put_contents($env, $envContent);
+
+        $command = $this->createCommandDumpEnv();
+        $command->execute([
+            'env' => 'prod',
+            '--env-file' => '.env.custom',
+        ]);
+
+        $this->assertFileExists($envLocalPhp);
+
+        $this->assertSame([
+            'APP_ENV' => 'prod',
+            'APP_SECRET' => 'abcdefgh1234567',
+        ], require $envLocalPhp);
+
+        unlink($env);
+        unlink($envLocalPhp);
+    }
+
     private function createCommandDumpEnv()
     {
         $command = new DumpEnvCommand(


### PR DESCRIPTION
symfony/dotenv allows customizing the name of the  .env files. Unfortunately, the dump-env command doesn't allow changing the name.

This PR adds a new command option through which the filename can be specified:
```
> composer dump-env prod --env-file=.env.custom
Successfully dumped .env.custom files in .env.custom.local.php
```

My specific need at the moment is that I want to reserve the usage of the .env file for docker-compose