### PR TITLE
do not try to write a cache entry if there is no cache key

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -293,7 +293,7 @@ class Downloader
         }
 
         $response = new Response($data, $lastHeaders);
-        if ($response->getHeader('last-modified')) {
+        if ($response->getHeader('last-modified') && $cacheKey) {
             $this->cache->write($cacheKey, json_encode($response));
         }
 


### PR DESCRIPTION
Writing to the cache with an empty key will fail with "failed to open stream: Is a directory", so do not try to do that.

We noticed this when cloudflare - or the backend service - responded with a "last-modified" header for our CI servers (AWS) but not for our local system. This triggered the condition to become true and it tries to write a cache file without a filename.

I hope this is the correct place to fix it, but from what I see, this code should not try to write a cache with am empty key, correct?

Here is how a `composer install` failed for us (because of this?): 
```
  [ErrorException]                                                                                              
  file_put_contents(/tmp/composer/cache/repo/https---flex.symfony.com/): failed to open stream: Is a directory  
```