### PR TITLE
Refactor PackageJsonSynchronizer to prevent unintentional duplicate dependencies

### DIFF
--- a/tests/Fixtures/packageJson/elevated_dependencies_package.json
+++ b/tests/Fixtures/packageJson/elevated_dependencies_package.json
@@ -1,0 +1,15 @@
+{
+   "name": "symfony/fixture",
+   "dependencies": {
+      "@hotcookies": "^1.1|^2",
+      "@hotdogs": "^2",
+      "@symfony/existing-package": "file:vendor/symfony/existing-package/Resources/assets"
+   },
+   "devDependencies": {
+      "@symfony/stimulus-bridge": "^1.0.0",
+      "stimulus": "^1.1.1"
+   },
+   "browserslist": [
+      "defaults"
+   ]
+}


### PR DESCRIPTION
Fixes https://github.com/symfony/flex/issues/840

Changes how `PackageJsonSynchronizer` handles dependency resolving. If a dependency is already defined under the `dependencies` section of package.json, Flex won't add it again under `devDependencies`. If multiple UX bundles require the same dependency, no action is performed.

Because the way `PackageJsonSynchronizer` was written, I had to change the order of the steps in the synchronization process. While it used to update the package.json for each UX dependency individually, it now resolves a list of dependencies and updates package.json at the end.

I also changed how it handles incompatible peer dependencies, no action is performed by the synchronizer if multiple ux package require incompatible peer dependencies.