### PR TITLE
feat: allow to enable Docker support using an env var

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -36,7 +36,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
 
     public function configure(Recipe $recipe, $config, Lock $lock, array $options = [])
     {
-        $installDocker = $this->composer->getPackage()->getExtra()['symfony']['docker'] ?? false;
+        $installDocker = (bool) ($_SERVER['SYMFONY_DOCKER'] ?? $this->composer->getPackage()->getExtra()['symfony']['docker'] ?? false);
         if (!$installDocker) {
             return;
         }

--- a/src/Configurator/DockerfileConfigurator.php
+++ b/src/Configurator/DockerfileConfigurator.php
@@ -23,7 +23,7 @@ class DockerfileConfigurator extends AbstractConfigurator
 {
     public function configure(Recipe $recipe, $config, Lock $lock, array $options = [])
     {
-        $installDocker = $this->composer->getPackage()->getExtra()['symfony']['docker'] ?? false;
+        $installDocker = (bool) ($_SERVER['SYMFONY_DOCKER'] ?? $this->composer->getPackage()->getExtra()['symfony']['docker'] ?? false);
         if (!$installDocker) {
             return;
         }


### PR DESCRIPTION
Currently, it's not possible to execute the Docker-related configurators when running `composer create-project` because of a chicken and egg problem: the `composer.json` file doesn't exist yet, so it's not possible to set `extra.symfony.docker` to `true`. This PR allows to enable the Docker support by setting an environment variable called `SYMFONY_DOCKER`.

Needed by https://github.com/dunglas/symfony-docker/pull/152.