### PR TITLE
Don't try to update package.json on composer install

### DIFF
--- a/src/Event/UpdateEvent.php
+++ b/src/Event/UpdateEvent.php
@@ -12,6 +12,7 @@
 namespace Symfony\Flex\Event;
 
 use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
 
 class UpdateEvent extends Event
 {
@@ -19,6 +20,7 @@ class UpdateEvent extends Event
 
     public function __construct(bool $force)
     {
+        $this->name = ScriptEvents::POST_UPDATE_CMD;
         $this->force = $force;
     }
 

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -483,7 +483,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $this->io->writeError('');
 
         if (!$recipes) {
-            $this->synchronizePackageJson($rootDir);
+            if (ScriptEvents::POST_UPDATE_CMD === $event->getName()) {
+                $this->synchronizePackageJson($rootDir);
+            }
             $this->lock->write();
 
             if ($this->downloader->isEnabled()) {


### PR DESCRIPTION
composer install should be read-only, so this doesn't make much sense and this spams the console with unneeded messages.