### PR TITLE
feat: enable Docker support by default

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -36,7 +36,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
 
     public function configure(Recipe $recipe, $config, Lock $lock, array $options = [])
     {
-        $installDocker = $this->composer->getPackage()->getExtra()['symfony']['docker'] ?? false;
+        $installDocker = $this->composer->getPackage()->getExtra()['symfony']['docker'] ?? true;
         if (!$installDocker) {
             return;
         }

--- a/src/Configurator/DockerfileConfigurator.php
+++ b/src/Configurator/DockerfileConfigurator.php
@@ -23,7 +23,7 @@ class DockerfileConfigurator extends AbstractConfigurator
 {
     public function configure(Recipe $recipe, $config, Lock $lock, array $options = [])
     {
-        $installDocker = $this->composer->getPackage()->getExtra()['symfony']['docker'] ?? false;
+        $installDocker = $this->composer->getPackage()->getExtra()['symfony']['docker'] ?? true;
         if (!$installDocker) {
             return;
         }


### PR DESCRIPTION
Docker and Docker Compose configurators now have been extensively tested, and there are many recipes with Docker support available. I think that it's time to enable this feature by default.

Note: the configurations are executed only if the `Dockerfile` and the `docker-compose.*` files are present in the project.