### PR TITLE
Skipping missing source directories during copy-from-package unconfiguration

### DIFF
--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -145,6 +145,9 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
 
     private function removeFilesFromDir(string $source, string $target)
     {
+        if (!is_dir($source)) {
+            return;
+        }
         $iterator = $this->createSourceIterator($source, \RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($iterator as $item) {
             $targetPath = $this->path->concatenate([$target, $iterator->getSubPathName()]);

--- a/tests/Configurator/CopyFromPackageConfiguratorTest.php
+++ b/tests/Configurator/CopyFromPackageConfiguratorTest.php
@@ -110,7 +110,11 @@ class CopyFromPackageConfiguratorTest extends TestCase
         file_put_contents($this->targetFile, '');
         $this->assertFileExists($this->targetFile);
         $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
-        $this->createConfigurator()->unconfigure($this->recipe, [$this->sourceFileRelativePath => $this->targetFileRelativePath], $lock);
+        $this->createConfigurator()->unconfigure(
+            $this->recipe,
+            [$this->sourceFileRelativePath => $this->targetFileRelativePath, 'missingdir/' => ''],
+            $lock
+        );
         $this->assertFileDoesNotExist($this->targetFile);
     }
 


### PR DESCRIPTION
https://github.com/symfony/flex/issues/73

This PR makes the output look like this: 
![image](https://user-images.githubusercontent.com/2622798/148063629-9f566dd7-f048-4c3e-9cce-e88f4655de74.png)
