### PR TITLE
Fix post install output not displayed when installing a pack

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -982,6 +982,8 @@ EOPHP
         }
 
         $installer->run();
+
+        $this->io->write($this->postInstallOutput);
     }
 
     public static function getSubscribedEvents(): array


### PR DESCRIPTION
When installing a pack, the `executeAutoScripts()` is not ran, so we need to explicitly display the post install output in `reinstall()` as well.
