### PR TITLE
Require UX packages to have the "symfony-ux" keyword in their composer.json file

### DIFF
--- a/tests/Fixtures/packageJson/vendor/symfony/existing-package/composer.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/existing-package/composer.json
@@ -1,0 +1,5 @@
+{
+    "keywords": [
+        "symfony-ux"
+    ]
+}

--- a/tests/Fixtures/packageJson/vendor/symfony/new-package/composer.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/new-package/composer.json
@@ -1,0 +1,5 @@
+{
+    "keywords": [
+        "symfony-ux"
+    ]
+}


### PR DESCRIPTION
Fix #762