### PR TITLE
Updating Recipe Fails When Using Git Sub-Modules

### DIFF
--- a/src/Update/RecipePatcher.php
+++ b/src/Update/RecipePatcher.php
@@ -225,17 +225,18 @@ class RecipePatcher
         return 'objects/'.$hashStart.'/'.$hashEnd;
     }
 
-    private function getGitPath(string $path): string {
+    private function getGitPath(string $path): string
+    {
         $searchPath = $path.'/'.'.git';
-        
+
         if (is_dir($searchPath)) {
             return $searchPath;
         }
 
         preg_match('/^\s*gitdir:\s*(.*)\s*$/', file_get_contents($searchPath), $matches);
 
-        if (count($matches) < 2) {
-            throw new RuntimeException('Could not find git submodule location in \''.$searchPath.'\'');
+        if (\count($matches) < 2) {
+            throw new RuntimeException('Could not find git submodule location in \'.'.$searchPath.'\'');
         }
 
         return $path.'/'.trim($matches[1]);


### PR DESCRIPTION
Closes #864 .

When using git sub-modules and a project therein, composer cannot update recipes, as flex does not know how to handle sub-modules.

The `.git` folder gets replaced by a file with the following contents:

```
gitdir: ../.git/modules/project
```

This PR fixes the used path to follow the sub-module structure.

### Questions
- I need some help figuring out how to test this. We assume a git repository is used for all tests.
- I'm certain that the regex needs improvements
- There could still be an issue when installing a recipe the first time