### PR TITLE
Preserve position of require-dev when it's empty before running "require"

### DIFF
--- a/src/Command/UnpackCommand.php
+++ b/src/Command/UnpackCommand.php
@@ -86,8 +86,9 @@ class UnpackCommand extends BaseCommand
             return 0;
         }
 
+        $io->writeError('<info>Unpacking Symfony packs</>');
         foreach ($result->getUnpacked() as $pkg) {
-            $io->writeError(sprintf('<info>Unpacked %s dependencies</>', $pkg->getName()));
+            $io->writeError(sprintf('  - Unpacked <info>%s</>', $pkg->getName()));
         }
 
         $unpacker->updateLock($result, $io);


### PR DESCRIPTION
Fixes a minor glitch where "require-dev" currently ends last in `composer.json` after a `composer req`.

This fixes it by keeping the empty entry if it's there before the run.