### PR TITLE
Package JSON sync alters array formatting

### DIFF
--- a/src/PackageJsonSynchronizer.php
+++ b/src/PackageJsonSynchronizer.php
@@ -76,9 +76,9 @@ class PackageJsonSynchronizer
 
         $devDependencies = $content['devDependencies'];
         uksort($devDependencies, 'strnatcmp');
-        $content['devDependencies'] = $devDependencies;
+        $manipulator->addMainKey('devDependencies', $devDependencies);
 
-        file_put_contents($this->rootDir.'/package.json', $manipulator->format($content, -1));
+        file_put_contents($this->rootDir.'/package.json', $manipulator->getContents());
     }
 
     private function registerWebpackResources(array $phpPackages)

--- a/tests/Fixtures/packageJson/package.json
+++ b/tests/Fixtures/packageJson/package.json
@@ -4,5 +4,8 @@
       "@symfony/stimulus-bridge": "^1.0.0",
       "stimulus": "^1.1.1",
       "@symfony/existing-package": "file:vendor/symfony/existing-package/Resources/assets"
-   }
+   },
+   "browserslist": [
+      "defaults"
+   ]
 }

--- a/tests/PackageJsonSynchronizerTest.php
+++ b/tests/PackageJsonSynchronizerTest.php
@@ -45,6 +45,9 @@ class PackageJsonSynchronizerTest extends TestCase
                     '@symfony/stimulus-bridge' => '^1.0.0',
                     'stimulus' => '^1.1.1',
                 ],
+                'browserslist' => [
+                    'defaults',
+                ],
             ],
             json_decode(file_get_contents($this->tempDir.'/package.json'), true)
         );
@@ -70,6 +73,9 @@ class PackageJsonSynchronizerTest extends TestCase
                     '@symfony/existing-package' => 'file:vendor/symfony/existing-package/Resources/assets',
                     '@symfony/stimulus-bridge' => '^1.0.0',
                     'stimulus' => '^1.1.1',
+                ],
+                'browserslist' => [
+                    'defaults',
                 ],
             ],
             json_decode(file_get_contents($this->tempDir.'/package.json'), true)
@@ -109,9 +115,12 @@ class PackageJsonSynchronizerTest extends TestCase
       "@symfony/new-package": "file:vendor/symfony/new-package/assets",
       "@symfony/stimulus-bridge": "^1.0.0",
       "stimulus": "^1.1.1"
-   }
+   },
+   "browserslist": [
+      "defaults"
+   ]
 }',
-            file_get_contents($this->tempDir.'/package.json')
+            trim(file_get_contents($this->tempDir.'/package.json'))
         );
 
         $this->assertSame(
@@ -140,6 +149,27 @@ class PackageJsonSynchronizerTest extends TestCase
                 'entrypoints' => ['admin.js'],
             ],
             json_decode(file_get_contents($this->tempDir.'/assets/controllers.json'), true)
+        );
+    }
+
+    public function testArrayFormattingHasNotChanged()
+    {
+        $this->synchronizer->synchronize(['symfony/existing-package']);
+
+        // Should keep existing array formatting
+        $this->assertSame(
+            '{
+   "name": "symfony/fixture",
+   "devDependencies": {
+      "@symfony/existing-package": "file:vendor/symfony/existing-package/Resources/assets",
+      "@symfony/stimulus-bridge": "^1.0.0",
+      "stimulus": "^1.1.1"
+   },
+   "browserslist": [
+      "defaults"
+   ]
+}',
+            trim(file_get_contents($this->tempDir.'/package.json'))
         );
     }
 }


### PR DESCRIPTION
Currently, each time `composer install` is run, it changes the formatting of arrays keys in `package.json`:

```diff
{
-   "browserslist": [
-      "defaults"
-   ]
+   "browserslist": ["defaults"]
}
```

This is especially annoying since `npm install` actually reverts it to the previous formatting, so it's a constant "battle" between the two package managers.