### PR TITLE
Automatically create Docker Compose files when needed

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -43,16 +43,20 @@ class DockerComposeConfigurator extends AbstractConfigurator
 
         $rootDir = $this->options->get('root-dir');
         foreach ($this->normalizeConfig($config) as $file => $extra) {
-            if (
-                (null === $dockerComposeFile = $this->findDockerComposeFile($rootDir, $file)) ||
-                $this->isFileMarked($recipe, $dockerComposeFile)
-            ) {
+            $dockerComposeFile = $this->findDockerComposeFile($rootDir, $file);
+            if (null === $dockerComposeFile) {
+                $dockerComposeFileName = preg_replace('/\.yml$/', '.yaml', $file);
+                $dockerComposeFile = $rootDir.'/'.$dockerComposeFileName;
+                file_put_contents($dockerComposeFile, "version: '3'\n");
+                $this->write(sprintf('  Created <fg=green>"%s"</>', $dockerComposeFileName));
+            }
+            if ($this->isFileMarked($recipe, $dockerComposeFile)) {
                 continue;
             }
 
             $this->write(sprintf('Adding Docker Compose definitions to "%s"', $dockerComposeFile));
 
-            $offset = 8;
+            $offset = 2;
             $node = null;
             $endAt = [];
             $lines = [];

--- a/tests/Configurator/DockerComposeConfiguratorTest.php
+++ b/tests/Configurator/DockerComposeConfiguratorTest.php
@@ -528,4 +528,41 @@ YAML
         $this->configurator->unconfigure($this->recipeDb, self::CONFIG_DB, $this->lock);
         $this->assertEquals(self::ORIGINAL_CONTENT, file_get_contents($dockerComposeFile));
     }
+
+    public function testConfigureWithoutExistingDockerComposeFiles()
+    {
+        $dockerComposeFile = FLEX_TEST_DIR.'/docker-compose.yaml';
+        $defaultContent = "version: '3'\n";
+
+        $this->configurator->configure($this->recipeDb, self::CONFIG_DB, $this->lock);
+
+        $this->assertStringEqualsFile($dockerComposeFile, $defaultContent.<<<'YAML'
+
+services:
+###> doctrine/doctrine-bundle ###
+  db:
+    image: mariadb:10.3
+    environment:
+      - MYSQL_DATABASE=symfony
+      # You should definitely change the password in production
+      - MYSQL_PASSWORD=password
+      - MYSQL_RANDOM_ROOT_PASSWORD=true
+      - MYSQL_USER=symfony
+    volumes:
+      - db-data:/var/lib/mysql:rw
+      # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
+      # - ./docker/db/data:/var/lib/mysql:rw
+###< doctrine/doctrine-bundle ###
+
+volumes:
+###> doctrine/doctrine-bundle ###
+  db-data: {}
+###< doctrine/doctrine-bundle ###
+
+YAML
+            );
+
+        $this->configurator->unconfigure($this->recipeDb, self::CONFIG_DB, $this->lock);
+        $this->assertEquals(trim($defaultContent), file_get_contents($dockerComposeFile));
+    }
 }


### PR DESCRIPTION
If you want to use Docker support in Flex, you must configure it explicitly in a project (via `symfony composer config extra.symfony.docker true` for instance). But that's not enough. You must also create the `docker-compose.yaml` file. And if you do not also create the `docker-compose.override.yaml` file, you will end up with half of the configuration.

In this PR, I propose to create those 2 files automatically if they don't exist when a service should be added by a recipe.

That way, using Docker support is "only" a matter of opting-in via `composer.json`.

/cc @dunglas
