### PR TITLE
Add some native return types

### DIFF
--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -103,7 +103,7 @@ class ParallelDownloader extends RemoteFilesystem
         }
     }
 
-    public function getOptions()
+    public function getOptions(): array
     {
         $options = array_replace_recursive(parent::getOptions(), $this->nextOptions);
         $this->nextOptions = [];
@@ -121,7 +121,7 @@ class ParallelDownloader extends RemoteFilesystem
     /**
      * {@inheritdoc}
      */
-    public function getLastHeaders()
+    public function getLastHeaders(): array
     {
         return $this->lastHeaders ?? parent::getLastHeaders();
     }
@@ -156,7 +156,7 @@ class ParallelDownloader extends RemoteFilesystem
     /**
      * @internal
      */
-    public function callbackGet($notificationCode, $severity, $message, $messageCode, $bytesTransferred, $bytesMax, $nativeDownload = true)
+    public function callbackGet($notificationCode, $severity, $message, $messageCode, $bytesTransferred, $bytesMax, $nativeDownload = true): void
     {
         if (!$nativeDownload && \STREAM_NOTIFY_SEVERITY_ERR === $severity) {
             throw new TransportException($message, $messageCode);


### PR DESCRIPTION
### Symfony version(s) affected

symfony/flex: v1.18.5

### Description

Composer version 2.3-dev (2.3-dev+c9baeda95b2da59a8c2d0bb7350b18d009aa891b) 2022-02-21 12:57:32

Symfony Project with `symfony/flex: v1.18.5` 

```
PHP Fatal error:  Declaration of Symfony\Flex\ParallelDownloader::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []) must be compatible with Composer\Util\RemoteFilesystem::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []): bool in /Users/phil/Sites/example.com/vendor/symfony/flex/src/ParallelDownloader.php on line 132

Fatal error: Declaration of Symfony\Flex\ParallelDownloader::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []) must be compatible with Composer\Util\RemoteFilesystem::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []): bool in /Users/phil/Sites/example.com/vendor/symfony/flex/src/ParallelDownloader.php on line 132
```



### How to reproduce

```

~/Sites/symfony-test composer -V
Composer version 2.3-dev (2.3-dev+c9baeda95b2da59a8c2d0bb7350b18d009aa891b) 2022-02-21 12:57:32
~/Sites/symfony-test composer selfup --snapshot
You are already using the latest available Composer version c9baeda95b2da59a8c2d0bb7350b18d009aa891b (snapshot channel).
~/Sites/symfony-test composer require symfony/flex 1.18.5
./composer.json has been created
Running composer update symfony/flex
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking symfony/flex (v1.18.5)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing symfony/flex (v1.18.5): Extracting archive
symfony/flex contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "symfony/flex" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
PHP Fatal error:  Declaration of Symfony\Flex\ParallelDownloader::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []) must be compatible with Composer\Util\RemoteFilesystem::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []): bool in /Users/phil/Sites/symfony-test/vendor/symfony/flex/src/ParallelDownloader.php on line 132

Fatal error: Declaration of Symfony\Flex\ParallelDownloader::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []) must be compatible with Composer\Util\RemoteFilesystem::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []): bool in /Users/phil/Sites/symfony-test/vendor/symfony/flex/src/ParallelDownloader.php on line 132
~/Sites/symfony-test



```

### Possible Solution

`:bool` ?

### Additional Context

I appreciate Im ahead of the game again running bleeding edge composer :) 