### PR TITLE
Fix handling of wildcards without slash in update command

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -47,7 +47,7 @@ class PackageResolver
         // second pass to resolve package names
         $packages = [];
         foreach ($explodedArguments as $i => $argument) {
-            if (false === strpos($argument, '/') && !preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument) && !\in_array($argument, ['mirrors', 'nothing'])) {
+            if (false === strpos($argument, '/') && !preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument) && !preg_match('{(?<!\.)\*}', $argument) && !\in_array($argument, ['mirrors', 'nothing'])) {
                 if (null === self::$aliases) {
                     self::$aliases = $this->downloader->get('/aliases.json')->getBody();
                 }

--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -47,7 +47,7 @@ class PackageResolver
         // second pass to resolve package names
         $packages = [];
         foreach ($explodedArguments as $i => $argument) {
-            if (false === strpos($argument, '/') && !preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument) && !preg_match('{(?<!\.)\*}', $argument) && !\in_array($argument, ['mirrors', 'nothing'])) {
+            if (false === strpos($argument, '/') && !preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument) && !preg_match('{(?<=[a-z0-9_/-])\*|\*(?=[a-z0-9_/-])}i', $argument) && !\in_array($argument, ['mirrors', 'nothing'])) {
                 if (null === self::$aliases) {
                     self::$aliases = $this->downloader->get('/aliases.json')->getBody();
                 }


### PR DESCRIPTION
`composer update symfony/* bar*  -v` yields:

```

  [UnexpectedValueException]
  Could not parse version constraint "bar*".

Exception trace:
 () at ./vendor/symfony/flex/src/PackageResolver.php:144
 Symfony\Flex\PackageResolver->throwAlternatives() at ./vendor/symfony/flex/src/PackageResolver.php:64
 Symfony\Flex\PackageResolver->resolve() at ./vendor/symfony/flex/src/Flex.php:245
 Symfony\Flex\Flex->activate() at /var/www/composer/src/Composer/Plugin/PluginManager.php:334
 Composer\Plugin\PluginManager->addPlugin() at /var/www/composer/src/Composer/Plugin/PluginManager.php:229
```

While really within the update context, these are just package names, or pkg version pairs but then with a separator, 

Valid for `update` are `pkg/name`, `pkg*` (wildcard anywhere), `pkg/name:constraint`, `pkg/name=constraint` or `pkg/name constraint` (quoted to make it a single arg despite the space).

For `require` you can use `pkg/name`, `pkg/name:constraint`, `pkg/name=constraint` or `pkg/name` `constraint` (as two args).

Anyway.. the PR solves it.

See https://github.com/composer/composer/commit/dd49db6f0864197b00c92e662f0d1ca8364e076a for a related fix in Composer