### PR TITLE
jsonSerialize return type to suppress PHP8.1 Deprecation notice.

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -65,7 +65,7 @@ class Response implements \JsonSerializable
         return $response;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return ['body' => $this->body, 'headers' => $this->headers];
     }


### PR DESCRIPTION
jsonSerialize return type to suppress PHP8.1 Deprecation notice. 

Alternative solution to #846