### PR TITLE
ReturnTypeWillChange to suppress PHP8.1 Deprecation notice.

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -65,6 +65,7 @@ class Response implements \JsonSerializable
         return $response;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['body' => $this->body, 'headers' => $this->headers];


### PR DESCRIPTION
Pretty quick and standard change for PHP 8.1

Surpress:
```
Deprecation Notice: Return type of Symfony\Flex\Response::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/phil/Sites/manage.mysites.guru/vendor/symfony/flex/src/Response.php:68
```
<img width="1608" alt="Screenshot 2022-01-05 at 10 50 58" src="https://user-images.githubusercontent.com/400092/148205892-ef7b9e40-1d52-46f1-9b4c-5e502e15dca9.png">



Alternative solution to #848 