### PR TITLE
Pass GitHub access token when accessing raw.githubusercontent.com in case of private recipes

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -276,6 +276,11 @@ class Downloader
 
             if (preg_match('{^https?://api\.github\.com/}', $url)) {
                 $headers[] = 'Accept: application/vnd.github.v3.raw';
+            } elseif (preg_match('{^https?://raw\.githubusercontent\.com/}', $url) && $this->io->hasAuthentication('github.com')) {
+                $auth = $this->io->getAuthentication('github.com');
+                if ('x-oauth-basic' === $auth['password']) {
+                    $headers[] = 'Authorization: token '.$auth['username'];
+                }
             } elseif ($this->legacyEndpoint) {
                 $headers[] = 'Package-Session: '.$this->sess;
             }


### PR DESCRIPTION
I'm checking how to use private symfony recipes and found that `symfony/flex` is not using GH access token when accessing `raw.githubcontent.com`.

For a public repositories it's not a case, but for private repositories it's not possible to access the recipe template url from `raw.githubcontent.com` without using access token.

Adding access token for requests to `api.github.com` is [covered by Composer](https://github.com/composer/composer/blob/f5ffedfe60b5b0043c368b91e656288517aad0d9/src/Composer/Util/AuthHelper.php#L210-L215), but it doesn't cover downloading files from `raw.githubcontent.com`.

This PR introduces logic for adding token for requests to `raw.githubcontent.com` in the [similar way as composer does](https://github.com/composer/composer/blob/f5ffedfe60b5b0043c368b91e656288517aad0d9/src/Composer/Util/AuthHelper.php#L210-L215) for `api.github.com`.

Limitations:
* Current implementation adds the token (if it presents) to ALL requests to the `raw.githubusercontent.com`, but I don't think that it's a big issue actually.