### PR TITLE
Clarify the dump-env exception message

### DIFF
--- a/src/Command/DumpEnvCommand.php
+++ b/src/Command/DumpEnvCommand.php
@@ -108,7 +108,7 @@ EOF;
             }
 
             if (!$env) {
-                throw new \RuntimeException('Please provide the name of the environment either by using the "--env" command line argument or by defining the "APP_ENV" variable in the ".env.local" file.');
+                throw new \RuntimeException('Please provide the name of the environment either by passing it as command line argument or by defining the "APP_ENV" variable in the ".env.local" file.');
             }
 
             if (method_exists($dotenv, 'loadEnv')) {

--- a/tests/Command/DumpEnvCommandTest.php
+++ b/tests/Command/DumpEnvCommandTest.php
@@ -131,7 +131,7 @@ EOF;
 
         $command = $this->createCommandDumpEnv();
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Please provide the name of the environment either by using the "--env" command line argument or by defining the "APP_ENV" variable in the ".env.local" file.');
+        $this->expectExceptionMessage('Please provide the name of the environment either by passing it as command line argument or by defining the "APP_ENV" variable in the ".env.local" file.');
 
         try {
             $command->execute([]);


### PR DESCRIPTION
`--env` would be an option, but `env` is an argument.

And the suggested/hinted

```bash
composer dump-env --env=prod
```

doesn't work