### PR TITLE
Replace flex-server by hosting recipe info on GitHub

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.13-dev"
+            "dev-main": "1.16-dev"
         },
         "class": "Symfony\\Flex\\Flex"
     }

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -799,8 +799,7 @@ EOPHP
                 }
             }
 
-            $noRecipe = !isset($manifests[$name]) || (isset($manifests[$name]['not_installable']) && $manifests[$name]['not_installable']);
-            if ($noRecipe) {
+            if (!isset($manifests[$name])) {
                 $bundles = [];
 
                 if (null === $devPackages) {

--- a/tests/PackageResolverTest.php
+++ b/tests/PackageResolverTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Flex\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Downloader;
 use Symfony\Flex\PackageResolver;
 
 class PackageResolverTest extends TestCase
@@ -96,7 +97,7 @@ class PackageResolverTest extends TestCase
 
     private function getResolver()
     {
-        $downloader = $this->getMockBuilder('Symfony\Flex\Downloader')->disableOriginalConstructor()->getMock();
+        $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();
         $downloader->expects($this->any())
             ->method('getVersions')
             ->willReturn([
@@ -108,17 +109,15 @@ class PackageResolverTest extends TestCase
                     'symfony/validator' => ['3.4'],
                 ],
             ]);
+        $downloader->expects($this->any())
+            ->method('getAliases')
+            ->willReturn([
+                'cli' => 'symfony/console',
+                'console' => 'symfony/console',
+                'translation' => 'symfony/translation',
+                'validator' => 'symfony/validator',
+            ]);
 
-        $resolver = new PackageResolver($downloader);
-        $p = new \ReflectionProperty($resolver, 'aliases');
-        $p->setAccessible(true);
-        $p->setValue($resolver, [
-            'cli' => 'symfony/console',
-            'console' => 'symfony/console',
-            'translation' => 'symfony/translation',
-            'validator' => 'symfony/validator',
-        ]);
-
-        return $resolver;
+        return new PackageResolver($downloader);
     }
 }


### PR DESCRIPTION
This PR replaces the `flex.symfony.com` endpoint that flex currently uses by a new endpoint made of static JSONs hosted on GitHub.

Said JSONs are here:
https://github.com/symfony/recipes/tree/flex/main

And are generated by GHA:
https://github.com/symfony/recipes/blob/master/.github/workflows/flex-endpoint.yml

With the help of this tool:
https://github.com/symfony-tools/recipes-checker

The target is to retire `flex.symfony.com` at some point in the future and free us from maintaining and hosting it.

As a nice side effect, this should make it easier for ppl to host their own flex endpoint overlay.

It should also enable contributions for the community to innovate at the Flex API layer.

The default endpoints can be changed by setting the `extra.symfony.endpoint` entry in the root `composer.json` file. The special `flex://defaults` endpoint can be used in that list to reference the default endpoints.

On top of that, the `SYMFONY_ENDPOINT` env var can be defined to a single endpoint. This endpoint will be used on top of (with higher priority than) the default endpoints of the app.