### PR TITLE
Fixing missing blank line at end of modified patch files

### DIFF
--- a/src/Update/DiffHelper.php
+++ b/src/Update/DiffHelper.php
@@ -35,6 +35,11 @@ class DiffHelper
             $patch = $contentBefore.substr($patch, $end);
         }
 
+        // valid patches end with a blank line
+        if ($patch && "\n" !== substr($patch, \strlen($patch) - 1, 1)) {
+            $patch = $patch."\n";
+        }
+
         return $patch;
     }
 }

--- a/tests/Update/DiffHelperTest.php
+++ b/tests/Update/DiffHelperTest.php
@@ -105,6 +105,7 @@ index 0000000..34c2ebc
 +    dbal:
 +        # "TEST_TOKEN" is typically set by ParaTest
 +        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+
 EOF
             , [
                 '.env' => <<<EOF
@@ -154,6 +155,7 @@ index 0000000..34c2ebc
 +    dbal:
 +        # "TEST_TOKEN" is typically set by ParaTest
 +        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+
 EOF
             , [
                 'config/packages/doctrine.yaml' => <<<EOF
@@ -204,6 +206,7 @@ index 8ae31a3..17299e2 100644
 -            type: pool
 -            pool: doctrine.system_cache_pool
          query_cache_driver:
+
 EOF
             , [
                 'config/packages/test/doctrine.yaml' => <<<EOF
@@ -244,6 +247,7 @@ index 8ae31a3..17299e2 100644
 -            type: pool
 -            pool: doctrine.system_cache_pool
          query_cache_driver:
+
 EOF
             , [
                 'config/packages/test/doctrine.yaml' => <<<EOF


### PR DESCRIPTION
Fixes #856

tl;dr If a file has been modified in a recipe, but that file has been deleted in the user's project, we manually remove that file from that patch to avoid conflicts (and we report the patch to the user). There was a bug in that process that didn't guarantee an empty line at the end of the patch file. That made the patch file invalid for git.

Thank you @fbourigault for the excellent bug report and reproducer!