### PR TITLE
Do not mark auto recipes as "update as available" (if private repository doesn't contain the recipe)

### DIFF
--- a/src/Command/RecipesCommand.php
+++ b/src/Command/RecipesCommand.php
@@ -109,7 +109,7 @@ class RecipesCommand extends BaseCommand
             $additional = null;
             if (null === $lockRef && null !== $recipe->getRef()) {
                 $additional = '<comment>(recipe not installed)</comment>';
-            } elseif ($recipe->getRef() !== $lockRef) {
+            } elseif ($recipe->getRef() !== $lockRef && !$recipe->isAuto()) {
                 $additional = '<comment>(update available)</comment>';
             }
 


### PR DESCRIPTION
This fixes a little edge-case while testing out the new flex endpoint feature.

How to reproduce the bug:

1. You don't use `flex://default` (so only allow internally maintained recipes)
2. You previously used Symfony's recipes to set-up the project
3. Now, the locked recipe ref for e.g. FrameworkBundle no longer matches the ref from the auto-generated recipe for bundles
4. This means you'll get "(update available)" when running `composer recipes`

If you install a new bundle, there is no locked ref and you'll get the "(recipe not installed)" message for auto-generated recipes, as expected.