### PR TITLE
Making conflict smarter: choose an older recipe to apply

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -280,6 +280,16 @@ class Downloader
     }
 
     /**
+     * Used to "hide" a recipe version so that the next most-recent will be returned.
+     *
+     * This is used when resolving "conflicts".
+     */
+    public function removeRecipeFromIndex(string $packageName, string $version)
+    {
+        unset($this->index[$packageName][$version]);
+    }
+
+    /**
      * Fetches and decodes JSON HTTP response bodies.
      */
     private function get(array $urls, bool $isRecipe = false, int $try = 3): array

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -15,6 +15,7 @@ use Composer\Command\GlobalCommand;
 use Composer\Composer;
 use Composer\Console\Application;
 use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Pool;
@@ -725,16 +726,21 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $name = $package->getName();
             $job = method_exists($operation, 'getOperationType') ? $operation->getOperationType() : $operation->getJobType();
 
-            if (!empty($manifests[$name]['manifest']['conflict']) && !$operation instanceof UninstallOperation) {
-                $lockedRepository = $this->composer->getLocker()->getLockedRepository();
+            while ($this->doesRecipeConflict($manifests[$name] ?? [], $operation)) {
+                $this->downloader->removeRecipeFromIndex($name, $manifests[$name]['version']);
+                $newData = $this->downloader->getRecipes([$operation]);
+                $newManifests = $newData['manifests'] ?? [];
 
-                foreach ($manifests[$name]['manifest']['conflict'] as $conflictingPackage => $constraint) {
-                    if ($lockedRepository->findPackage($conflictingPackage, $constraint)) {
-                        $this->io->writeError(sprintf('  - Skipping recipe for %s: it conflicts with %s %s.', $name, $conflictingPackage, $constraint), true, IOInterface::VERBOSE);
+                if (!isset($newManifests[$name])) {
+                    // no older recipe found
+                    $this->io->writeError(sprintf('  - Skipping recipe for %s: all versions of the recipe conflict with your package versions.', $name), true, IOInterface::VERBOSE);
 
-                        continue 2;
-                    }
+                    continue 2;
                 }
+
+                // push the "old" recipe into the $manifests
+                $manifests[$name] = $newManifests[$name];
+                $locks[$name] = $newData['locks'][$name];
             }
 
             if ($operation instanceof InstallOperation && isset($locks[$name])) {
@@ -990,5 +996,22 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
 
         return $events;
+    }
+
+    private function doesRecipeConflict(array $recipeData, OperationInterface $operation): bool
+    {
+        if (empty($recipeData['manifest']['conflict']) || $operation instanceof UninstallOperation) {
+            return false;
+        }
+
+        $lockedRepository = $this->composer->getLocker()->getLockedRepository();
+
+        foreach ($recipeData['manifest']['conflict'] as $conflictingPackage => $constraint) {
+            if ($lockedRepository->findPackage($conflictingPackage, $constraint)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Hi!

Flex recipes support a `conflict` key - e.g. https://github.com/symfony/recipes/blob/ee79aec15811a380b09c53d058972c74e77e25d9/doctrine/doctrine-bundle/2.4/manifest.json#L48-L50

In this case, we added that so that we could use `when@dev` in the recipe, but that requires `symfony/framework-bundle` 5.3 or greater.

Anyways, the current `conflict` behavior is overly simple: if a recipe conflicts with a package you have installed, it simply skips the recipe entirely. This, for example, makes the following fail right now:

```
symfony new 4.4_app --version=4.4
cd 4.4_app
composer require doctrine
```

If you try this, the `doctrine/doctrine-bundle` will be skipped **entirely**.

This PR makes that behavior smarter. For each recipe that conflicts with your app (e.g. `doctrine/doctrine-bundle` 2.4 recipe), it will try the next oldest recipe version (e.g. `doctrine/doctrine-bundle` 2.3) until it finds one that does *not* conflict. So, you will always get the latest recipe version *without* any conflicts. If no compatible recipes are found, none would be installed (but I don't believe we have this situation anywhere anyways).

Tested locally on an app also.

Cheers!