### PR TITLE
Use the extra.runtime.test_envs composer variabels in the symfony:dump-env command

### DIFF
--- a/src/Command/DumpEnvCommand.php
+++ b/src/Command/DumpEnvCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Command;
 
 use Composer\Command\BaseCommand;
 use Composer\Config;
+use Composer\Factory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -112,7 +113,13 @@ EOF;
             }
 
             if (method_exists($dotenv, 'loadEnv')) {
-                $dotenv->loadEnv($path);
+                $config = @json_decode(file_get_contents(Factory::getComposerFile()), true);
+                $dotenv->loadEnv(
+                    $path,
+                    null,
+                    'dev',
+                    $config['extra']['runtime']['test_envs'] ?? ['test']
+                );
             } else {
                 // fallback code in case your Dotenv component is not 4.2 or higher (when loadEnv() was added)
                 $dotenv->load(file_exists($path) || !file_exists($p = "$path.dist") ? $path : $p);

--- a/tests/Command/DumpEnvCommandTest.php
+++ b/tests/Command/DumpEnvCommandTest.php
@@ -164,6 +164,46 @@ EOF;
         unlink($envLocalPhp);
     }
 
+    public function testLoadLocalEnvWhenTestEnvIsNotEqual()
+    {
+        @mkdir(FLEX_TEST_DIR);
+        $env = FLEX_TEST_DIR.'/.env';
+        $envLocal = FLEX_TEST_DIR.'/.env.local';
+        $envLocalPhp = FLEX_TEST_DIR.'/.env.local.php';
+        $composer = __DIR__.'/../../composer.json';
+        @unlink($envLocalPhp);
+
+        file_put_contents($env, 'APP_ENV=dev');
+        $envContent = <<<EOF
+APP_ENV=test
+APP_SECRET=abcdefgh123456789
+EOF;
+        file_put_contents($envLocal, $envContent);
+
+        copy($composer, FLEX_TEST_DIR.'/composer-backup.json');
+        $composerContent = @json_decode(file_get_contents($composer), true);
+        $composerContent['extra']['runtime']['test_envs'] = [];
+        file_put_contents($composer, json_encode($composerContent));
+
+        $command = $this->createCommandDumpEnv();
+        $command->execute([
+            'env' => 'test',
+        ]);
+
+        $this->assertFileExists($envLocalPhp);
+
+        $vars = require $envLocalPhp;
+        $this->assertSame([
+            'APP_ENV' => 'test',
+            'APP_SECRET' => 'abcdefgh123456789',
+        ], $vars);
+
+        unlink($env);
+        unlink($envLocal);
+        unlink($envLocalPhp);
+        copy(FLEX_TEST_DIR.'/composer-backup.json', $composer);
+    }
+
     private function createCommandDumpEnv()
     {
         $command = new DumpEnvCommand(


### PR DESCRIPTION
Added the option to read the `extra.runtime.test_envs` to load the test envs during the environment dump.