### PR TITLE
Fix copy from package with directories

### DIFF
--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -73,6 +73,8 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
 
     private function copyDir(string $source, string $target, array $options)
     {
+        $overwrite = $options['force'] ?? false;
+
         if (!is_dir($target)) {
             mkdir($target, 0777, true);
         }
@@ -85,7 +87,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
                     mkdir($targetPath);
                     $this->write(sprintf('  Created <fg=green>"%s"</>', $this->path->relativize($targetPath)));
                 }
-            } elseif (!file_exists($targetPath)) {
+            } elseif ($overwrite || !file_exists($targetPath)) {
                 $this->copyFile($item, $targetPath, $options);
             }
         }


### PR DESCRIPTION
Potential fix for https://github.com/symfony/flex/issues/755

I've:
1) added a test that uncovers the issue - even when `force` is used the existing files are not overwritten
2) added a test that makes sure the behaviour does not change when force is not used
3) fixed the issue by respecting the `force` option in `copyDir` method.

