### PR TITLE
Fixed directory separator trimming in vendors path

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -531,7 +531,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
     private function synchronizePackageJson(string $rootDir)
     {
         $rootDir = realpath($rootDir);
-        $vendorDir = trim((new Filesystem())->makePathRelative($this->config->get('vendor-dir'), $rootDir), \DIRECTORY_SEPARATOR);
+        $vendorDir = trim((new Filesystem())->makePathRelative($this->config->get('vendor-dir'), $rootDir), '/');
 
         $synchronizer = new PackageJsonSynchronizer($rootDir, $vendorDir);
 


### PR DESCRIPTION
Fixes #796 

We don't need to use `\DIRECTORY_SEPARATOR` here, as [**symfony/filesystem**](https://github.com/symfony/filesystem/blob/4.4/Filesystem.php#L451) already normalizes windows directory separator to use forward slash.