### PR TITLE
Flex recipe should always be installed first

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -702,9 +702,10 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $data = $this->downloader->getRecipes($operations);
         $manifests = $data['manifests'] ?? [];
         $locks = $data['locks'] ?? [];
-        // symfony/flex and symfony/framework-bundle recipes should always be applied first
+        // symfony/flex recipes should always be applied first
+        $flexRecipe = [];
+        // symfony/framework-bundle recipe should always be applied first after the metapackages
         $recipes = [
-            'symfony/flex' => null,
             'symfony/framework-bundle' => null,
         ];
         $metaRecipes = [];
@@ -748,6 +749,8 @@ class Flex implements PluginInterface, EventSubscriberInterface
             if (isset($manifests[$name])) {
                 if ('metapackage' === $package->getType()) {
                     $metaRecipes[$name] = new Recipe($package, $name, $job, $manifests[$name], $locks[$name] ?? []);
+                } elseif ('symfony/flex' === $name) {
+                    $flexRecipe = [$name => new Recipe($package, $name, $job, $manifests[$name], $locks[$name] ?? [])];
                 } else {
                     $recipes[$name] = new Recipe($package, $name, $job, $manifests[$name], $locks[$name] ?? []);
                 }
@@ -775,7 +778,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             }
         }
 
-        return array_merge($metaRecipes, array_filter($recipes));
+        return array_merge($flexRecipe, $metaRecipes, array_filter($recipes));
     }
 
     public function truncatePackages(PrePoolCreateEvent $event)


### PR DESCRIPTION
I've noticed that when running `composer symfony:recipes:install --reset --force` the `symfony/webapp-meta` section is removed from the `.env` file:

```
symfony new --webapp sfwebapp
cd sfwebapp/
composer symfony:recipes:install --reset --force
```

results in:

```diff
-###> symfony/webapp-meta ###
-MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
-###< symfony/webapp-meta ###
```

This is because the [meta recipes have precedence](https://github.com/symfony/flex/blob/e9a1e596e18b5b2f337dcb5f942d598eaf9a5502/src/Flex.php#L778) over other recipes, so the `symfony/webapp-meta` recipe is installed first, but since the `symfony/flex` recipe that is installed later has a [default `.env` file](https://github.com/symfony/recipes/blob/c985160644792e891d5a6c6d5d4d1088bedbab6e/symfony/flex/1.0/.env), it overwrites everything.

This PR fixes the problem by making sure the `symfony/flex` recipe is always installed first, as was the case [previously](https://github.com/symfony/flex/pull/439/files#diff-0de31db49040778c07ce10b8959584b33d2ee5c880e4f8a7c19e4055f95ccbe9R583).