### PR TITLE
Fix errors during the upgrade or downgrade of symfony/flex

### DIFF
--- a/src/Command/GenerateIdCommand.php
+++ b/src/Command/GenerateIdCommand.php
@@ -18,6 +18,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class GenerateIdCommand extends Command
 {
+    public function __construct(/* cannot be type-hinted */ $flex = null)
+    {
+        // No-op to support downgrading to v1.12.x
+
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this->setName('symfony:generate-id');

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -59,6 +59,11 @@ class Downloader
         return $this->sess;
     }
 
+    public function setFlexId(string $id = null)
+    {
+        // No-op to support downgrading to v1.12.x
+    }
+
     public function isEnabled()
     {
         return $this->enabled;

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -275,7 +275,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $app->add(new Command\UnpackCommand($resolver));
             $app->add(new Command\RecipesCommand($this, $this->lock, $rfs));
             $app->add(new Command\InstallRecipesCommand($this, $this->options->get('root-dir')));
-            $app->add(new Command\GenerateIdCommand());
+            if (class_exists(Command\GenerateIdCommand::class)) {
+                $app->add(new Command\GenerateIdCommand(null));
+            }
             $app->add(new Command\DumpEnvCommand($this->config, $this->options));
 
             break;


### PR DESCRIPTION
Composer fails during the upgrade of symfony/flex
```
$ composer create-project symfony/skeleton flex && cd flex
$ composer require symfony/flex dev-main -v
./composer.json has been updated
Running composer update symfony/flex
> pre-update-cmd: Symfony\Flex\Flex_composer_tmp0->configureInstaller
Loading composer repositories with package information
> pre-pool-create: Symfony\Flex\Flex_composer_tmp0->truncatePackages
Updating dependencies
Dependency resolution completed in 0.000 seconds
Analyzed 135 packages to resolve dependencies
Analyzed 210 rules to resolve dependencies
Lock file operations: 0 installs, 1 update, 0 removals
Updates: symfony/flex:dev-main 4d7970f
  - Upgrading symfony/flex (v1.12.2 => dev-main 4d7970f)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
Updates: symfony/flex:dev-main 4d7970f
  - Upgrading symfony/flex (v1.12.2 => dev-main 4d7970f): Extracting archive
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Symfony\Flex\Command\GenerateIdCommand::__construct(), 0 passed in phar:///usr/local/bin/composer/src/Composer/Plugin/PluginManager.php(213) : eval()'d code on line 278 and exactly 1 expected in /private/tmp/flex/vendor/symfony/flex/src/Command/GenerateIdCommand.php:22
Stack trace:
#0 phar:///usr/local/bin/composer/src/Composer/Plugin/PluginManager.php(213) : eval()'d code(278): Symfony\Flex\Command\GenerateIdCommand->__construct()
#1 phar:///usr/local/bin/composer/src/Composer/Plugin/PluginManager.php(320): Symfony\Flex\Flex_composer_tmp1->activate(Object(Composer\Composer), Object(Composer\IO\ConsoleIO))
#2 phar:///usr/local/bin/composer/src/Composer/Plugin/PluginManager.php(224): Composer\Plugin\PluginManager->addPlugin(Object(Symfony\Flex\Flex_composer_tmp1), false)
#3 phar:///usr/local/bin/composer/src/Composer/Installer/PluginInstaller.php(100): Composer\Plugin\PluginManager->registerPackage(Object(Composer\Package\CompletePackage), true)
#4 [in in /private/tmp/flex/vendor/symfony/flex/src/Command/GenerateIdCommand.php on line 22
