### PR TITLE
Merge-powered recipe update system

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,7 +2,7 @@
 
 $finder = PhpCsFixer\Finder::create()->in(__DIR__);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setFinder($finder)
     ->setRules(array(
         '@Symfony' => true,

--- a/src/Command/InstallRecipesCommand.php
+++ b/src/Command/InstallRecipesCommand.php
@@ -13,17 +13,17 @@ namespace Symfony\Flex\Command;
 
 use Composer\Command\BaseCommand;
 use Composer\DependencyResolver\Operation\InstallOperation;
-use Composer\Factory;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Flex\Event\UpdateEvent;
-use Symfony\Flex\Lock;
+use Symfony\Flex\Flex;
 
 class InstallRecipesCommand extends BaseCommand
 {
+    /** @var Flex */
     private $flex;
     private $rootDir;
 
@@ -55,7 +55,7 @@ class InstallRecipesCommand extends BaseCommand
             throw new RuntimeException('Cannot run "sync-recipes --force": git not found.');
         }
 
-        $symfonyLock = new Lock(getenv('SYMFONY_LOCKFILE') ?: str_replace('composer.json', 'symfony.lock', Factory::getComposerFile()));
+        $symfonyLock = $this->flex->getLock();
         $composer = $this->getComposer();
         $locker = $composer->getLocker();
         $lockData = $locker->getLockData();

--- a/src/Command/RecipesCommand.php
+++ b/src/Command/RecipesCommand.php
@@ -13,11 +13,11 @@ namespace Symfony\Flex\Command;
 
 use Composer\Command\BaseCommand;
 use Composer\Downloader\TransportException;
-use Composer\Util\HttpDownloader;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Flex\GithubApi;
 use Symfony\Flex\InformationOperation;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
@@ -31,13 +31,13 @@ class RecipesCommand extends BaseCommand
     private $flex;
 
     private $symfonyLock;
-    private $downloader;
+    private $githubApi;
 
     public function __construct(/* cannot be type-hinted */ $flex, Lock $symfonyLock, $downloader)
     {
         $this->flex = $flex;
         $this->symfonyLock = $symfonyLock;
-        $this->downloader = $downloader;
+        $this->githubApi = new GithubApi($downloader);
 
         parent::__construct();
     }
@@ -136,7 +136,7 @@ class RecipesCommand extends BaseCommand
             '',
             'Run:',
             ' * <info>composer recipes vendor/package</info> to see details about a recipe.',
-            ' * <info>composer recipes:install vendor/package --force -v</info> to update that recipe.',
+            ' * <info>composer recipes:update vendor/package</info> to update that recipe.',
             '',
         ]));
 
@@ -171,13 +171,15 @@ class RecipesCommand extends BaseCommand
         $commitDate = null;
         if (null !== $lockRef && null !== $lockRepo) {
             try {
-                list($gitSha, $commitDate) = $this->findRecipeCommitDataFromTreeRef(
+                $recipeCommitData = $this->githubApi->findRecipeCommitDataFromTreeRef(
                     $recipe->getName(),
                     $lockRepo,
                     $lockBranch ?? '',
                     $lockVersion,
                     $lockRef
                 );
+                $gitSha = $recipeCommitData ? $recipeCommitData['commit'] : null;
+                $commitDate = $recipeCommitData ? $recipeCommitData['date'] : null;
             } catch (TransportException $exception) {
                 $io->writeError('Error downloading exact git sha for installed recipe.');
             }
@@ -232,7 +234,7 @@ class RecipesCommand extends BaseCommand
             $io->write([
                 '',
                 'Update this recipe by running:',
-                sprintf('<info>composer recipes:install %s --force -v</info>', $recipe->getName()),
+                sprintf('<info>composer recipes:update %s</info>', $recipe->getName()),
             ]);
         }
     }
@@ -323,64 +325,5 @@ class RecipesCommand extends BaseCommand
         }
 
         $io->write($line);
-    }
-
-    /**
-     * Attempts to find the original git sha when the recipe was installed.
-     */
-    private function findRecipeCommitDataFromTreeRef(string $package, string $repo, string $branch, string $version, string $lockRef)
-    {
-        // only supports public repository placement
-        if (0 !== strpos($repo, 'github.com')) {
-            return [null, null];
-        }
-
-        $parts = explode('/', $repo);
-        if (3 !== \count($parts)) {
-            return [null, null];
-        }
-
-        $recipePath = sprintf('%s/%s', $package, $version);
-        $commitsData = $this->requestGitHubApi(sprintf(
-            'https://api.github.com/repos/%s/%s/commits?path=%s&sha=%s',
-            $parts[1],
-            $parts[2],
-            $recipePath,
-            $branch
-        ));
-
-        foreach ($commitsData as $commitData) {
-            // go back the commits one-by-one
-            $treeUrl = $commitData['commit']['tree']['url'].'?recursive=true';
-
-            // fetch the full tree, then look for the tree for the package path
-            $treeData = $this->requestGitHubApi($treeUrl);
-            foreach ($treeData['tree'] as $treeItem) {
-                if ($treeItem['path'] !== $recipePath) {
-                    continue;
-                }
-
-                if ($treeItem['sha'] === $lockRef) {
-                    // shorten for brevity
-                    return [
-                        substr($commitData['sha'], 0, 7),
-                        $commitData['commit']['committer']['date'],
-                    ];
-                }
-            }
-        }
-
-        return [null, null];
-    }
-
-    private function requestGitHubApi(string $path)
-    {
-        if ($this->downloader instanceof HttpDownloader) {
-            $contents = $this->downloader->get($path)->getBody();
-        } else {
-            $contents = $this->downloader->getContents('api.github.com', $path, false);
-        }
-
-        return json_decode($contents, true);
     }
 }

--- a/src/Command/UpdateRecipesCommand.php
+++ b/src/Command/UpdateRecipesCommand.php
@@ -1,0 +1,423 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Command;
+
+use Composer\Command\BaseCommand;
+use Composer\IO\IOInterface;
+use Composer\Util\ProcessExecutor;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Flex\Configurator;
+use Symfony\Flex\Downloader;
+use Symfony\Flex\Flex;
+use Symfony\Flex\GithubApi;
+use Symfony\Flex\InformationOperation;
+use Symfony\Flex\Lock;
+use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipePatcher;
+use Symfony\Flex\Update\RecipeUpdate;
+
+class UpdateRecipesCommand extends BaseCommand
+{
+    /** @var Flex */
+    private $flex;
+    private $downloader;
+    private $configurator;
+    private $rootDir;
+    private $githubApi;
+    private $processExecutor;
+
+    public function __construct(/* cannot be type-hinted */ $flex, Downloader $downloader, $httpDownloader, Configurator $configurator, string $rootDir)
+    {
+        $this->flex = $flex;
+        $this->downloader = $downloader;
+        $this->configurator = $configurator;
+        $this->rootDir = $rootDir;
+        $this->githubApi = new GithubApi($httpDownloader);
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('symfony:recipes:update')
+            ->setAliases(['recipes:update'])
+            ->setDescription('Updates an already-installed recipe to the latest version.')
+            ->addArgument('package', InputArgument::OPTIONAL, 'Recipe that should be updated.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $win = '\\' === \DIRECTORY_SEPARATOR;
+        $runtimeExceptionClass = class_exists(RuntimeException::class) ? RuntimeException::class : \RuntimeException::class;
+        if (!@is_executable(strtok(exec($win ? 'where git' : 'command -v git'), \PHP_EOL))) {
+            throw new $runtimeExceptionClass('Cannot run "recipes:update": git not found.');
+        }
+
+        $io = $this->getIO();
+        if (!$this->isIndexClean($io)) {
+            $io->write([
+                '  Cannot run <comment>recipes:update</comment>: Your git index contains uncommitted changes.',
+                '  Please commit or stash them and try again!',
+            ]);
+
+            return 1;
+        }
+
+        $packageName = $input->getArgument('package');
+        $symfonyLock = $this->flex->getLock();
+        if (!$packageName) {
+            $packageName = $this->askForPackage($io, $symfonyLock);
+
+            if (null === $packageName) {
+                $io->writeError('All packages appear to be up-to-date!');
+
+                return 0;
+            }
+        }
+
+        if (!$symfonyLock->has($packageName)) {
+            $io->writeError([
+                'Package not found inside symfony.lock. It looks like it\'s not installed?',
+                sprintf('Try running <info>composer recipes:install %s --force -v</info> to re-install the recipe.', $packageName),
+            ]);
+
+            return 1;
+        }
+
+        $packageLockData = $symfonyLock->get($packageName);
+        if (!isset($packageLockData['recipe'])) {
+            $io->writeError([
+                'It doesn\'t look like this package had a recipe when it was originally installed.',
+                'To install the latest version of the recipe, if there is one, run:',
+                sprintf('  <info>composer recipes:install %s --force -v</info>', $packageName),
+            ]);
+
+            return 1;
+        }
+
+        $recipeRef = $packageLockData['recipe']['ref'] ?? null;
+        $recipeVersion = $packageLockData['recipe']['version'] ?? null;
+        if (!$recipeRef || !$recipeVersion) {
+            $io->writeError([
+                'The version of the installed recipe was not saved into symfony.lock.',
+                'This is possible if it was installed by an old version of Symfony Flex.',
+                'Update the recipe by re-installing the latest version with:',
+                sprintf('  <info>composer recipes:install %s --force -v</info>', $packageName),
+            ]);
+
+            return 1;
+        }
+
+        $originalRecipe = $this->getRecipe($packageName, $recipeRef, $recipeVersion);
+
+        if (null === $originalRecipe) {
+            $io->writeError([
+                'The original recipe version you have installed could not be found, it may be too old.',
+                'Update the recipe by re-installing the latest version with:',
+                sprintf('  <info>composer recipes:install %s --force -v</info>', $packageName),
+            ]);
+
+            return 1;
+        }
+
+        $newRecipe = $this->getRecipe($packageName);
+
+        if ($newRecipe->getRef() === $originalRecipe->getRef()) {
+            $io->write(sprintf('This recipe for <info>%s</info> is already at the latest version.', $packageName));
+
+            return 0;
+        }
+
+        $io->write([
+            sprintf('  Updating recipe for <info>%s</info>...', $packageName),
+            '',
+        ]);
+
+        $recipeUpdate = new RecipeUpdate($originalRecipe, $newRecipe, $symfonyLock, $this->rootDir);
+        $this->configurator->populateUpdate($recipeUpdate);
+        $originalComposerJsonHash = $this->flex->getComposerJsonHash();
+        $patcher = new RecipePatcher($this->rootDir, $io);
+
+        try {
+            $patch = $patcher->generatePatch($recipeUpdate->getOriginalFiles(), $recipeUpdate->getNewFiles());
+            $hasConflicts = !$patcher->applyPatch($patch);
+        } catch (\Throwable $throwable) {
+            $io->writeError([
+                '<bg=red;fg=white>There was an error applying the recipe update patch</>',
+                $throwable->getMessage(),
+                '',
+                'Update the recipe by re-installing the latest version with:',
+                sprintf('  <info>composer recipes:install %s --force -v</info>', $packageName),
+            ]);
+
+            return 1;
+        }
+
+        $symfonyLock->add($packageName, $newRecipe->getLock());
+        $this->flex->finish($this->rootDir, $originalComposerJsonHash);
+
+        // stage symfony.lock, as all patched files with already be staged
+        $cmdOutput = '';
+        $this->getProcessExecutor()->execute('git add symfony.lock', $cmdOutput, $this->rootDir);
+
+        $io->write([
+            '  <bg=blue;fg=white>                      </>',
+            '  <bg=blue;fg=white> Yes! Recipe updated! </>',
+            '  <bg=blue;fg=white>                      </>',
+            '',
+        ]);
+
+        if ($hasConflicts) {
+            $io->write([
+                '  The recipe was updated but with <bg=red;fg=white>one or more conflicts</>.',
+                '  Run <comment>git status</comment> to see them.',
+                '  After resolving, commit your changes like normal.',
+            ]);
+        } else {
+            if (!$patch->getPatch()) {
+                // no changes were required
+                $io->write([
+                    '  No files were changed as a result of the update.',
+                ]);
+            } else {
+                $io->write([
+                    '  Run <comment>git status</comment> or <comment>git diff --cached</comment> to see the changes.',
+                    '  When you\'re ready, commit these changes like normal.',
+                ]);
+            }
+        }
+
+        if (0 !== \count($recipeUpdate->getCopyFromPackagePaths())) {
+            $io->write([
+                '',
+                '  <bg=red;fg=white>NOTE:</>',
+                '  This recipe copies the following paths from the bundle into your app:',
+            ]);
+            foreach ($recipeUpdate->getCopyFromPackagePaths() as $source => $target) {
+                $io->write(sprintf('  * %s => %s', $source, $target));
+            }
+            $io->write([
+                '',
+                '  The recipe updater has no way of knowing if these files have changed since you originally installed the recipe.',
+                '  And so, no updates were made to these paths.',
+            ]);
+        }
+
+        if (0 !== \count($patch->getRemovedPatches())) {
+            if (1 === \count($patch->getRemovedPatches())) {
+                $notes = [
+                    sprintf('  The file <comment>%s</comment> was not updated because it doesn\'t exist in your app.', array_keys($patch->getRemovedPatches())[0]),
+                ];
+            } else {
+                $notes = ['  The following files were not updated because they don\'t exist in your app:'];
+                foreach ($patch->getRemovedPatches() as $filename => $contents) {
+                    $notes[] = sprintf('    * <comment>%s</comment>', $filename);
+                }
+            }
+            $io->write([
+                '',
+                '  <bg=red;fg=white>NOTE:</>',
+            ]);
+            $io->write($notes);
+            $io->write('');
+            if ($io->askConfirmation('  Would you like to save the "diff" to a file so you can review it? (Y/n) ')) {
+                $patchFilename = str_replace('/', '.', $packageName).'.updates-for-deleted-files.patch';
+                file_put_contents($this->rootDir.'/'.$patchFilename, implode("\n", $patch->getRemovedPatches()));
+                $io->write([
+                    '',
+                    sprintf('  Saved diff to <info>%s</info>', $patchFilename),
+                ]);
+            }
+        }
+
+        if ($patch->getPatch()) {
+            $io->write('');
+            $io->write('  Calculating CHANGELOG...', false);
+            $changelog = $this->generateChangelog($originalRecipe);
+            $io->write("\r", false); // clear current line
+            if ($changelog) {
+                $io->write($changelog);
+            } else {
+                $io->write('No CHANGELOG could be calculated.');
+            }
+        }
+
+        return 0;
+    }
+
+    private function getRecipe(string $packageName, string $recipeRef = null, string $recipeVersion = null): ?Recipe
+    {
+        $installedRepo = $this->getComposer()->getRepositoryManager()->getLocalRepository();
+        $package = $installedRepo->findPackage($packageName, '*');
+        if (null === $package) {
+            throw new RuntimeException(sprintf('Could not find package "%s". Try running "composer install".', $packageName));
+        }
+        $operation = new InformationOperation($package);
+        if (null !== $recipeRef) {
+            $operation->setSpecificRecipeVersion($recipeRef, $recipeVersion);
+        }
+        $recipes = $this->downloader->getRecipes([$operation]);
+
+        if (0 === \count($recipes['manifests'] ?? [])) {
+            return null;
+        }
+
+        return new Recipe(
+            $package,
+            $packageName,
+            $operation->getOperationType(),
+            $recipes['manifests'][$packageName],
+            $recipes['locks'][$packageName] ?? []
+        );
+    }
+
+    private function generateChangelog(Recipe $originalRecipe): ?array
+    {
+        $recipeData = $originalRecipe->getLock()['recipe'] ?? null;
+        if (null === $recipeData) {
+            return null;
+        }
+
+        if (!isset($recipeData['ref']) || !isset($recipeData['repo']) || !isset($recipeData['branch']) || !isset($recipeData['version'])) {
+            return null;
+        }
+
+        $currentRecipeVersionData = $this->githubApi->findRecipeCommitDataFromTreeRef(
+            $originalRecipe->getName(),
+            $recipeData['repo'],
+            $recipeData['branch'],
+            $recipeData['version'],
+            $recipeData['ref']
+        );
+
+        if (!$currentRecipeVersionData) {
+            return null;
+        }
+
+        $recipeVersions = $this->githubApi->getVersionsOfRecipe(
+            $recipeData['repo'],
+            $recipeData['branch'],
+            $originalRecipe->getName()
+        );
+        if (!$recipeVersions) {
+            return null;
+        }
+
+        $newerRecipeVersions = array_filter($recipeVersions, function ($version) use ($recipeData) {
+            return version_compare($version, $recipeData['version'], '>');
+        });
+
+        $newCommits = $currentRecipeVersionData['new_commits'];
+        foreach ($newerRecipeVersions as $newerRecipeVersion) {
+            $newCommits = array_merge(
+                $newCommits,
+                $this->githubApi->getCommitDataForPath($recipeData['repo'], $originalRecipe->getName().'/'.$newerRecipeVersion, $recipeData['branch'])
+            );
+        }
+
+        $newCommits = array_unique($newCommits);
+        asort($newCommits);
+
+        $pullRequests = [];
+        foreach ($newCommits as $commit => $date) {
+            $pr = $this->githubApi->getPullRequestForCommit($commit, $recipeData['repo']);
+            if ($pr) {
+                $pullRequests[$pr['number']] = $pr;
+            }
+        }
+
+        $lines = [];
+        // borrowed from symfony/console's OutputFormatterStyle
+        $handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR')
+                        && (!getenv('KONSOLE_VERSION') || (int) getenv('KONSOLE_VERSION') > 201100);
+        foreach ($pullRequests as $number => $data) {
+            $url = $data['url'];
+            if ($handlesHrefGracefully) {
+                $url = "\033]8;;$url\033\\$number\033]8;;\033\\";
+            }
+            $lines[] = sprintf('  * %s (PR %s)', $data['title'], $url);
+        }
+
+        return $lines;
+    }
+
+    private function askForPackage(IOInterface $io, Lock $symfonyLock): ?string
+    {
+        $installedRepo = $this->getComposer()->getRepositoryManager()->getLocalRepository();
+        $locker = $this->getComposer()->getLocker();
+        $lockData = $locker->getLockData();
+
+        // Merge all packages installed
+        $packages = array_merge($lockData['packages'], $lockData['packages-dev']);
+
+        $operations = [];
+        foreach ($packages as $value) {
+            if (null === $pkg = $installedRepo->findPackage($value['name'], '*')) {
+                continue;
+            }
+
+            $operations[] = new InformationOperation($pkg);
+        }
+
+        $recipes = $this->flex->fetchRecipes($operations, false);
+        ksort($recipes);
+
+        $outdatedRecipes = [];
+        foreach ($recipes as $name => $recipe) {
+            $lockRef = $symfonyLock->get($name)['recipe']['ref'] ?? null;
+
+            if (null !== $lockRef && $recipe->getRef() !== $lockRef && !$recipe->isAuto()) {
+                $outdatedRecipes[] = $name;
+            }
+        }
+
+        if (0 === \count($outdatedRecipes)) {
+            return null;
+        }
+
+        $question = 'Which outdated recipe would you like to update? (default: <info>0</info>)';
+
+        $choice = $io->select(
+            $question,
+            $outdatedRecipes,
+            0
+        );
+
+        return $outdatedRecipes[$choice];
+    }
+
+    private function isIndexClean(IOInterface $io): bool
+    {
+        $output = '';
+
+        $this->getProcessExecutor()->execute('git status --porcelain --untracked-files=no', $output, $this->rootDir);
+        if ('' !== trim($output)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function getProcessExecutor(): ProcessExecutor
+    {
+        if (null === $this->processExecutor) {
+            $this->processExecutor = new ProcessExecutor($this->getIO());
+        }
+
+        return $this->processExecutor;
+    }
+}

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -14,6 +14,7 @@ namespace Symfony\Flex;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Symfony\Flex\Configurator\AbstractConfigurator;
+use Symfony\Flex\Update\RecipeUpdate;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -53,6 +54,19 @@ class Configurator
             if (isset($manifest[$key])) {
                 $this->get($key)->configure($recipe, $manifest[$key], $lock, $options);
             }
+        }
+    }
+
+    public function populateUpdate(RecipeUpdate $recipeUpdate): void
+    {
+        $originalManifest = $recipeUpdate->getOriginalRecipe()->getManifest();
+        $newManifest = $recipeUpdate->getNewRecipe()->getManifest();
+        foreach (array_keys($this->configurators) as $key) {
+            if (!isset($originalManifest[$key]) && !isset($newManifest[$key])) {
+                continue;
+            }
+
+            $this->get($key)->update($recipeUpdate, $originalManifest[$key] ?? [], $newManifest[$key] ?? []);
         }
     }
 

--- a/src/Configurator/AbstractConfigurator.php
+++ b/src/Configurator/AbstractConfigurator.php
@@ -17,6 +17,7 @@ use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Path;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -39,6 +40,8 @@ abstract class AbstractConfigurator
     abstract public function configure(Recipe $recipe, $config, Lock $lock, array $options = []);
 
     abstract public function unconfigure(Recipe $recipe, $config, Lock $lock);
+
+    abstract public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void;
 
     protected function write($messages)
     {
@@ -80,19 +83,49 @@ abstract class AbstractConfigurator
             return false;
         }
 
-        $pieces = explode("\n", trim($data));
-        $startMark = trim(reset($pieces));
-        $endMark = trim(end($pieces));
         $contents = file_get_contents($file);
 
-        if (false === strpos($contents, $startMark) || false === strpos($contents, $endMark)) {
+        $newContents = $this->updateDataString($contents, $data);
+        if (null === $newContents) {
             return false;
         }
 
-        $pattern = '/'.preg_quote($startMark, '/').'.*?'.preg_quote($endMark, '/').'/s';
-        $newContents = preg_replace($pattern, trim($data), $contents);
         file_put_contents($file, $newContents);
 
         return true;
+    }
+
+    /**
+     * @return string|null returns the updated content if the section was found, null if not found
+     */
+    protected function updateDataString(string $contents, string $data): ?string
+    {
+        $pieces = explode("\n", trim($data));
+        $startMark = trim(reset($pieces));
+        $endMark = trim(end($pieces));
+
+        if (false === strpos($contents, $startMark) || false === strpos($contents, $endMark)) {
+            return null;
+        }
+
+        $pattern = '/'.preg_quote($startMark, '/').'.*?'.preg_quote($endMark, '/').'/s';
+
+        return preg_replace($pattern, trim($data), $contents);
+    }
+
+    protected function extractSection(Recipe $recipe, string $contents): ?string
+    {
+        $section = $this->markData($recipe, '----');
+
+        $pieces = explode("\n", trim($section));
+        $startMark = trim(reset($pieces));
+        $endMark = trim(end($pieces));
+
+        $pattern = '/'.preg_quote($startMark, '/').'.*?'.preg_quote($endMark, '/').'/s';
+
+        $matches = [];
+        preg_match($pattern, $contents, $matches);
+
+        return $matches[0] ?? null;
     }
 }

--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Configurator;
 
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -22,21 +23,8 @@ class BundlesConfigurator extends AbstractConfigurator
     public function configure(Recipe $recipe, $bundles, Lock $lock, array $options = [])
     {
         $this->write('Enabling the package as a Symfony bundle');
-        $file = $this->getConfFile();
-        $registered = $this->load($file);
-        $classes = $this->parse($bundles, $registered);
-        if (isset($classes[$fwb = 'Symfony\Bundle\FrameworkBundle\FrameworkBundle'])) {
-            foreach ($classes[$fwb] as $env) {
-                $registered[$fwb][$env] = true;
-            }
-            unset($classes[$fwb]);
-        }
-        foreach ($classes as $class => $envs) {
-            foreach ($envs as $env) {
-                $registered[$class][$env] = true;
-            }
-        }
-        $this->dump($file, $registered);
+        $registered = $this->configureBundles($bundles);
+        $this->dump($this->getConfFile(), $registered);
     }
 
     public function unconfigure(Recipe $recipe, $bundles, Lock $lock)
@@ -48,19 +36,55 @@ class BundlesConfigurator extends AbstractConfigurator
         }
 
         $registered = $this->load($file);
-        foreach (array_keys($this->parse($bundles, [])) as $class) {
+        foreach (array_keys($this->prepareBundles($bundles)) as $class) {
             unset($registered[$class]);
         }
         $this->dump($file, $registered);
     }
 
-    private function parse(array $manifest, array $registered): array
+    public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
     {
-        $bundles = [];
-        foreach ($manifest as $class => $envs) {
-            if (!isset($registered[$class])) {
-                $bundles[ltrim($class, '\\')] = $envs;
+        $originalBundles = $this->configureBundles($originalConfig);
+        $recipeUpdate->setOriginalFile(
+            $this->getLocalConfFile(),
+            $this->buildContents($originalBundles)
+        );
+
+        $newBundles = $this->configureBundles($newConfig);
+        $recipeUpdate->setNewFile(
+            $this->getLocalConfFile(),
+            $this->buildContents($newBundles)
+        );
+    }
+
+    private function configureBundles(array $bundles): array
+    {
+        $file = $this->getConfFile();
+        $registered = $this->load($file);
+        $classes = $this->prepareBundles($bundles);
+        if (isset($classes[$fwb = 'Symfony\Bundle\FrameworkBundle\FrameworkBundle'])) {
+            foreach ($classes[$fwb] as $env) {
+                $registered[$fwb][$env] = true;
             }
+            unset($classes[$fwb]);
+        }
+        foreach ($classes as $class => $envs) {
+            // if the class already existed, clear so we can update the envs
+            if (isset($registered[$class])) {
+                $registered[$class] = [];
+            }
+            foreach ($envs as $env) {
+                $registered[$class][$env] = true;
+            }
+        }
+
+        return $registered;
+    }
+
+    private function prepareBundles(array $bundles): array
+    {
+        foreach ($bundles as $class => $envs) {
+            $bundles[ltrim($class, '\\')] = $envs;
         }
 
         return $bundles;
@@ -78,16 +102,7 @@ class BundlesConfigurator extends AbstractConfigurator
 
     private function dump(string $file, array $bundles)
     {
-        $contents = "<?php\n\nreturn [\n";
-        foreach ($bundles as $class => $envs) {
-            $contents .= "    $class::class => [";
-            foreach ($envs as $env => $value) {
-                $booleanValue = var_export($value, true);
-                $contents .= "'$env' => $booleanValue, ";
-            }
-            $contents = substr($contents, 0, -2)."],\n";
-        }
-        $contents .= "];\n";
+        $contents = $this->buildContents($bundles);
 
         if (!is_dir(\dirname($file))) {
             mkdir(\dirname($file), 0777, true);
@@ -100,8 +115,29 @@ class BundlesConfigurator extends AbstractConfigurator
         }
     }
 
+    private function buildContents(array $bundles): string
+    {
+        $contents = "<?php\n\nreturn [\n";
+        foreach ($bundles as $class => $envs) {
+            $contents .= "    $class::class => [";
+            foreach ($envs as $env => $value) {
+                $booleanValue = var_export($value, true);
+                $contents .= "'$env' => $booleanValue, ";
+            }
+            $contents = substr($contents, 0, -2)."],\n";
+        }
+        $contents .= "];\n";
+
+        return $contents;
+    }
+
     private function getConfFile(): string
     {
-        return $this->options->get('root-dir').'/'.$this->options->expandTargetDir('%CONFIG_DIR%/bundles.php');
+        return $this->options->get('root-dir').'/'.$this->getLocalConfFile();
+    }
+
+    private function getLocalConfFile(): string
+    {
+        return $this->options->expandTargetDir('%CONFIG_DIR%/bundles.php');
     }
 }

--- a/src/Configurator/ComposerScriptsConfigurator.php
+++ b/src/Configurator/ComposerScriptsConfigurator.php
@@ -16,6 +16,7 @@ use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -26,14 +27,7 @@ class ComposerScriptsConfigurator extends AbstractConfigurator
     {
         $json = new JsonFile(Factory::getComposerFile());
 
-        $jsonContents = $json->read();
-        $autoScripts = $jsonContents['scripts']['auto-scripts'] ?? [];
-        $autoScripts = array_merge($autoScripts, $scripts);
-
-        $manipulator = new JsonManipulator(file_get_contents($json->getPath()));
-        $manipulator->addSubNode('scripts', 'auto-scripts', $autoScripts);
-
-        file_put_contents($json->getPath(), $manipulator->getContents());
+        file_put_contents($json->getPath(), $this->configureScripts($scripts, $json));
     }
 
     public function unconfigure(Recipe $recipe, $scripts, Lock $lock)
@@ -50,5 +44,32 @@ class ComposerScriptsConfigurator extends AbstractConfigurator
         $manipulator->addSubNode('scripts', 'auto-scripts', $autoScripts);
 
         file_put_contents($json->getPath(), $manipulator->getContents());
+    }
+
+    public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
+    {
+        $json = new JsonFile(Factory::getComposerFile());
+        $jsonPath = ltrim(str_replace($recipeUpdate->getRootDir(), '', $json->getPath()), '/\\');
+
+        $recipeUpdate->setOriginalFile(
+            $jsonPath,
+            $this->configureScripts($originalConfig, $json)
+        );
+        $recipeUpdate->setNewFile(
+            $jsonPath,
+            $this->configureScripts($newConfig, $json)
+        );
+    }
+
+    private function configureScripts(array $scripts, JsonFile $json): string
+    {
+        $jsonContents = $json->read();
+        $autoScripts = $jsonContents['scripts']['auto-scripts'] ?? [];
+        $autoScripts = array_merge($autoScripts, $scripts);
+
+        $manipulator = new JsonManipulator(file_get_contents($json->getPath()));
+        $manipulator->addSubNode('scripts', 'auto-scripts', $autoScripts);
+
+        return $manipulator->getContents();
     }
 }

--- a/src/Configurator/ContainerConfigurator.php
+++ b/src/Configurator/ContainerConfigurator.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Configurator;
 
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -22,13 +23,17 @@ class ContainerConfigurator extends AbstractConfigurator
     public function configure(Recipe $recipe, $parameters, Lock $lock, array $options = [])
     {
         $this->write('Setting parameters');
-        $this->addParameters($parameters);
+        $contents = $this->configureParameters($parameters);
+
+        if (null !== $contents) {
+            file_put_contents($this->options->get('root-dir').'/'.$this->getServicesPath(), $contents);
+        }
     }
 
     public function unconfigure(Recipe $recipe, $parameters, Lock $lock)
     {
         $this->write('Unsetting parameters');
-        $target = $this->options->get('root-dir').'/'.$this->options->expandTargetDir('%CONFIG_DIR%/services.yaml');
+        $target = $this->options->get('root-dir').'/'.$this->getServicesPath();
         $lines = [];
         foreach (file($target) as $line) {
             if ($this->removeParameters(1, $parameters, $line)) {
@@ -39,9 +44,26 @@ class ContainerConfigurator extends AbstractConfigurator
         file_put_contents($target, implode('', $lines));
     }
 
-    private function addParameters(array $parameters)
+    public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
     {
-        $target = $this->options->get('root-dir').'/'.$this->options->expandTargetDir('%CONFIG_DIR%/services.yaml');
+        if ($originalConfig) {
+            $recipeUpdate->setOriginalFile(
+                $this->getServicesPath(),
+                $this->configureParameters($originalConfig, true)
+            );
+        }
+
+        if ($newConfig) {
+            $recipeUpdate->setNewFile(
+                $this->getServicesPath(),
+                $this->configureParameters($newConfig, true)
+            );
+        }
+    }
+
+    private function configureParameters(array $parameters, bool $update = false): string
+    {
+        $target = $this->options->get('root-dir').'/'.$this->getServicesPath();
         $endAt = 0;
         $isParameters = false;
         $lines = [];
@@ -60,31 +82,36 @@ class ContainerConfigurator extends AbstractConfigurator
                 continue;
             }
             foreach ($parameters as $key => $value) {
-                if (preg_match(sprintf('/^\s+%s\:/', preg_quote($key, '/')), $line)) {
+                $matches = [];
+                if (preg_match(sprintf('/^\s+%s\:/', preg_quote($key, '/')), $line, $matches)) {
+                    if ($update) {
+                        $lines[$i] = substr($line, 0, \strlen($matches[0])).' '.str_replace("'", "''", $value)."\n";
+                    }
+
                     unset($parameters[$key]);
                 }
             }
         }
-        if (!$parameters) {
-            return;
+
+        if ($parameters) {
+            $parametersLines = [];
+            if (!$endAt) {
+                $parametersLines[] = "parameters:\n";
+            }
+            foreach ($parameters as $key => $value) {
+                if (\is_array($value)) {
+                    $parametersLines[] = sprintf("    %s:\n%s", $key, $this->dumpYaml(2, $value));
+                    continue;
+                }
+                $parametersLines[] = sprintf("    %s: '%s'%s", $key, str_replace("'", "''", $value), "\n");
+            }
+            if (!$endAt) {
+                $parametersLines[] = "\n";
+            }
+            array_splice($lines, $endAt, 0, $parametersLines);
         }
 
-        $parametersLines = [];
-        if (!$endAt) {
-            $parametersLines[] = "parameters:\n";
-        }
-        foreach ($parameters as $key => $value) {
-            if (\is_array($value)) {
-                $parametersLines[] = sprintf("    %s:\n%s", $key, $this->dumpYaml(2, $value));
-                continue;
-            }
-            $parametersLines[] = sprintf("    %s: '%s'%s", $key, str_replace("'", "''", $value), "\n");
-        }
-        if (!$endAt) {
-            $parametersLines[] = "\n";
-        }
-        array_splice($lines, $endAt, 0, $parametersLines);
-        file_put_contents($target, implode('', $lines));
+        return implode('', $lines);
     }
 
     private function removeParameters($level, $params, $line)
@@ -114,5 +141,10 @@ class ContainerConfigurator extends AbstractConfigurator
         }
 
         return $line;
+    }
+
+    private function getServicesPath(): string
+    {
+        return $this->options->expandTargetDir('%CONFIG_DIR%/services.yaml');
     }
 }

--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Configurator;
 
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -25,7 +26,10 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
         $packageDir = $this->composer->getInstallationManager()->getInstallPath($recipe->getPackage());
         $options = array_merge($this->options->toArray(), $options);
 
-        $this->copyFiles($config, $packageDir, $options);
+        $files = $this->getFilesToCopy($config, $packageDir);
+        foreach ($files as $source => $target) {
+            $this->copyFile($source, $target, $options);
+        }
     }
 
     public function unconfigure(Recipe $recipe, $config, Lock $lock)
@@ -35,23 +39,48 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
         $this->removeFiles($config, $packageDir, $this->options->get('root-dir'));
     }
 
-    private function copyFiles(array $manifest, string $from, array $options)
+    public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
     {
-        $to = $options['root-dir'] ?? '.';
+        $packageDir = $this->composer->getInstallationManager()->getInstallPath($recipeUpdate->getNewRecipe()->getPackage());
+        foreach ($originalConfig as $source => $target) {
+            if (isset($newConfig[$source])) {
+                // path is in both, we cannot update
+                $recipeUpdate->addCopyFromPackagePath(
+                    $packageDir.'/'.$source,
+                    $this->options->expandTargetDir($target)
+                );
+
+                unset($newConfig[$source]);
+            }
+
+            // if any paths were removed from the recipe, we'll keep them
+        }
+
+        // any remaining files are new, and we can copy them
+        foreach ($this->getFilesToCopy($newConfig, $packageDir) as $source => $target) {
+            if (!file_exists($source)) {
+                throw new \LogicException(sprintf('File "%s" does not exist!', $source));
+            }
+
+            $recipeUpdate->setNewFile($target, file_get_contents($source));
+        }
+    }
+
+    private function getFilesToCopy(array $manifest, string $from): array
+    {
+        $files = [];
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
             if ('/' === substr($source, -1)) {
-                $this->copyDir($this->path->concatenate([$from, $source]), $this->path->concatenate([$to, $target]), $options);
-            } else {
-                $targetPath = $this->path->concatenate([$to, $target]);
-                if (!is_dir(\dirname($targetPath))) {
-                    mkdir(\dirname($targetPath), 0777, true);
-                    $this->write(sprintf('  Created <fg=green>"%s"</>', $this->path->relativize(\dirname($targetPath))));
-                }
+                $files = array_merge($files, $this->getFilesForDir($this->path->concatenate([$from, $source]), $this->path->concatenate([$target])));
 
-                $this->copyFile($this->path->concatenate([$from, $source]), $targetPath, $options);
+                continue;
             }
+
+            $files[$this->path->concatenate([$from, $source])] = $target;
         }
+
+        return $files;
     }
 
     private function removeFiles(array $manifest, string $from, string $to)
@@ -70,30 +99,31 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
         }
     }
 
-    private function copyDir(string $source, string $target, array $options)
+    private function getFilesForDir(string $source, string $target): array
     {
-        $overwrite = $options['force'] ?? false;
-
-        if (!is_dir($target)) {
-            mkdir($target, 0777, true);
-        }
-
         $iterator = $this->createSourceIterator($source, \RecursiveIteratorIterator::SELF_FIRST);
+        $files = [];
         foreach ($iterator as $item) {
             $targetPath = $this->path->concatenate([$target, $iterator->getSubPathName()]);
-            if ($item->isDir()) {
-                if (!is_dir($targetPath)) {
-                    mkdir($targetPath);
-                    $this->write(sprintf('  Created <fg=green>"%s"</>', $this->path->relativize($targetPath)));
-                }
-            } elseif ($overwrite || !file_exists($targetPath)) {
-                $this->copyFile($item, $targetPath, $options);
-            }
+
+            $files[(string) $item] = $targetPath;
         }
+
+        return $files;
     }
 
+    /**
+     * @param string $source The absolute path to the source file
+     * @param string $target The relative (to root dir) path to the target
+     */
     public function copyFile(string $source, string $target, array $options)
     {
+        $target = $this->options->get('root-dir').'/'.$target;
+        if (is_dir($source)) {
+            // directory will be created when a file is copied to it
+            return;
+        }
+
         $overwrite = $options['force'] ?? false;
         if (!$this->options->shouldWriteFile($target, $overwrite)) {
             return;
@@ -101,6 +131,11 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
 
         if (!file_exists($source)) {
             throw new \LogicException(sprintf('File "%s" does not exist!', $source));
+        }
+
+        if (!file_exists(\dirname($target))) {
+            mkdir(\dirname($target), 0777, true);
+            $this->write(sprintf('  Created <fg=green>"%s"</>', $this->path->relativize(\dirname($target))));
         }
 
         file_put_contents($target, $this->options->expandTargetDir(file_get_contents($source)));

--- a/src/Configurator/DockerfileConfigurator.php
+++ b/src/Configurator/DockerfileConfigurator.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Configurator;
 
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
 
 /**
  * Adds commands to a Dockerfile.
@@ -27,24 +28,7 @@ class DockerfileConfigurator extends AbstractConfigurator
             return;
         }
 
-        $dockerfile = $this->options->get('root-dir').'/Dockerfile';
-        if (!file_exists($dockerfile) || $this->isFileMarked($recipe, $dockerfile)) {
-            return;
-        }
-
-        $this->write('Adding Dockerfile entries');
-
-        $lines = [];
-        foreach (file($dockerfile) as $line) {
-            $lines[] = $line;
-            if (!preg_match('/^###> recipes ###$/', $line)) {
-                continue;
-            }
-
-            $lines[] = ltrim($this->markData($recipe, implode("\n", $config)), "\n");
-        }
-
-        file_put_contents($dockerfile, implode('', $lines));
+        $this->configureDockerfile($recipe, $config, $options['force'] ?? false);
     }
 
     public function unconfigure(Recipe $recipe, $config, Lock $lock)
@@ -61,5 +45,81 @@ class DockerfileConfigurator extends AbstractConfigurator
 
         $this->write('Removing Dockerfile entries');
         file_put_contents($dockerfile, ltrim($contents, "\n"));
+    }
+
+    public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
+    {
+        if (!DockerComposeConfigurator::shouldConfigureDockerRecipe($this->composer, $this->io, $recipeUpdate->getNewRecipe())) {
+            return;
+        }
+
+        $recipeUpdate->setOriginalFile(
+            'Dockerfile',
+            $this->getContentsAfterApplyingRecipe($recipeUpdate->getOriginalRecipe(), $originalConfig)
+        );
+
+        $recipeUpdate->setNewFile(
+            'Dockerfile',
+            $this->getContentsAfterApplyingRecipe($recipeUpdate->getNewRecipe(), $newConfig)
+        );
+    }
+
+    private function configureDockerfile(Recipe $recipe, array $config, bool $update, bool $writeOutput = true): void
+    {
+        $dockerfile = $this->options->get('root-dir').'/Dockerfile';
+        if (!file_exists($dockerfile) || (!$update && $this->isFileMarked($recipe, $dockerfile))) {
+            return;
+        }
+
+        if ($writeOutput) {
+            $this->write('Adding Dockerfile entries');
+        }
+
+        $data = ltrim($this->markData($recipe, implode("\n", $config)), "\n");
+        if ($this->updateData($dockerfile, $data)) {
+            // done! Existing spot updated
+            return;
+        }
+
+        $lines = [];
+        foreach (file($dockerfile) as $line) {
+            $lines[] = $line;
+            if (!preg_match('/^###> recipes ###$/', $line)) {
+                continue;
+            }
+
+            $lines[] = $data;
+        }
+
+        file_put_contents($dockerfile, implode('', $lines));
+    }
+
+    private function getContentsAfterApplyingRecipe(Recipe $recipe, array $config): ?string
+    {
+        if (0 === \count($config)) {
+            return null;
+        }
+
+        $dockerfile = $this->options->get('root-dir').'/Dockerfile';
+        $originalContents = file_exists($dockerfile) ? file_get_contents($dockerfile) : null;
+
+        $this->configureDockerfile(
+            $recipe,
+            $config,
+            true,
+            false
+        );
+
+        $updatedContents = file_exists($dockerfile) ? file_get_contents($dockerfile) : null;
+
+        if (null === $originalContents) {
+            if (file_exists($dockerfile)) {
+                unlink($dockerfile);
+            }
+        } else {
+            file_put_contents($dockerfile, $originalContents);
+        }
+
+        return $updatedContents;
     }
 }

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Configurator;
 
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -35,6 +36,17 @@ class EnvConfigurator extends AbstractConfigurator
         $this->unconfigurePhpUnit($recipe, $vars);
     }
 
+    public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
+    {
+        $recipeUpdate->addOriginalFiles(
+            $this->getContentsAfterApplyingRecipe($recipeUpdate->getRootDir(), $recipeUpdate->getOriginalRecipe(), $originalConfig)
+        );
+
+        $recipeUpdate->addNewFiles(
+            $this->getContentsAfterApplyingRecipe($recipeUpdate->getRootDir(), $recipeUpdate->getNewRecipe(), $newConfig)
+        );
+    }
+
     private function configureEnvDist(Recipe $recipe, $vars, bool $update)
     {
         foreach (['.env.dist', '.env'] as $file) {
@@ -49,7 +61,8 @@ class EnvConfigurator extends AbstractConfigurator
 
             $data = '';
             foreach ($vars as $key => $value) {
-                $value = $this->evaluateValue($value);
+                $existingValue = $update ? $this->findExistingValue($key, $env, $recipe) : null;
+                $value = $this->evaluateValue($value, $existingValue);
                 if ('#' === $key[0] && is_numeric(substr($key, 1))) {
                     if ('' === $value) {
                         $data .= "#\n";
@@ -154,12 +167,26 @@ class EnvConfigurator extends AbstractConfigurator
         }
     }
 
-    private function evaluateValue($value)
+    /**
+     * Evaluates expressions like %generate(secret)%.
+     *
+     * If $originalValue is passed, and the value contains an expression.
+     * the $originalValue is used.
+     */
+    private function evaluateValue($value, string $originalValue = null)
     {
         if ('%generate(secret)%' === $value) {
+            if (null !== $originalValue) {
+                return $originalValue;
+            }
+
             return $this->generateRandomBytes();
         }
         if (preg_match('~^%generate\(secret,\s*([0-9]+)\)%$~', $value, $matches)) {
+            if (null !== $originalValue) {
+                return $originalValue;
+            }
+
             return $this->generateRandomBytes($matches[1]);
         }
 
@@ -169,5 +196,77 @@ class EnvConfigurator extends AbstractConfigurator
     private function generateRandomBytes($length = 16)
     {
         return bin2hex(random_bytes($length));
+    }
+
+    private function getContentsAfterApplyingRecipe(string $rootDir, Recipe $recipe, array $vars): array
+    {
+        $files = ['.env', '.env.dist', 'phpunit.xml.dist', 'phpunit.xml'];
+
+        if (0 === \count($vars)) {
+            return array_fill_keys($files, null);
+        }
+
+        $originalContents = [];
+        foreach ($files as $file) {
+            $originalContents[$file] = file_exists($rootDir.'/'.$file) ? file_get_contents($rootDir.'/'.$file) : null;
+        }
+
+        $this->configureEnvDist(
+            $recipe,
+            $vars,
+            true
+        );
+
+        if (!file_exists($rootDir.'/.env.test')) {
+            $this->configurePhpUnit(
+                $recipe,
+                $vars,
+                true
+            );
+        }
+
+        $updatedContents = [];
+        foreach ($files as $file) {
+            $updatedContents[$file] = file_exists($rootDir.'/'.$file) ? file_get_contents($rootDir.'/'.$file) : null;
+        }
+
+        foreach ($originalContents as $file => $contents) {
+            if (null === $contents) {
+                if (file_exists($rootDir.'/'.$file)) {
+                    unlink($rootDir.'/'.$file);
+                }
+            } else {
+                file_put_contents($rootDir.'/'.$file, $contents);
+            }
+        }
+
+        return $updatedContents;
+    }
+
+    /**
+     * Attempts to find the existing value of an environment variable.
+     */
+    private function findExistingValue(string $var, string $filename, Recipe $recipe): ?string
+    {
+        if (!file_exists($filename)) {
+            return null;
+        }
+
+        $contents = file_get_contents($filename);
+        $section = $this->extractSection($recipe, $contents);
+        if (!$section) {
+            return null;
+        }
+
+        $lines = explode("\n", $section);
+        foreach ($lines as $line) {
+            if (0 !== strpos($line, sprintf('%s=', $var))) {
+                continue;
+            }
+
+            return trim(substr($line, \strlen($var) + 1));
+        }
+
+        return null;
     }
 }

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -139,6 +139,7 @@ class Downloader
         $data = [];
         $urls = [];
         $chunk = '';
+        $recipeRef = null;
         foreach ($operations as $operation) {
             $o = 'i';
             if ($operation instanceof UpdateOperation) {
@@ -149,9 +150,16 @@ class Downloader
                 if ($operation instanceof UninstallOperation) {
                     $o = 'r';
                 }
+
+                if ($operation instanceof InformationOperation) {
+                    $recipeRef = $operation->getRecipeRef();
+                }
             }
 
             $version = $package->getPrettyVersion();
+            if ($operation instanceof InformationOperation && $operation->getVersion()) {
+                $version = $operation->getVersion();
+            }
             if (0 === strpos($version, 'dev-') && isset($package->getExtra()['branch-alias'])) {
                 $branchAliases = $package->getExtra()['branch-alias'];
                 if (
@@ -179,6 +187,16 @@ class Downloader
                     if (version_compare($version, $v, '>=')) {
                         $data['locks'][$package->getName()]['version'] = $version;
                         $data['locks'][$package->getName()]['recipe']['version'] = $v;
+
+                        if (null !== $recipeRef && isset($this->endpoints[$endpoint]['_links']['archived_recipes_template'])) {
+                            $urls[] = strtr($this->endpoints[$endpoint]['_links']['archived_recipes_template'], [
+                                '{package_dotted}' => str_replace('/', '.', $package->getName()),
+                                '{ref}' => $recipeRef,
+                            ]);
+
+                            break;
+                        }
+
                         $urls[] = strtr($this->endpoints[$endpoint]['_links']['recipe_template'], [
                             '{package_dotted}' => str_replace('/', '.', $package->getName()),
                             '{package}' => $package->getName(),
@@ -418,6 +436,9 @@ class Downloader
         $url = preg_replace('{^https://api.github.com/repos/([^/]++/[^/]++)/contents/}', '$1/', $url);
         $url = preg_replace('{^https://raw.githubusercontent.com/([^/]++/[^/]++)/}', '$1/', $url);
 
-        return preg_replace('{[^a-z0-9.]}i', '-', $url);
+        $key = preg_replace('{[^a-z0-9.]}i', '-', $url);
+
+        // eCryptfs can have problems with filenames longer than around 143 chars
+        return \strlen($key) > 140 ? md5($url) : $key;
     }
 }

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -276,6 +276,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $app->add(new Command\UnpackCommand($resolver));
             $app->add(new Command\RecipesCommand($this, $this->lock, $rfs));
             $app->add(new Command\InstallRecipesCommand($this, $this->options->get('root-dir')));
+            $app->add(new Command\UpdateRecipesCommand($this, $this->downloader, $rfs, $this->configurator, $this->options->get('root-dir')));
             if (class_exists(Command\GenerateIdCommand::class)) {
                 $app->add(new Command\GenerateIdCommand(null));
             }
@@ -411,8 +412,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
         if (!$recipes) {
             if (ScriptEvents::POST_UPDATE_CMD === $event->getName()) {
-                $this->synchronizePackageJson($rootDir);
-                $this->lock->write();
+                $this->finish($rootDir);
             }
 
             if ($this->downloader->isEnabled()) {
@@ -508,10 +508,15 @@ class Flex implements PluginInterface, EventSubscriberInterface
             );
         }
 
+        $this->finish($rootDir, $originalComposerJsonHash);
+    }
+
+    public function finish(string $rootDir, string $originalComposerJsonHash = null): void
+    {
         $this->synchronizePackageJson($rootDir);
         $this->lock->write();
 
-        if ($this->getComposerJsonHash() !== $originalComposerJsonHash) {
+        if ($originalComposerJsonHash && $this->getComposerJsonHash() !== $originalComposerJsonHash) {
             $this->updateComposerLock();
         }
     }
@@ -790,6 +795,20 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $event->setPackages($this->filter->removeLegacyPackages($event->getPackages(), $rootPackage, $lockedPackages));
     }
 
+    public function getComposerJsonHash(): string
+    {
+        return md5_file(Factory::getComposerFile());
+    }
+
+    public function getLock(): Lock
+    {
+        if (null === $this->lock) {
+            throw new \Exception('Cannot access lock before calling activate().');
+        }
+
+        return $this->lock;
+    }
+
     private function initOptions(): Options
     {
         $extra = $this->composer->getPackage()->getExtra();
@@ -969,10 +988,5 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
 
         return $events;
-    }
-
-    private function getComposerJsonHash(): string
-    {
-        return md5_file(Factory::getComposerFile());
     }
 }

--- a/src/GithubApi.php
+++ b/src/GithubApi.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex;
+
+use Composer\Util\HttpDownloader;
+use Composer\Util\RemoteFilesystem;
+
+class GithubApi
+{
+    /** @var HttpDownloader|RemoteFilesystem */
+    private $downloader;
+
+    public function __construct($downloader)
+    {
+        $this->downloader = $downloader;
+    }
+
+    /**
+     * Attempts to find data about when the recipe was installed.
+     *
+     * Returns an array containing:
+     *      commit: The git sha of the last commit of the recipe
+     *      date: The date of the commit
+     *      new_commits: An array of commit sha's in this recipe's directory+version since the commit
+     *                   The key is the sha & the value is the date
+     */
+    public function findRecipeCommitDataFromTreeRef(string $package, string $repo, string $branch, string $version, string $lockRef): ?array
+    {
+        $repositoryName = $this->getRepositoryName($repo);
+        if (!$repositoryName) {
+            return null;
+        }
+
+        $recipePath = sprintf('%s/%s', $package, $version);
+        $commitsData = $this->requestGitHubApi(sprintf(
+            'https://api.github.com/repos/%s/commits?path=%s&sha=%s',
+            $repositoryName,
+            $recipePath,
+            $branch
+        ));
+
+        $commitShas = [];
+        foreach ($commitsData as $commitData) {
+            $commitShas[$commitData['sha']] = $commitData['commit']['committer']['date'];
+            // go back the commits one-by-one
+            $treeUrl = $commitData['commit']['tree']['url'].'?recursive=true';
+
+            // fetch the full tree, then look for the tree for the package path
+            $treeData = $this->requestGitHubApi($treeUrl);
+            foreach ($treeData['tree'] as $treeItem) {
+                if ($treeItem['path'] !== $recipePath) {
+                    continue;
+                }
+
+                if ($treeItem['sha'] === $lockRef) {
+                    // remove *this* commit from the new commits list
+                    array_pop($commitShas);
+
+                    return [
+                        // shorten for brevity
+                        'commit' => substr($commitData['sha'], 0, 7),
+                        'date' => $commitData['commit']['committer']['date'],
+                        'new_commits' => $commitShas,
+                    ];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function getVersionsOfRecipe(string $repo, string $branch, string $recipePath): ?array
+    {
+        $repositoryName = $this->getRepositoryName($repo);
+        if (!$repositoryName) {
+            return null;
+        }
+
+        $url = sprintf(
+            'https://api.github.com/repos/%s/contents/%s?ref=%s',
+            $repositoryName,
+            $recipePath,
+            $branch
+        );
+        $contents = $this->requestGitHubApi($url);
+        $versions = [];
+        foreach ($contents as $fileData) {
+            if ('dir' !== $fileData['type']) {
+                continue;
+            }
+
+            $versions[] = $fileData['name'];
+        }
+
+        return $versions;
+    }
+
+    public function getCommitDataForPath(string $repo, string $path, string $branch): array
+    {
+        $repositoryName = $this->getRepositoryName($repo);
+        if (!$repositoryName) {
+            return [];
+        }
+
+        $commitsData = $this->requestGitHubApi(sprintf(
+            'https://api.github.com/repos/%s/commits?path=%s&sha=%s',
+            $repositoryName,
+            $path,
+            $branch
+        ));
+
+        $data = [];
+        foreach ($commitsData as $commitData) {
+            $data[$commitData['sha']] = $commitData['commit']['committer']['date'];
+        }
+
+        return $data;
+    }
+
+    public function getPullRequestForCommit(string $commit, string $repo): ?array
+    {
+        $data = $this->requestGitHubApi('https://api.github.com/search/issues?q='.$commit);
+
+        if (0 === \count($data['items'])) {
+            return null;
+        }
+
+        $repositoryName = $this->getRepositoryName($repo);
+        if (!$repositoryName) {
+            return null;
+        }
+
+        $bestItem = null;
+        foreach ($data['items'] as $item) {
+            // make sure the PR referenced isn't from a different repository
+            if (false === strpos($item['html_url'], sprintf('%s/pull', $repositoryName))) {
+                continue;
+            }
+
+            if (null === $bestItem) {
+                $bestItem = $item;
+
+                continue;
+            }
+
+            // find the first PR to reference - avoids rare cases where an invalid
+            // PR that references *many* commits is first
+            // e.g. https://api.github.com/search/issues?q=a1a70353f64f405cfbacfc4ce860af623442d6e5
+            if ($item['number'] < $bestItem['number']) {
+                $bestItem = $item;
+            }
+        }
+
+        if (!$bestItem) {
+            return null;
+        }
+
+        return [
+            'number' => $bestItem['number'],
+            'url' => $bestItem['html_url'],
+            'title' => $bestItem['title'],
+        ];
+    }
+
+    private function requestGitHubApi(string $path)
+    {
+        if ($this->downloader instanceof HttpDownloader) {
+            $contents = $this->downloader->get($path)->getBody();
+        } else {
+            $contents = $this->downloader->getContents('api.github.com', $path, false);
+        }
+
+        return json_decode($contents, true);
+    }
+
+    /**
+     * Converts the "repo" stored in symfony.lock to a repository name.
+     *
+     * For example: "github.com/symfony/recipes" => "symfony/recipes"
+     */
+    private function getRepositoryName(string $repo): ?string
+    {
+        // only supports public repository placement
+        if (0 !== strpos($repo, 'github.com')) {
+            return null;
+        }
+
+        $parts = explode('/', $repo);
+        if (3 !== \count($parts)) {
+            return null;
+        }
+
+        return implode('/', [$parts[1], $parts[2]]);
+    }
+}

--- a/src/InformationOperation.php
+++ b/src/InformationOperation.php
@@ -11,10 +11,23 @@ use Composer\Package\PackageInterface;
 class InformationOperation implements OperationInterface
 {
     private $package;
+    private $recipeRef = null;
+    private $version = null;
 
     public function __construct(PackageInterface $package)
     {
         $this->package = $package;
+    }
+
+    /**
+     * Call to get information about a specific version of a recipe.
+     *
+     * Both $recipeRef and $version would normally come from the symfony.lock file.
+     */
+    public function setSpecificRecipeVersion(string $recipeRef, string $version)
+    {
+        $this->recipeRef = $recipeRef;
+        $this->version = $version;
     }
 
     /**
@@ -25,6 +38,16 @@ class InformationOperation implements OperationInterface
     public function getPackage()
     {
         return $this->package;
+    }
+
+    public function getRecipeRef(): ?string
+    {
+        return $this->recipeRef;
+    }
+
+    public function getVersion(): ?string
+    {
+        return $this->version;
     }
 
     public function getJobType()

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -115,4 +115,9 @@ class Recipe
     {
         return $this->lock['recipe']['version'] ?? $this->lock['version'];
     }
+
+    public function getLock(): array
+    {
+        return $this->lock;
+    }
 }

--- a/src/Update/DiffHelper.php
+++ b/src/Update/DiffHelper.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Update;
+
+class DiffHelper
+{
+    public static function removeFilesFromPatch(string $patch, array $files, array &$removedPatches): string
+    {
+        foreach ($files as $filename) {
+            $start = strpos($patch, sprintf('diff --git a/%s b/%s', $filename, $filename));
+            if (false === $start) {
+                throw new \LogicException(sprintf('Could not find file "%s" in the patch.', $filename));
+            }
+
+            $end = strpos($patch, 'diff --git a/', $start + 1);
+            $contentBefore = substr($patch, 0, $start);
+            if (false === $end) {
+                // last patch in the file
+                $removedPatches[$filename] = rtrim(substr($patch, $start), "\n");
+                $patch = rtrim($contentBefore, "\n");
+
+                continue;
+            }
+
+            $removedPatches[$filename] = rtrim(substr($patch, $start, $end - $start), "\n");
+            $patch = $contentBefore.substr($patch, $end);
+        }
+
+        return $patch;
+    }
+}

--- a/src/Update/RecipePatch.php
+++ b/src/Update/RecipePatch.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Update;
+
+class RecipePatch
+{
+    private $patch;
+    private $blobs;
+    private $removedPatches;
+
+    public function __construct(string $patch, array $blobs, array $removedPatches = [])
+    {
+        $this->patch = $patch;
+        $this->blobs = $blobs;
+        $this->removedPatches = $removedPatches;
+    }
+
+    public function getPatch(): string
+    {
+        return $this->patch;
+    }
+
+    public function getBlobs(): array
+    {
+        return $this->blobs;
+    }
+
+    /**
+     * Patches for modified files that were removed because the file
+     * has been deleted in the user's project.
+     */
+    public function getRemovedPatches(): array
+    {
+        return $this->removedPatches;
+    }
+}

--- a/src/Update/RecipePatcher.php
+++ b/src/Update/RecipePatcher.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Update;
+
+use Composer\IO\IOInterface;
+use Composer\Util\ProcessExecutor;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+class RecipePatcher
+{
+    private $rootDir;
+    private $filesystem;
+    private $io;
+    private $processExecutor;
+
+    public function __construct(string $rootDir, IOInterface $io)
+    {
+        $this->rootDir = $rootDir;
+        $this->filesystem = new Filesystem();
+        $this->io = $io;
+        $this->processExecutor = new ProcessExecutor($io);
+    }
+
+    /**
+     * Applies the patch. If it fails unexpectedly, an exception will be thrown.
+     *
+     * @return bool returns true if fully successful, false if conflicts were encountered
+     */
+    public function applyPatch(RecipePatch $patch): bool
+    {
+        if (!$patch->getPatch()) {
+            // nothing to do!
+            return true;
+        }
+
+        $addedBlobs = $this->addMissingBlobs($patch->getBlobs());
+
+        $patchPath = $this->rootDir.'/_flex_recipe_update.patch';
+        file_put_contents($patchPath, $patch->getPatch());
+
+        try {
+            $this->execute('git update-index --refresh', $this->rootDir);
+
+            $output = '';
+            $statusCode = $this->processExecutor->execute('git apply "_flex_recipe_update.patch" -3', $output, $this->rootDir);
+
+            if (0 === $statusCode) {
+                // successful with no conflicts
+                return true;
+            }
+
+            if (false !== strpos($this->processExecutor->getErrorOutput(), 'with conflicts')) {
+                // successful with conflicts
+                return false;
+            }
+
+            throw new \LogicException('Error applying the patch: '.$this->processExecutor->getErrorOutput());
+        } finally {
+            unlink($patchPath);
+            // clean up any temporary blobs
+            foreach ($addedBlobs as $filename) {
+                unlink($filename);
+            }
+        }
+    }
+
+    public function generatePatch(array $originalFiles, array $newFiles): RecipePatch
+    {
+        // null implies "file does not exist"
+        $originalFiles = array_filter($originalFiles, function ($file) {
+            return null !== $file;
+        });
+        $newFiles = array_filter($newFiles, function ($file) {
+            return null !== $file;
+        });
+
+        // find removed files and add them so they will be deleted
+        foreach ($originalFiles as $file => $contents) {
+            if (!isset($newFiles[$file])) {
+                $newFiles[$file] = null;
+            }
+        }
+
+        // If a file is being modified, but does not exist in the current project,
+        // it cannot be patched. We generate the diff for these, but then remove
+        // it from the patch (and optionally report this diff to the user).
+        $modifiedFiles = array_intersect_key(array_keys($originalFiles), array_keys($newFiles));
+        $deletedModifiedFiles = [];
+        foreach ($modifiedFiles as $modifiedFile) {
+            if (!file_exists($this->rootDir.'/'.$modifiedFile) && $originalFiles[$modifiedFile] !== $newFiles[$modifiedFile]) {
+                $deletedModifiedFiles[] = $modifiedFile;
+            }
+        }
+
+        $tmpPath = sys_get_temp_dir().'/_flex_recipe_update'.uniqid(mt_rand(), true);
+        $this->filesystem->mkdir($tmpPath);
+
+        try {
+            $this->execute('git init', $tmpPath);
+            $this->execute('git config commit.gpgsign false', $tmpPath);
+            $this->execute('git config user.name "Flex Updater"', $tmpPath);
+            $this->execute('git config user.email ""', $tmpPath);
+
+            $blobs = [];
+            if (\count($originalFiles) > 0) {
+                $this->writeFiles($originalFiles, $tmpPath);
+                $this->execute('git add -A', $tmpPath);
+                $this->execute('git commit -m "original files"', $tmpPath);
+
+                $blobs = $this->generateBlobs($originalFiles, $tmpPath);
+            }
+
+            $this->writeFiles($newFiles, $tmpPath);
+            $this->execute('git add -A', $tmpPath);
+
+            $patchString = $this->execute('git diff --cached', $tmpPath);
+            $removedPatches = [];
+            $patchString = DiffHelper::removeFilesFromPatch($patchString, $deletedModifiedFiles, $removedPatches);
+
+            return new RecipePatch(
+                $patchString,
+                $blobs,
+                $removedPatches
+            );
+        } finally {
+            try {
+                $this->filesystem->remove($tmpPath);
+            } catch (IOException $e) {
+                // this can sometimes fail due to git file permissions
+                // if that happens, just leave it: we're in the temp directory anyways
+            }
+        }
+    }
+
+    private function writeFiles(array $files, string $directory): void
+    {
+        foreach ($files as $filename => $contents) {
+            $path = $directory.'/'.$filename;
+            if (null === $contents) {
+                if (file_exists($path)) {
+                    unlink($path);
+                }
+
+                continue;
+            }
+
+            if (!file_exists(\dirname($path))) {
+                $this->filesystem->mkdir(\dirname($path));
+            }
+            file_put_contents($path, $contents);
+        }
+    }
+
+    private function execute(string $command, string $cwd): string
+    {
+        $output = '';
+        $statusCode = $this->processExecutor->execute($command, $output, $cwd);
+
+        if (0 !== $statusCode) {
+            throw new \LogicException(sprintf('Command "%s" failed: "%s". Output: "%s".', $command, $this->processExecutor->getErrorOutput(), $output));
+        }
+
+        return $output;
+    }
+
+    /**
+     * Adds git blobs for each original file.
+     *
+     * For patching to work, each original file & contents needs to be
+     * available to git as a blob. This is because the patch contains
+     * the ref to the original blob, and git uses that to find the
+     * original file (which is needed for the 3-way merge).
+     */
+    private function addMissingBlobs(array $blobs): array
+    {
+        $addedBlobs = [];
+        foreach ($blobs as $hash => $contents) {
+            $blobPath = $this->rootDir.'/'.$this->getBlobPath($hash);
+            if (file_exists($blobPath)) {
+                continue;
+            }
+
+            $addedBlobs[] = $blobPath;
+            if (!file_exists(\dirname($blobPath))) {
+                $this->filesystem->mkdir(\dirname($blobPath));
+            }
+            file_put_contents($blobPath, $contents);
+        }
+
+        return $addedBlobs;
+    }
+
+    private function generateBlobs(array $originalFiles, string $originalFilesRoot): array
+    {
+        $addedBlobs = [];
+        foreach ($originalFiles as $filename => $contents) {
+            // if the file didn't originally exist, no blob needed
+            if (!file_exists($originalFilesRoot.'/'.$filename)) {
+                continue;
+            }
+
+            $hash = trim($this->execute('git hash-object '.ProcessExecutor::escape($filename), $originalFilesRoot));
+            $addedBlobs[$hash] = file_get_contents($originalFilesRoot.'/'.$this->getBlobPath($hash));
+        }
+
+        return $addedBlobs;
+    }
+
+    private function getBlobPath(string $hash): string
+    {
+        $hashStart = substr($hash, 0, 2);
+        $hashEnd = substr($hash, 2);
+
+        return '.git/objects/'.$hashStart.'/'.$hashEnd;
+    }
+}

--- a/src/Update/RecipeUpdate.php
+++ b/src/Update/RecipeUpdate.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Update;
+
+use Symfony\Flex\Lock;
+use Symfony\Flex\Recipe;
+
+class RecipeUpdate
+{
+    private $originalRecipe;
+    private $newRecipe;
+    private $lock;
+    private $rootDir;
+
+    /** @var string[] */
+    private $originalRecipeFiles = [];
+    /** @var string[] */
+    private $newRecipeFiles = [];
+    private $copyFromPackagePaths = [];
+
+    public function __construct(Recipe $originalRecipe, Recipe $newRecipe, Lock $lock, string $rootDir)
+    {
+        $this->originalRecipe = $originalRecipe;
+        $this->newRecipe = $newRecipe;
+        $this->lock = $lock;
+        $this->rootDir = $rootDir;
+    }
+
+    public function getOriginalRecipe(): Recipe
+    {
+        return $this->originalRecipe;
+    }
+
+    public function getNewRecipe(): Recipe
+    {
+        return $this->newRecipe;
+    }
+
+    public function getLock(): Lock
+    {
+        return $this->lock;
+    }
+
+    public function getRootDir(): string
+    {
+        return $this->rootDir;
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->originalRecipe->getName();
+    }
+
+    public function setOriginalFile(string $filename, ?string $contents): void
+    {
+        $this->originalRecipeFiles[$filename] = $contents;
+    }
+
+    public function setNewFile(string $filename, ?string $contents): void
+    {
+        $this->newRecipeFiles[$filename] = $contents;
+    }
+
+    public function addOriginalFiles(array $files)
+    {
+        foreach ($files as $file => $contents) {
+            if (null === $contents) {
+                continue;
+            }
+
+            $this->setOriginalFile($file, $contents);
+        }
+    }
+
+    public function addNewFiles(array $files)
+    {
+        foreach ($files as $file => $contents) {
+            if (null === $contents) {
+                continue;
+            }
+
+            $this->setNewFile($file, $contents);
+        }
+    }
+
+    public function getOriginalFiles(): array
+    {
+        return $this->originalRecipeFiles;
+    }
+
+    public function getNewFiles(): array
+    {
+        return $this->newRecipeFiles;
+    }
+
+    public function getCopyFromPackagePaths(): array
+    {
+        return $this->copyFromPackagePaths;
+    }
+
+    public function addCopyFromPackagePath(string $source, string $target)
+    {
+        $this->copyFromPackagePaths[$source] = $target;
+    }
+}

--- a/tests/Command/UpdateRecipesCommandTest.php
+++ b/tests/Command/UpdateRecipesCommandTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests\Command;
+
+use Composer\Factory;
+use Composer\IO\BufferIO;
+use Composer\Plugin\PluginInterface;
+use Composer\Util\Platform;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use Symfony\Flex\Command\UpdateRecipesCommand;
+use Symfony\Flex\Configurator;
+use Symfony\Flex\Downloader;
+use Symfony\Flex\Flex;
+use Symfony\Flex\Options;
+use Symfony\Flex\ParallelDownloader;
+
+class UpdateRecipesCommandTest extends TestCase
+{
+    private $io;
+
+    protected function setUp(): void
+    {
+        if (method_exists(Platform::class, 'putEnv')) {
+            Platform::putEnv('COMPOSER', FLEX_TEST_DIR.'/composer.json');
+        } else {
+            putenv('COMPOSER='.FLEX_TEST_DIR.'/composer.json');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (method_exists(Platform::class, 'clearEnv')) {
+            Platform::clearEnv('COMPOSER');
+        } else {
+            putenv('COMPOSER');
+        }
+
+        $filesystem = new Filesystem();
+        $filesystem->remove(FLEX_TEST_DIR);
+    }
+
+    /**
+     * Skip 7.1, simply because there isn't a newer recipe version available
+     * that we can easily use to assert.
+     *
+     * @requires PHP >= 7.2
+     */
+    public function testCommandUpdatesRecipe()
+    {
+        @mkdir(FLEX_TEST_DIR);
+        (new Process(['git', 'init'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Unit test'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'config', 'user.email', ''], FLEX_TEST_DIR))->mustRun();
+
+        @mkdir(FLEX_TEST_DIR.'/bin');
+
+        // copy in outdated bin/console and symfony.lock set at the recipe it came from
+        file_put_contents(FLEX_TEST_DIR.'/bin/console', file_get_contents(__DIR__.'/../Fixtures/update_recipes/console'));
+        file_put_contents(FLEX_TEST_DIR.'/symfony.lock', file_get_contents(__DIR__.'/../Fixtures/update_recipes/symfony.lock'));
+        file_put_contents(FLEX_TEST_DIR.'/composer.json', file_get_contents(__DIR__.'/../Fixtures/update_recipes/composer.json'));
+
+        (new Process(['git', 'add', '-A'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'commit', '-m', 'setup of original console files'], FLEX_TEST_DIR))->mustRun();
+
+        (new Process([__DIR__.'/../../vendor/bin/composer', 'install'], FLEX_TEST_DIR))->mustRun();
+
+        $command = $this->createCommandUpdateRecipes();
+        $command->execute(['package' => 'symfony/console']);
+
+        $this->assertSame(0, $command->getStatusCode());
+        $this->assertStringContainsString('Recipe updated', $this->io->getOutput());
+        // assert bin/console has changed
+        $this->assertStringNotContainsString('vendor/autoload.php', file_get_contents(FLEX_TEST_DIR.'/bin/console'));
+        // assert the recipe was updated
+        $this->assertStringNotContainsString('c6d02bdfba9da13c22157520e32a602dbee8a75c', file_get_contents(FLEX_TEST_DIR.'/symfony.lock'));
+    }
+
+    private function createCommandUpdateRecipes(): CommandTester
+    {
+        $this->io = new BufferIO();
+        $composer = (new Factory())->createComposer($this->io, null, false, FLEX_TEST_DIR);
+        $flex = new Flex();
+        $flex->activate($composer, $this->io);
+        if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '<=')) {
+            $rfs = Factory::createHttpDownloader($this->io, $composer->getConfig());
+        } else {
+            $rfs = Factory::createRemoteFilesystem($this->io, $composer->getConfig());
+            $rfs = new ParallelDownloader($this->io, $composer->getConfig(), $rfs->getOptions(), $rfs->isTlsDisabled());
+        }
+        $options = new Options(['root-dir' => FLEX_TEST_DIR]);
+        $command = new UpdateRecipesCommand(
+            $flex,
+            new Downloader($composer, $this->io, $rfs),
+            $rfs,
+            new Configurator($composer, $this->io, $options),
+            FLEX_TEST_DIR
+        );
+        $command->setIO($this->io);
+        $command->setComposer($composer);
+
+        $application = new Application();
+        $application->add($command);
+        $command = $application->find('recipes:update');
+
+        return new CommandTester($command);
+    }
+}

--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Flex\Tests\Configurator;
 
+use Composer\Composer;
+use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Flex\Configurator\BundlesConfigurator;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
 
 class BundlesConfiguratorTest extends TestCase
 {
@@ -24,8 +27,8 @@ class BundlesConfiguratorTest extends TestCase
         $config = FLEX_TEST_DIR.'/config/bundles.php';
 
         $configurator = new BundlesConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
 
@@ -49,10 +52,9 @@ EOF
         , file_get_contents($config));
     }
 
-    public function testConfigureWhenBundlesAlreayExists()
+    public function testConfigureWhenBundlesAlreadyExists()
     {
-        $config = FLEX_TEST_DIR.'/config/bundles.php';
-        file_put_contents($config, <<<EOF
+        $this->saveBundlesFile(<<<EOF
 <?php
 
 return [
@@ -62,8 +64,8 @@ EOF
         );
 
         $configurator = new BundlesConfigurator(
-            $this->getMockBuilder('Composer\Composer')->getMock(),
-            $this->getMockBuilder('Composer\IO\IOInterface')->getMock(),
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
             new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
         );
 
@@ -84,6 +86,110 @@ return [
 ];
 
 EOF
-        , file_get_contents($config));
+        , file_get_contents(FLEX_TEST_DIR.'/config/bundles.php'));
+    }
+
+    public function testUnconfigure()
+    {
+        $this->saveBundlesFile(<<<EOF
+<?php
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    BarBundle::class => ['prod' => false, 'all' => true],
+    OtherBundle::class => ['all' => true],
+];
+EOF
+        );
+
+        $configurator = new BundlesConfigurator(
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipe = $this->createMock(Recipe::class);
+        $lock = $this->createMock(Lock::class);
+
+        $configurator->unconfigure($recipe, [
+            'BarBundle' => ['dev', 'all'],
+        ], $lock);
+        $this->assertEquals(<<<EOF
+<?php
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    OtherBundle::class => ['all' => true],
+];
+
+EOF
+        , file_get_contents(FLEX_TEST_DIR.'/config/bundles.php'));
+    }
+
+    public function testUpdate()
+    {
+        $configurator = new BundlesConfigurator(
+            $this->createMock(Composer::class),
+            $this->createMock(IOInterface::class),
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipeUpdate = new RecipeUpdate(
+            $this->createMock(Recipe::class),
+            $this->createMock(Recipe::class),
+            $this->createMock(Lock::class),
+            FLEX_TEST_DIR
+        );
+
+        $this->saveBundlesFile(<<<EOF
+<?php
+
+return [
+    BarBundle::class => ['prod' => false, 'all' => true],
+    FooBundle::class => ['dev' => true, 'test' => true],
+    BazBundle::class => ['all' => true],
+];
+EOF
+        );
+
+        $configurator->update(
+            $recipeUpdate,
+            ['FooBundle' => ['dev', 'test']],
+            ['FooBundle' => ['all'], 'NewBundle' => ['all']]
+        );
+
+        $this->assertSame(['config/bundles.php' => <<<EOF
+<?php
+
+return [
+    BarBundle::class => ['prod' => false, 'all' => true],
+    FooBundle::class => ['dev' => true, 'test' => true],
+    BazBundle::class => ['all' => true],
+];
+
+EOF
+        ], $recipeUpdate->getOriginalFiles());
+
+        $this->assertSame(['config/bundles.php' => <<<EOF
+<?php
+
+return [
+    BarBundle::class => ['prod' => false, 'all' => true],
+    FooBundle::class => ['all' => true],
+    BazBundle::class => ['all' => true],
+    NewBundle::class => ['all' => true],
+];
+
+EOF
+        ], $recipeUpdate->getNewFiles());
+    }
+
+    private function saveBundlesFile(string $contents)
+    {
+        $config = FLEX_TEST_DIR.'/config/bundles.php';
+        if (!file_exists(\dirname($config))) {
+            @mkdir(\dirname($config), 0777, true);
+        }
+        file_put_contents($config, $contents);
     }
 }

--- a/tests/Configurator/ComposerScriptsConfiguratorTest.php
+++ b/tests/Configurator/ComposerScriptsConfiguratorTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests\Configurator;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Util\Platform;
+use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Configurator\ComposerScriptsConfigurator;
+use Symfony\Flex\Lock;
+use Symfony\Flex\Options;
+use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
+
+class ComposerScriptsConfiguratorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        @mkdir(FLEX_TEST_DIR);
+        if (method_exists(Platform::class, 'putEnv')) {
+            Platform::putEnv('COMPOSER', FLEX_TEST_DIR.'/composer.json');
+        } else {
+            putenv('COMPOSER='.FLEX_TEST_DIR.'/composer.json');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink(FLEX_TEST_DIR.'/composer.json');
+        @rmdir(FLEX_TEST_DIR);
+        if (method_exists(Platform::class, 'clearEnv')) {
+            Platform::clearEnv('COMPOSER');
+        } else {
+            putenv('COMPOSER');
+        }
+    }
+
+    public function testConfigure()
+    {
+        file_put_contents(FLEX_TEST_DIR.'/composer.json', json_encode([
+            'scripts' => [
+                'auto-scripts' => [
+                    'cache:clear' => 'symfony-cmd',
+                    'assets:install %PUBLIC_DIR%' => 'symfony-cmd',
+                ],
+                'post-install-cmd' => ['@auto-scripts'],
+                'post-update-cmd' => ['@auto-scripts'],
+            ],
+        ], \JSON_PRETTY_PRINT));
+
+        $configurator = new ComposerScriptsConfigurator(
+            $this->createMock(Composer::class),
+            $this->createMock(IOInterface::class),
+            new Options(['root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+
+        $configurator->configure($recipe, [
+            'do:cool-stuff' => 'symfony-cmd',
+        ], $lock);
+        $this->assertEquals(<<<EOF
+{
+    "scripts": {
+        "auto-scripts": {
+            "cache:clear": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd",
+            "do:cool-stuff": "symfony-cmd"
+        },
+        "post-install-cmd": [
+            "@auto-scripts"
+        ],
+        "post-update-cmd": [
+            "@auto-scripts"
+        ]
+    }
+}
+
+EOF
+            , file_get_contents(FLEX_TEST_DIR.'/composer.json')
+        );
+    }
+
+    public function testUnconfigure()
+    {
+        file_put_contents(FLEX_TEST_DIR.'/composer.json', json_encode([
+            'scripts' => [
+                'auto-scripts' => [
+                    'cache:clear' => 'symfony-cmd',
+                    'assets:install %PUBLIC_DIR%' => 'symfony-cmd',
+                ],
+                'post-install-cmd' => ['@auto-scripts'],
+                'post-update-cmd' => ['@auto-scripts'],
+            ],
+        ], \JSON_PRETTY_PRINT));
+
+        $configurator = new ComposerScriptsConfigurator(
+            $this->createMock(Composer::class),
+            $this->createMock(IOInterface::class),
+            new Options(['root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipe = $this->createMock(Recipe::class);
+        $lock = $this->createMock(Lock::class);
+
+        $configurator->unconfigure($recipe, [
+            'do:cool-stuff' => 'symfony-cmd',
+            'cache:clear' => 'symfony-cmd',
+        ], $lock);
+        $this->assertEquals(<<<EOF
+{
+    "scripts": {
+        "auto-scripts": {
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+        },
+        "post-install-cmd": [
+            "@auto-scripts"
+        ],
+        "post-update-cmd": [
+            "@auto-scripts"
+        ]
+    }
+}
+
+EOF
+            , file_get_contents(FLEX_TEST_DIR.'/composer.json')
+        );
+    }
+
+    public function testUpdate()
+    {
+        $configurator = new ComposerScriptsConfigurator(
+            $this->createMock(Composer::class),
+            $this->createMock(IOInterface::class),
+            new Options(['root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipeUpdate = new RecipeUpdate(
+            $this->createMock(Recipe::class),
+            $this->createMock(Recipe::class),
+            $this->createMock(Lock::class),
+            FLEX_TEST_DIR
+        );
+
+        file_put_contents(FLEX_TEST_DIR.'/composer.json', json_encode([
+            'scripts' => [
+                'auto-scripts' => [
+                    'cache:clear' => 'symfony-cmd',
+                    'assets:install %PUBLIC_DIR%' => 'symfony-cmd',
+                ],
+                'post-install-cmd' => ['@auto-scripts'],
+                'post-update-cmd' => ['@auto-scripts'],
+            ],
+        ], \JSON_PRETTY_PRINT));
+
+        $configurator->update(
+            $recipeUpdate,
+            ['cache:clear' => 'symfony-cmd'],
+            ['cache:clear' => 'other-cmd', 'do:cool-stuff' => 'symfony-cmd']
+        );
+
+        $expectedComposerJsonOriginal = <<<EOF
+{
+    "scripts": {
+        "auto-scripts": {
+            "cache:clear": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+        },
+        "post-install-cmd": [
+            "@auto-scripts"
+        ],
+        "post-update-cmd": [
+            "@auto-scripts"
+        ]
+    }
+}
+
+EOF
+        ;
+        $this->assertSame(['composer.json' => $expectedComposerJsonOriginal], $recipeUpdate->getOriginalFiles());
+
+        $expectedComposerJsonNew = <<<EOF
+{
+    "scripts": {
+        "auto-scripts": {
+            "cache:clear": "other-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd",
+            "do:cool-stuff": "symfony-cmd"
+        },
+        "post-install-cmd": [
+            "@auto-scripts"
+        ],
+        "post-update-cmd": [
+            "@auto-scripts"
+        ]
+    }
+}
+
+EOF
+        ;
+        $this->assertSame(['composer.json' => $expectedComposerJsonNew], $recipeUpdate->getNewFiles());
+    }
+}

--- a/tests/Configurator/CopyFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyFromPackageConfiguratorTest.php
@@ -73,8 +73,7 @@ class CopyFromPackageConfiguratorTest extends TestCase
 
     public function testSourceFileNotExist()
     {
-        $this->io->expects($this->at(0))->method('writeError')->with(['    Copying files from package']);
-        $this->io->expects($this->at(1))->method('writeError')->with(['      Created <fg=green>"./public/"</>']);
+        $this->io->expects($this->once())->method('writeError')->with(['    Copying files from package']);
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(sprintf('File "%s" does not exist!', $this->sourceFile));
         $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();

--- a/tests/Fixtures/update_recipes/composer.json
+++ b/tests/Fixtures/update_recipes/composer.json
@@ -1,0 +1,13 @@
+{
+    "type": "project",
+    "license": "proprietary",
+    "require": {
+        "php": ">=7.1",
+        "symfony/console": "5.4.*"
+    },
+    "config": {
+        "allow-plugins": {
+            "symfony/flex": true
+        }
+    }
+}

--- a/tests/Fixtures/update_recipes/console
+++ b/tests/Fixtures/update_recipes/console
@@ -1,0 +1,43 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\Debug;
+
+if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
+}
+
+set_time_limit(0);
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (!class_exists(Application::class) || !class_exists(Dotenv::class)) {
+    throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
+}
+
+$input = new ArgvInput();
+if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
+    putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
+}
+
+if ($input->hasParameterOption('--no-debug', true)) {
+    putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+}
+
+(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+
+    if (class_exists(Debug::class)) {
+        Debug::enable();
+    }
+}
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$application = new Application($kernel);
+$application->run($input);

--- a/tests/Fixtures/update_recipes/symfony.lock
+++ b/tests/Fixtures/update_recipes/symfony.lock
@@ -1,0 +1,14 @@
+{
+    "symfony/console": {
+        "version": "5.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "5.1",
+            "ref": "c6d02bdfba9da13c22157520e32a602dbee8a75c"
+        },
+        "files": [
+            "bin/console"
+        ]
+    }
+}

--- a/tests/Update/DiffHelperTest.php
+++ b/tests/Update/DiffHelperTest.php
@@ -1,0 +1,331 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests\Update;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Update\DiffHelper;
+
+class DiffHelperTest extends TestCase
+{
+    /**
+     * @dataProvider getRemoveFilesFromPatchTests
+     */
+    public function testRemoveFilesFromPatch(string $patch, array $filesToRemove, string $expectedPatch, array $expectedRemovedPatches)
+    {
+        $removedPatches = [];
+        $this->assertSame($expectedPatch, DiffHelper::removeFilesFromPatch($patch, $filesToRemove, $removedPatches));
+
+        $this->assertSame($expectedRemovedPatches, $removedPatches);
+    }
+
+    public function getRemoveFilesFromPatchTests(): iterable
+    {
+        $patch = <<<EOF
+diff --git a/.env b/.env
+index ea34452..daaeb63 100644
+--- a/.env
++++ b/.env
+@@ -24,8 +24,9 @@ APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+
+-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+-# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+ # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+diff --git a/config/packages/doctrine.yaml b/config/packages/doctrine.yaml
+index 5e80e77..c319176 100644
+--- a/config/packages/doctrine.yaml
++++ b/config/packages/doctrine.yaml
+@@ -4,7 +4,7 @@ doctrine:
+         # either here or in the DATABASE_URL env var (see .env file)
+-        #server_version: '5.7'
++        #server_version: '13'
+     orm:
+         auto_generate_proxy_classes: true
+diff --git a/config/packages/prod/doctrine.yaml b/config/packages/prod/doctrine.yaml
+index 8ae31a3..17299e2 100644
+--- a/config/packages/prod/doctrine.yaml
++++ b/config/packages/prod/doctrine.yaml
+@@ -1,16 +1,13 @@
+         auto_generate_proxy_classes: false
+-        metadata_cache_driver:
+-            type: pool
+-            pool: doctrine.system_cache_pool
+         query_cache_driver:
+diff --git a/config/packages/test/doctrine.yaml b/config/packages/test/doctrine.yaml
+new file mode 100644
+index 0000000..34c2ebc
+--- /dev/null
++++ b/config/packages/test/doctrine.yaml
+@@ -0,0 +1,4 @@
++doctrine:
++    dbal:
++        # "TEST_TOKEN" is typically set by ParaTest
++        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+EOF;
+
+        yield 'remove_first_file' => [
+            $patch,
+            ['.env'],
+            <<<EOF
+diff --git a/config/packages/doctrine.yaml b/config/packages/doctrine.yaml
+index 5e80e77..c319176 100644
+--- a/config/packages/doctrine.yaml
++++ b/config/packages/doctrine.yaml
+@@ -4,7 +4,7 @@ doctrine:
+         # either here or in the DATABASE_URL env var (see .env file)
+-        #server_version: '5.7'
++        #server_version: '13'
+     orm:
+         auto_generate_proxy_classes: true
+diff --git a/config/packages/prod/doctrine.yaml b/config/packages/prod/doctrine.yaml
+index 8ae31a3..17299e2 100644
+--- a/config/packages/prod/doctrine.yaml
++++ b/config/packages/prod/doctrine.yaml
+@@ -1,16 +1,13 @@
+         auto_generate_proxy_classes: false
+-        metadata_cache_driver:
+-            type: pool
+-            pool: doctrine.system_cache_pool
+         query_cache_driver:
+diff --git a/config/packages/test/doctrine.yaml b/config/packages/test/doctrine.yaml
+new file mode 100644
+index 0000000..34c2ebc
+--- /dev/null
++++ b/config/packages/test/doctrine.yaml
+@@ -0,0 +1,4 @@
++doctrine:
++    dbal:
++        # "TEST_TOKEN" is typically set by ParaTest
++        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+EOF
+            , [
+                '.env' => <<<EOF
+diff --git a/.env b/.env
+index ea34452..daaeb63 100644
+--- a/.env
++++ b/.env
+@@ -24,8 +24,9 @@ APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+
+-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+-# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+ # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+EOF
+            ],
+        ];
+
+        yield 'remove_middle_file' => [
+            $patch,
+            ['config/packages/doctrine.yaml'],
+            <<<EOF
+diff --git a/.env b/.env
+index ea34452..daaeb63 100644
+--- a/.env
++++ b/.env
+@@ -24,8 +24,9 @@ APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+
+-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+-# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+ # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+diff --git a/config/packages/prod/doctrine.yaml b/config/packages/prod/doctrine.yaml
+index 8ae31a3..17299e2 100644
+--- a/config/packages/prod/doctrine.yaml
++++ b/config/packages/prod/doctrine.yaml
+@@ -1,16 +1,13 @@
+         auto_generate_proxy_classes: false
+-        metadata_cache_driver:
+-            type: pool
+-            pool: doctrine.system_cache_pool
+         query_cache_driver:
+diff --git a/config/packages/test/doctrine.yaml b/config/packages/test/doctrine.yaml
+new file mode 100644
+index 0000000..34c2ebc
+--- /dev/null
++++ b/config/packages/test/doctrine.yaml
+@@ -0,0 +1,4 @@
++doctrine:
++    dbal:
++        # "TEST_TOKEN" is typically set by ParaTest
++        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+EOF
+            , [
+                'config/packages/doctrine.yaml' => <<<EOF
+diff --git a/config/packages/doctrine.yaml b/config/packages/doctrine.yaml
+index 5e80e77..c319176 100644
+--- a/config/packages/doctrine.yaml
++++ b/config/packages/doctrine.yaml
+@@ -4,7 +4,7 @@ doctrine:
+         # either here or in the DATABASE_URL env var (see .env file)
+-        #server_version: '5.7'
++        #server_version: '13'
+     orm:
+         auto_generate_proxy_classes: true
+EOF
+            ],
+        ];
+
+        yield 'remove_last_file' => [
+            $patch,
+            ['config/packages/test/doctrine.yaml'],
+            <<<EOF
+diff --git a/.env b/.env
+index ea34452..daaeb63 100644
+--- a/.env
++++ b/.env
+@@ -24,8 +24,9 @@ APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+
+-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+-# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+ # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+diff --git a/config/packages/doctrine.yaml b/config/packages/doctrine.yaml
+index 5e80e77..c319176 100644
+--- a/config/packages/doctrine.yaml
++++ b/config/packages/doctrine.yaml
+@@ -4,7 +4,7 @@ doctrine:
+         # either here or in the DATABASE_URL env var (see .env file)
+-        #server_version: '5.7'
++        #server_version: '13'
+     orm:
+         auto_generate_proxy_classes: true
+diff --git a/config/packages/prod/doctrine.yaml b/config/packages/prod/doctrine.yaml
+index 8ae31a3..17299e2 100644
+--- a/config/packages/prod/doctrine.yaml
++++ b/config/packages/prod/doctrine.yaml
+@@ -1,16 +1,13 @@
+         auto_generate_proxy_classes: false
+-        metadata_cache_driver:
+-            type: pool
+-            pool: doctrine.system_cache_pool
+         query_cache_driver:
+EOF
+            , [
+                'config/packages/test/doctrine.yaml' => <<<EOF
+diff --git a/config/packages/test/doctrine.yaml b/config/packages/test/doctrine.yaml
+new file mode 100644
+index 0000000..34c2ebc
+--- /dev/null
++++ b/config/packages/test/doctrine.yaml
+@@ -0,0 +1,4 @@
++doctrine:
++    dbal:
++        # "TEST_TOKEN" is typically set by ParaTest
++        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+EOF
+            ],
+        ];
+
+        yield 'remove_multiple_files' => [
+            $patch,
+            ['config/packages/test/doctrine.yaml', 'config/packages/doctrine.yaml'],
+            <<<EOF
+diff --git a/.env b/.env
+index ea34452..daaeb63 100644
+--- a/.env
++++ b/.env
+@@ -24,8 +24,9 @@ APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+
+-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+-# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+ # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+diff --git a/config/packages/prod/doctrine.yaml b/config/packages/prod/doctrine.yaml
+index 8ae31a3..17299e2 100644
+--- a/config/packages/prod/doctrine.yaml
++++ b/config/packages/prod/doctrine.yaml
+@@ -1,16 +1,13 @@
+         auto_generate_proxy_classes: false
+-        metadata_cache_driver:
+-            type: pool
+-            pool: doctrine.system_cache_pool
+         query_cache_driver:
+EOF
+            , [
+                'config/packages/test/doctrine.yaml' => <<<EOF
+diff --git a/config/packages/test/doctrine.yaml b/config/packages/test/doctrine.yaml
+new file mode 100644
+index 0000000..34c2ebc
+--- /dev/null
++++ b/config/packages/test/doctrine.yaml
+@@ -0,0 +1,4 @@
++doctrine:
++    dbal:
++        # "TEST_TOKEN" is typically set by ParaTest
++        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+EOF
+                , 'config/packages/doctrine.yaml' => <<<EOF
+diff --git a/config/packages/doctrine.yaml b/config/packages/doctrine.yaml
+index 5e80e77..c319176 100644
+--- a/config/packages/doctrine.yaml
++++ b/config/packages/doctrine.yaml
+@@ -4,7 +4,7 @@ doctrine:
+         # either here or in the DATABASE_URL env var (see .env file)
+-        #server_version: '5.7'
++        #server_version: '13'
+     orm:
+         auto_generate_proxy_classes: true
+EOF
+            ],
+        ];
+
+        yield 'remove_everything' => [
+            $patch,
+            ['config/packages/test/doctrine.yaml', 'config/packages/doctrine.yaml', '.env', 'config/packages/prod/doctrine.yaml'],
+            '',
+            [
+                'config/packages/test/doctrine.yaml' => <<<EOF
+diff --git a/config/packages/test/doctrine.yaml b/config/packages/test/doctrine.yaml
+new file mode 100644
+index 0000000..34c2ebc
+--- /dev/null
++++ b/config/packages/test/doctrine.yaml
+@@ -0,0 +1,4 @@
++doctrine:
++    dbal:
++        # "TEST_TOKEN" is typically set by ParaTest
++        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+EOF
+                , 'config/packages/doctrine.yaml' => <<<EOF
+diff --git a/config/packages/doctrine.yaml b/config/packages/doctrine.yaml
+index 5e80e77..c319176 100644
+--- a/config/packages/doctrine.yaml
++++ b/config/packages/doctrine.yaml
+@@ -4,7 +4,7 @@ doctrine:
+         # either here or in the DATABASE_URL env var (see .env file)
+-        #server_version: '5.7'
++        #server_version: '13'
+     orm:
+         auto_generate_proxy_classes: true
+EOF
+                , '.env' => <<<EOF
+diff --git a/.env b/.env
+index ea34452..daaeb63 100644
+--- a/.env
++++ b/.env
+@@ -24,8 +24,9 @@ APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+
+-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+-# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+ # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+EOF
+                , 'config/packages/prod/doctrine.yaml' => <<<EOF
+diff --git a/config/packages/prod/doctrine.yaml b/config/packages/prod/doctrine.yaml
+index 8ae31a3..17299e2 100644
+--- a/config/packages/prod/doctrine.yaml
++++ b/config/packages/prod/doctrine.yaml
+@@ -1,16 +1,13 @@
+         auto_generate_proxy_classes: false
+-        metadata_cache_driver:
+-            type: pool
+-            pool: doctrine.system_cache_pool
+         query_cache_driver:
+EOF
+            ],
+        ];
+    }
+}

--- a/tests/Update/RecipePatchTest.php
+++ b/tests/Update/RecipePatchTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests\Update;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Update\RecipePatch;
+
+class RecipePatchTest extends TestCase
+{
+    public function testBasicFunctioning()
+    {
+        $thePatch = 'the patch';
+        $blobs = ['blob1', 'blob2', 'beware of the blob'];
+        $removedPatches = ['foo' => 'some diff'];
+
+        $patch = new RecipePatch($thePatch, $blobs, $removedPatches);
+
+        $this->assertSame($thePatch, $patch->getPatch());
+        $this->assertSame($blobs, $patch->getBlobs());
+        $this->assertSame($removedPatches, $patch->getRemovedPatches());
+    }
+}

--- a/tests/Update/RecipePatcherTest.php
+++ b/tests/Update/RecipePatcherTest.php
@@ -1,0 +1,593 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests\Update;
+
+use Composer\IO\IOInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use Symfony\Flex\Update\RecipePatch;
+use Symfony\Flex\Update\RecipePatcher;
+
+class RecipePatcherTest extends TestCase
+{
+    private $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->getFilesystem()->remove(FLEX_TEST_DIR);
+        $this->getFilesystem()->mkdir(FLEX_TEST_DIR);
+    }
+
+    /**
+     * @dataProvider getGeneratePatchTests
+     */
+    public function testGeneratePatch(array $originalFiles, array $newFiles, string $expectedPatch)
+    {
+        $this->getFilesystem()->remove(FLEX_TEST_DIR);
+        $this->getFilesystem()->mkdir(FLEX_TEST_DIR);
+        // original files need to be present to avoid patcher thinking they were deleting and skipping patch
+        foreach ($originalFiles as $file => $contents) {
+            touch(FLEX_TEST_DIR.'/'.$file);
+        }
+
+        $patcher = new RecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
+
+        $patch = $patcher->generatePatch($originalFiles, $newFiles);
+        $this->assertSame($expectedPatch, rtrim($patch->getPatch(), "\n"));
+
+        // find all "index 7d30dc7.." in patch
+        $matches = [];
+        preg_match_all('/index\ ([0-9|a-z]+)\.\./', $patch->getPatch(), $matches);
+        $expectedBlobs = $matches[1];
+        // new files (0000000) do not need a blob
+        $expectedBlobs = array_values(array_filter($expectedBlobs, function ($blob) {
+            return '0000000' !== $blob;
+        }));
+
+        $actualShortenedBlobs = array_map(function ($blob) {
+            return substr($blob, 0, 7);
+        }, array_keys($patch->getBlobs()));
+
+        $this->assertSame($expectedBlobs, $actualShortenedBlobs);
+    }
+
+    public function getGeneratePatchTests(): iterable
+    {
+        yield 'updated_file' => [
+            ['file1.txt' => 'Original contents', 'file2.txt' => 'Original file2'],
+            ['file1.txt' => 'Updated contents', 'file2.txt' => 'Updated file2'],
+            <<<EOF
+diff --git a/file1.txt b/file1.txt
+index 7d30dc7..1a78767 100644
+--- a/file1.txt
++++ b/file1.txt
+@@ -1 +1 @@
+-Original contents
+\ No newline at end of file
++Updated contents
+\ No newline at end of file
+diff --git a/file2.txt b/file2.txt
+index b3b20af..4e66429 100644
+--- a/file2.txt
++++ b/file2.txt
+@@ -1 +1 @@
+-Original file2
+\ No newline at end of file
++Updated file2
+\ No newline at end of file
+EOF
+        ];
+
+        yield 'file_created_in_update_because_missing' => [
+            [],
+            ['file1.txt' => 'New file'],
+            <<<EOF
+diff --git a/file1.txt b/file1.txt
+new file mode 100644
+index 0000000..b78ca63
+--- /dev/null
++++ b/file1.txt
+@@ -0,0 +1 @@
++New file
+\ No newline at end of file
+EOF
+        ];
+
+        yield 'file_created_in_update_because_null' => [
+            ['file1.txt' => null],
+            ['file1.txt' => 'New file'],
+            <<<EOF
+diff --git a/file1.txt b/file1.txt
+new file mode 100644
+index 0000000..b78ca63
+--- /dev/null
++++ b/file1.txt
+@@ -0,0 +1 @@
++New file
+\ No newline at end of file
+EOF
+        ];
+
+        yield 'file_deleted_in_update_because_missing' => [
+            ['file1.txt' => 'New file'],
+            [],
+            <<<EOF
+diff --git a/file1.txt b/file1.txt
+deleted file mode 100644
+index b78ca63..0000000
+--- a/file1.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-New file
+\ No newline at end of file
+EOF
+        ];
+
+        yield 'file_deleted_in_update_because_null' => [
+            ['file1.txt' => 'New file'],
+            ['file1.txt' => null],
+            <<<EOF
+diff --git a/file1.txt b/file1.txt
+deleted file mode 100644
+index b78ca63..0000000
+--- a/file1.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-New file
+\ No newline at end of file
+EOF
+        ];
+
+        yield 'mixture_of_added_updated_removed' => [
+            ['file1.txt' => 'Original file1', 'will_be_deleted.txt' => 'file to delete'],
+            ['file1.txt' => 'Updated file1', 'will_be_created.text' => 'file to create'],
+            <<<EOF
+diff --git a/file1.txt b/file1.txt
+index aed3283..cdbcdc0 100644
+--- a/file1.txt
++++ b/file1.txt
+@@ -1 +1 @@
+-Original file1
+\ No newline at end of file
++Updated file1
+\ No newline at end of file
+diff --git a/will_be_created.text b/will_be_created.text
+new file mode 100644
+index 0000000..f5074b6
+--- /dev/null
++++ b/will_be_created.text
+@@ -0,0 +1 @@
++file to create
+\ No newline at end of file
+diff --git a/will_be_deleted.txt b/will_be_deleted.txt
+deleted file mode 100644
+index 98ff166..0000000
+--- a/will_be_deleted.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-file to delete
+\ No newline at end of file
+EOF
+        ];
+    }
+
+    public function testGeneratePatchOnDeletedFile()
+    {
+        // make sure the target directory is empty
+        $this->getFilesystem()->remove(FLEX_TEST_DIR);
+        $this->getFilesystem()->mkdir(FLEX_TEST_DIR);
+
+        $patcher = new RecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
+
+        // try to update a file that does not exist in the project
+        $patch = $patcher->generatePatch(['.env' => 'original contents'], ['.env' => 'new contents']);
+        $this->assertSame('', $patch->getPatch());
+    }
+
+    /**
+     * @dataProvider getApplyPatchTests
+     */
+    public function testApplyPatch(array $filesCurrentlyInApp, RecipePatch $recipePatch, array $expectedFiles, bool $expectedConflicts)
+    {
+        (new Process(['git', 'init'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Unit test'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'config', 'user.email', ''], FLEX_TEST_DIR))->mustRun();
+
+        foreach ($filesCurrentlyInApp as $file => $contents) {
+            $path = FLEX_TEST_DIR.'/'.$file;
+            if (!file_exists(\dirname($path))) {
+                @mkdir(\dirname($path), 0777, true);
+            }
+            file_put_contents($path, $contents);
+        }
+        if (\count($filesCurrentlyInApp) > 0) {
+            (new Process(['git', 'add', '-A'], FLEX_TEST_DIR))->mustRun();
+            (new Process(['git', 'commit', '-m', 'Committing original files'], FLEX_TEST_DIR))->mustRun();
+        }
+
+        $patcher = new RecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
+        $hadConflicts = !$patcher->applyPatch($recipePatch);
+
+        foreach ($expectedFiles as $file => $expectedContents) {
+            if (null === $expectedContents) {
+                $this->assertFileDoesNotExist(FLEX_TEST_DIR.'/'.$file);
+
+                continue;
+            }
+            $this->assertFileExists(FLEX_TEST_DIR.'/'.$file);
+            $this->assertSame($expectedContents, file_get_contents(FLEX_TEST_DIR.'/'.$file));
+        }
+
+        $this->assertSame($expectedConflicts, $hadConflicts);
+    }
+
+    public function getApplyPatchTests(): iterable
+    {
+        $files = $this->getFilesForPatching();
+        $dotEnvClean = $files['dot_env_clean'];
+        $packageJsonConflict = $files['package_json_conflict'];
+        $webpackEncoreAdded = $files['webpack_encore_added'];
+        $securityRemoved = $files['security_removed'];
+
+        yield 'cleanly_patch_one_file' => [
+            ['.env' => $dotEnvClean['in_app']],
+            new RecipePatch(
+                $dotEnvClean['patch'],
+                [$dotEnvClean['hash'] => $dotEnvClean['blob']]
+            ),
+            ['.env' => $dotEnvClean['expected']],
+            false,
+        ];
+
+        yield 'conflict_on_one_file' => [
+            ['package.json' => $packageJsonConflict['in_app']],
+            new RecipePatch(
+                $packageJsonConflict['patch'],
+                [$packageJsonConflict['hash'] => $packageJsonConflict['blob']]
+            ),
+            ['package.json' => $packageJsonConflict['expected']],
+            true,
+        ];
+
+        yield 'add_one_new_file' => [
+            // file is not currently in the app
+            [],
+            new RecipePatch(
+                $webpackEncoreAdded['patch'],
+                // no blobs needed for a new file
+                []
+            ),
+            ['config/packages/webpack_encore.yaml' => $webpackEncoreAdded['expected']],
+            false,
+        ];
+
+        yield 'removed_one_file' => [
+            ['config/packages/security.yaml' => $securityRemoved['in_app']],
+            new RecipePatch(
+                $securityRemoved['patch'],
+                [$securityRemoved['hash'] => $securityRemoved['blob']]
+            ),
+            // expected to be deleted
+            ['config/packages/security.yaml' => null],
+            false,
+        ];
+
+        yield 'complex_mixture' => [
+            [
+                '.env' => $dotEnvClean['in_app'],
+                'package.json' => $packageJsonConflict['in_app'],
+                // webpack_encore.yaml not in starting project
+                'config/packages/security.yaml' => $securityRemoved['in_app'],
+            ],
+            new RecipePatch(
+                $dotEnvClean['patch']."\n".$packageJsonConflict['patch']."\n".$webpackEncoreAdded['patch']."\n".$securityRemoved['patch'],
+                [
+                    $dotEnvClean['hash'] => $dotEnvClean['blob'],
+                    $packageJsonConflict['hash'] => $packageJsonConflict['blob'],
+                    $webpackEncoreAdded['hash'] => $webpackEncoreAdded['blob'],
+                    $securityRemoved['hash'] => $securityRemoved['blob'],
+                ]
+            ),
+            [
+                '.env' => $dotEnvClean['expected'],
+                'package.json' => $packageJsonConflict['expected'],
+                'config/packages/webpack_encore.yaml' => $webpackEncoreAdded['expected'],
+                'config/packages/security.yaml' => null,
+            ],
+            true,
+        ];
+    }
+
+    /**
+     * @dataProvider getIntegrationTests
+     */
+    public function testIntegration(bool $useNullForMissingFiles)
+    {
+        $files = $this->getFilesForPatching();
+        (new Process(['git', 'init'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Unit test'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'config', 'user.email', ''], FLEX_TEST_DIR))->mustRun();
+
+        $startingFiles = [
+            '.env' => $files['dot_env_clean']['in_app'],
+            'package.json' => $files['package_json_conflict']['in_app'],
+            // no webpack_encore.yaml in app
+            'config/packages/security.yaml' => $files['security_removed']['in_app'],
+            // no cache.yaml in app - the update patch will be skipped
+        ];
+        foreach ($startingFiles as $file => $contents) {
+            if (!file_exists(\dirname(FLEX_TEST_DIR.'/'.$file))) {
+                @mkdir(\dirname(FLEX_TEST_DIR.'/'.$file), 0777, true);
+            }
+
+            file_put_contents(FLEX_TEST_DIR.'/'.$file, $contents);
+        }
+        // commit the files in the app
+        (new Process(['git', 'add', '-A'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'commit', '-m', 'committing in app start files'], FLEX_TEST_DIR))->mustRun();
+
+        $patcher = new RecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
+        $originalFiles = [
+            '.env' => $files['dot_env_clean']['original_recipe'],
+            'package.json' => $files['package_json_conflict']['original_recipe'],
+            'config/packages/security.yaml' => $files['security_removed']['original_recipe'],
+            'config/packages/cache.yaml' => 'original cache.yaml',
+        ];
+        if ($useNullForMissingFiles) {
+            $originalFiles['config/packages/webpack_encore.yaml'] = null;
+        }
+
+        $updatedFiles = [
+            '.env' => $files['dot_env_clean']['updated_recipe'],
+            'package.json' => $files['package_json_conflict']['updated_recipe'],
+            'config/packages/webpack_encore.yaml' => $files['webpack_encore_added']['updated_recipe'],
+            'config/packages/cache.yaml' => 'updated cache.yaml',
+        ];
+        if ($useNullForMissingFiles) {
+            $updatedFiles['config/packages/security.yaml'] = null;
+        }
+
+        $recipePatch = $patcher->generatePatch($originalFiles, $updatedFiles);
+        $appliedCleanly = $patcher->applyPatch($recipePatch);
+
+        $this->assertFalse($appliedCleanly);
+        $this->assertSame($files['dot_env_clean']['expected'], file_get_contents(FLEX_TEST_DIR.'/.env'));
+        $this->assertSame($files['package_json_conflict']['expected'], file_get_contents(FLEX_TEST_DIR.'/package.json'));
+        $this->assertSame($files['webpack_encore_added']['expected'], file_get_contents(FLEX_TEST_DIR.'/config/packages/webpack_encore.yaml'));
+        $this->assertFileDoesNotExist(FLEX_TEST_DIR.'/security.yaml');
+    }
+
+    public function getIntegrationTests(): iterable
+    {
+        yield 'missing_files_set_to_null' => [true];
+        yield 'missing_files_not_in_array' => [false];
+    }
+
+    /**
+     * Returns files with keys:
+     *      * filename
+     *      * in_app:   Contents the file currently has in the app
+     *      * patch     The diff/patch to apply to the file
+     *      * expected  The expected final contents
+     *      * hash      hash-object used for the blob address
+     *      * blob      The raw file blob of the original recipe contents
+     *      * original_recipe
+     *      * updated_recipe.
+     */
+    private function getFilesForPatching(): array
+    {
+        $files = [
+            // .env
+            'dot_env_clean' => [
+                'filename' => '.env',
+                'original_recipe' => <<<EOF
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+###< symfony/framework-bundle ###
+
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db
+###< doctrine/doctrine-bundle ###
+EOF
+                , 'updated_recipe' => <<<EOF
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+###< symfony/framework-bundle ###
+
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# For an SQL-HEAVY database, use: "sqlheavy:///%kernel.project_dir%/var/data.db"
+DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db
+###< doctrine/doctrine-bundle ###
+EOF
+                , 'in_app' => <<<EOF
+###> symfony/framework-bundle ###
+APP_ENV=CHANGED_TO_PROD_ENVIRONMENT
+APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+###< symfony/framework-bundle ###
+
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db
+###< doctrine/doctrine-bundle ###
+EOF
+                , 'expected' => <<<EOF
+###> symfony/framework-bundle ###
+APP_ENV=CHANGED_TO_PROD_ENVIRONMENT
+APP_SECRET=cd0019c56963e76bacd77eee67e1b222
+###< symfony/framework-bundle ###
+
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# For an SQL-HEAVY database, use: "sqlheavy:///%kernel.project_dir%/var/data.db"
+DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db
+###< doctrine/doctrine-bundle ###
+EOF
+            ],
+
+            // package.json
+            'package_json_conflict' => [
+                'filename' => 'package.json',
+                'original_recipe' => <<<EOF
+{
+    "devDependencies": {
+        "@hotwired/stimulus": "^2.0.0",
+        "@symfony/stimulus-bridge": "^3.0.0",
+        "@symfony/webpack-encore": "^1.4.0"
+    }
+}
+EOF
+                , 'updated_recipe' => <<<EOF
+{
+    "devDependencies": {
+        "@hotwired/stimulus": "^3.0.0",
+        "@symfony/stimulus-bridge": "^3.0.0",
+        "@symfony/webpack-encore": "^1.7.0"
+    }
+}
+EOF
+                , 'in_app' => <<<EOF
+{
+    "devDependencies": {
+        "@hotwired/stimulus": "^2.1.0",
+        "@symfony/stimulus-bridge": "^3.0.0",
+        "@symfony/webpack-encore": "^1.4.0"
+    }
+}
+EOF
+                , 'expected' => <<<EOF
+{
+    "devDependencies": {
+<<<<<<< ours
+        "@hotwired/stimulus": "^2.1.0",
+=======
+        "@hotwired/stimulus": "^3.0.0",
+>>>>>>> theirs
+        "@symfony/stimulus-bridge": "^3.0.0",
+        "@symfony/webpack-encore": "^1.7.0"
+    }
+}
+EOF
+            ],
+
+            // config/packages/webpack_encore.yaml
+            'webpack_encore_added' => [
+                'filename' => 'config/packages/webpack_encore.yaml',
+                'original_recipe' => null,
+                'updated_recipe' => <<<EOF
+webpack_encore:
+    # The path where Encore is building the assets - i.e. Encore.setOutputPath()
+    output_path: '%kernel.project_dir%/public/build'
+    # If multiple builds are defined (as shown below), you can disable the default build:
+    # output_path: false
+EOF
+                , 'in_app' => null,
+                'expected' => <<<EOF
+webpack_encore:
+    # The path where Encore is building the assets - i.e. Encore.setOutputPath()
+    output_path: '%kernel.project_dir%/public/build'
+    # If multiple builds are defined (as shown below), you can disable the default build:
+    # output_path: false
+EOF
+            ],
+
+            // config/packages/security.yaml
+            'security_removed' => [
+                'filename' => 'config/packages/security.yaml',
+                'original_recipe' => <<<EOF
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+EOF
+                , 'updated_recipe' => null,
+                'in_app' => <<<EOF
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+EOF
+                , 'expected' => null,
+            ],
+        ];
+
+        // calculate the patch, hash & blob from the files for convenience
+        // (it's easier than storing those in the test directly)
+        foreach ($files as $key => $data) {
+            $files[$key] = array_merge(
+                $data,
+                $this->generatePatchData($data['filename'], $data['original_recipe'], $data['updated_recipe'])
+            );
+        }
+
+        return $files;
+    }
+
+    private function generatePatchData(string $filename, ?string $start, ?string $end): array
+    {
+        $dir = sys_get_temp_dir().'/_flex_diff';
+        if (file_exists($dir)) {
+            $this->getFilesystem()->remove($dir);
+        }
+        @mkdir($dir);
+        (new Process(['git', 'init'], $dir))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Unit test'], $dir))->mustRun();
+        (new Process(['git', 'config', 'user.email', ''], $dir))->mustRun();
+
+        if (!file_exists(\dirname($dir.'/'.$filename))) {
+            @mkdir(\dirname($dir.'/'.$filename), 0777, true);
+        }
+
+        $hash = null;
+        $blob = null;
+        if (null !== $start) {
+            file_put_contents($dir.'/'.$filename, $start);
+            (new Process(['git', 'add', '-A'], $dir))->mustRun();
+            (new Process(['git', 'commit', '-m', 'adding file'], $dir))->mustRun();
+
+            $process = (new Process(['git', 'hash-object', $filename], $dir))->mustRun();
+            $hash = trim($process->getOutput());
+
+            $hashStart = substr($hash, 0, 2);
+            $hashEnd = substr($hash, 2);
+            $blob = file_get_contents($dir.'/.git/objects/'.$hashStart.'/'.$hashEnd);
+        }
+
+        if (null === $end) {
+            unlink($dir.'/'.$filename);
+        } else {
+            file_put_contents($dir.'/'.$filename, $end);
+        }
+        (new Process(['git', 'add', '-A'], $dir))->mustRun();
+        $process = (new Process(['git', 'diff', '--cached'], $dir))->mustRun();
+        $diff = $process->getOutput();
+
+        return [
+            'patch' => $diff,
+            'hash' => $hash,
+            'blob' => $blob,
+        ];
+    }
+
+    private function getFilesystem(): Filesystem
+    {
+        if (null === $this->filesystem) {
+            $this->filesystem = new Filesystem();
+        }
+
+        return $this->filesystem;
+    }
+}

--- a/tests/Update/RecipeUpdateTest.php
+++ b/tests/Update/RecipeUpdateTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests\Update;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Lock;
+use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
+
+class RecipeUpdateTest extends TestCase
+{
+    private $originalRecipe;
+    private $newRecipe;
+    private $lock;
+    private $rootDir;
+    private $update;
+
+    protected function setUp(): void
+    {
+        $this->originalRecipe = $this->createMock(Recipe::class);
+        $this->newRecipe = $this->createMock(Recipe::class);
+        $this->lock = new Lock('lock_file');
+        $this->rootDir = '/path/to/here';
+        $this->update = new RecipeUpdate($this->originalRecipe, $this->newRecipe, $this->lock, $this->rootDir);
+    }
+
+    public function testGetters()
+    {
+        $this->assertSame($this->originalRecipe, $this->update->getOriginalRecipe());
+        $this->assertSame($this->newRecipe, $this->update->getNewRecipe());
+        $this->assertSame($this->lock, $this->update->getLock());
+        $this->assertSame($this->rootDir, $this->update->getRootDir());
+    }
+
+    public function testOriginalFiles()
+    {
+        $this->update->setOriginalFile('file1', 'file1_contents');
+        $this->update->addOriginalFiles([
+            'file2' => 'file2_contents',
+            'file3' => 'file3_contents',
+        ]);
+
+        $this->assertSame(
+            ['file1' => 'file1_contents', 'file2' => 'file2_contents', 'file3' => 'file3_contents'],
+            $this->update->getOriginalFiles()
+        );
+    }
+
+    public function testNewFiles()
+    {
+        $this->update->setNewFile('file1', 'file1_contents');
+        $this->update->addNewFiles([
+            'file2' => 'file2_contents',
+            'file3' => 'file3_contents',
+        ]);
+
+        $this->assertSame(
+            ['file1' => 'file1_contents', 'file2' => 'file2_contents', 'file3' => 'file3_contents'],
+            $this->update->getNewFiles()
+        );
+    }
+}


### PR DESCRIPTION
Hi!

tl;dr; Updating recipes was a pain. Now its easy: the new `recipes:update` command performs a smart "patch" to your project of what actually changed in the recipe.

[![asciicast](https://asciinema.org/a/456707.svg)](https://asciinema.org/a/456707)

If you run simply `composer recipes:update`, then it will ask you what to update, from a list of only the out-dated recipes (thanks to @shadowc for the idea!):

<img width="696" alt="Screen Shot 2021-12-17 at 11 18 09 AM" src="https://user-images.githubusercontent.com/121003/146575617-8ca7c6c8-1897-4fb4-be33-cdd5bf6894c0.png">

As you can see, if there are conflicts, you fix them like normal git conflicts. In addition to the unit tests, I've tried this on a fairly out-dated project and it worked *brilliantly*. This was NOT possible until @nicolas-grekas open sourced the Flex server - so a HUGE thanks 🎆 

### How It Works

A) Whenever `symfony/recipes` (or contrib) has a new commit, a GitHub action *already* stores each recipe as JSON, which becomes the "recipe API": https://github.com/symfony/recipes/tree/flex/main. A change to that action (https://github.com/symfony/recipes/pull/1037) and the recipes-checker (https://github.com/symfony-tools/recipes-checker/pull/2) will add an "archived/" directory that contains EVERY version of every recipe. You can see an example in my fork: https://github.com/weaverryan/recipes/tree/flex/main/archived

B) When you run `recipes:update <package/name>`, we fetch the "original" recipe and "new" recipe and then pass both to each "configurator". Its job is to say what files would exist and what they would look if the "original" recipe were installed now and if the "new" recipe were installed now.

C) We use these "original files" and "new files" to generate a patch file.

D) We apply that patch file to the user's actual project. There are a few tricks here, like temporarily inserting the git "blob" for what the "original" version of the file would look like. That allows for a 3-way merge.

So, while it was a bit of work, it's a fairly straightforward process. It makes keeping your recipes up to date both easy and rewarding.

## TODOS

* [x] Merge recipes-checker PR https://github.com/symfony-tools/recipes-checker/pull/2
* [x] Merge symfony/recipes PR https://github.com/symfony/recipes/pull/1037
* [x] Update `Downloader` in this PR to remove 2x TODOs that the above PR's will enable
* [x] Make sure the `archived/` directory is populated for both `recipes` and `recipes-contrib` - see https://github.com/symfony-tools/recipes-checker/pull/3 and https://github.com/symfony/recipes/pull/1038
* [x] Document that this now exists https://github.com/symfony/symfony-docs/pull/16301

Cheers!