### PR TITLE
Enable --force to work without .git/

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -65,6 +65,9 @@ class Options
             return true;
         }
 
+        if (!file_exists('.git')) {
+            return true;
+        }
         exec('git status --short --ignored --untracked-files=all -- '.ProcessExecutor::escape($file).' 2>&1', $output, $status);
 
         if (0 !== $status) {


### PR DESCRIPTION
Not sure about the fix,  BUT we ran into that issue during automation and I think there is something to improve.

The `exec` command COULD return a bad status because the project does not have git yet. When `git init` is not yet done.

In this situation, the `--force` is not working as expected and we can't enforce the "override".

We fixed our issue doing the following, but we think Flex should NOT consider that `.git` exists.

Another workaround would be to add an option to the `--force` to decide the answer to the questions. Today there is no way to force the `y` to each question triggered by the `exec` bad return status code.

Let us know!

Thanks

```bash
if [ ! -d .git ]; then
    git init
    git add .
    git config --global user.email "ezlaunchpad@ibexa.co"
    git config --global user.name "eZ Launchpad"
    git commit -m "Fake commit that will be removed"
    composer recipes:install $REPO --force
    rm -rf .git
else
    echo "There is a .git we don't take the risk to override it."
fi
```


