### PR TITLE
Fix detecting new packages before installing their recipes

### DIFF
--- a/tests/Command/DumpEnvCommandTest.php
+++ b/tests/Command/DumpEnvCommandTest.php
@@ -12,8 +12,9 @@
 namespace Symfony\Flex\Tests\Command;
 
 use Composer\Config;
+use Composer\Console\Application;
+use Composer\IO\NullIO;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Flex\Command\DumpEnvCommand;
 use Symfony\Flex\Options;
@@ -210,6 +211,11 @@ EOF
         );
 
         $application = new Application();
+
+        \Closure::bind(function () {
+            $this->io = new NullIO();
+        }, $application, $application)();
+
         $application->add($command);
         $command = $application->find('dump-env');
 

--- a/tests/Command/UpdateRecipesCommandTest.php
+++ b/tests/Command/UpdateRecipesCommandTest.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\Flex\Tests\Command;
 
+use Composer\Console\Application;
 use Composer\Factory;
 use Composer\IO\BufferIO;
 use Composer\Plugin\PluginInterface;
 use Composer\Util\Platform;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -364,6 +364,7 @@ EOF
     {
         $event = $this->getMockBuilder(PackageEvent::class, ['getOperation'])->disableOriginalConstructor()->getMock();
         $event->expects($this->any())->method('getOperation')->willReturn(new InstallOperation($package));
+        $event->expects($this->any())->method('isDevMode')->willReturn(true);
 
         return $event;
     }


### PR DESCRIPTION
Fix #851

Tracking the transactional changeset from composer.lock leads to the linked issue.
Instead, this tracks the changeset by computing it from symfony.lock.

Requires the `InstallerEvents::PRE_OPERATIONS_EXEC` event, which is Composer 2-only.