### PR TITLE
fix: use .yml instead of .yaml for Docker Compose files

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -45,10 +45,9 @@ class DockerComposeConfigurator extends AbstractConfigurator
         foreach ($this->normalizeConfig($config) as $file => $extra) {
             $dockerComposeFile = $this->findDockerComposeFile($rootDir, $file);
             if (null === $dockerComposeFile) {
-                $dockerComposeFileName = preg_replace('/\.yml$/', '.yaml', $file);
-                $dockerComposeFile = $rootDir.'/'.$dockerComposeFileName;
+                $dockerComposeFile = $rootDir.'/'.$file;
                 file_put_contents($dockerComposeFile, "version: '3'\n");
-                $this->write(sprintf('  Created <fg=green>"%s"</>', $dockerComposeFileName));
+                $this->write(sprintf('  Created <fg=green>"%s"</>', $file));
             }
             if ($this->isFileMarked($recipe, $dockerComposeFile)) {
                 continue;
@@ -168,7 +167,6 @@ class DockerComposeConfigurator extends AbstractConfigurator
 
         // COMPOSE_FILE not set, or doesn't contain the file we're looking for
         $dir = $rootDir;
-        $previousDir = null;
         do {
             // Test with the ".yaml" extension if the file doesn't end up with ".yml".
             if (

--- a/tests/Configurator/DockerComposeConfiguratorTest.php
+++ b/tests/Configurator/DockerComposeConfiguratorTest.php
@@ -531,7 +531,7 @@ YAML
 
     public function testConfigureWithoutExistingDockerComposeFiles()
     {
-        $dockerComposeFile = FLEX_TEST_DIR.'/docker-compose.yaml';
+        $dockerComposeFile = FLEX_TEST_DIR.'/docker-compose.yml';
         $defaultContent = "version: '3'\n";
 
         $this->configurator->configure($this->recipeDb, self::CONFIG_DB, $this->lock);


### PR DESCRIPTION
Docker best practices are to use the `yml` extension for these files: https://docs.docker.com/compose/compose-file/compose-file-v3/#service-configuration-reference. While official Docker tools support both extensions, some tools  and scripts only support `.yml`. Also, the `.yml` version is more common and used everywhere in Docker's docs.