### PR TITLE
fix version info

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -260,7 +260,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $versionParser = new VersionParser();
         $packages = [];
         foreach ($this->lock->all() as $name => $info) {
-            $packages[] = new Package($name, $versionParser->normalize($info['version']), $info['version']);
+            if (is_array($info) && array_key_exists('version', $info)) {
+                $packages[] = new Package($name, $versionParser->normalize($info['version']), $info['version']);
+            }
         }
 
         $transation = \Closure::bind(function () use ($packages, $event) {


### PR DESCRIPTION
we had an issue, that our composer.json somehow seems to trigger an error



```
{
	"autoload": {
		"psr-4": {
			"App\\": "src/"
		}
	},
        "name": "XXX"
}
```

flex tried to find "autoload["version"]" and also "name["version"]"


it only happens, after the first composer install.
any ideas what could have introduced that - or how i further can track it down?


composer: 2.2.6
flex: 2.1.6


<img width="901" alt="Bildschirmfoto 2022-02-22 um 16 08 34" src="https://user-images.githubusercontent.com/2891702/155160851-5f6c196a-c81a-4100-a686-b3003396483f.png">


stacktrace:

```
Exception trace:
 () at /KRN/API/vendor/symfony/flex/src/Flex.php:263
 Composer\Util\ErrorHandler::handle() at /KRN/API/vendor/symfony/flex/src/Flex.php:263
 Symfony\Flex\Flex->recordOperations() at n/a:n/a
 call_user_func() at phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:192
 Composer\EventDispatcher\EventDispatcher->doDispatch() at phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:152
 Composer\EventDispatcher\EventDispatcher->dispatchInstallerEvent() at phar:///usr/local/bin/composer/src/Composer/Installer.php:714
 Composer\Installer->doInstall() at phar:///usr/local/bin/composer/src/Composer/Installer.php:583
 Composer\Installer->doUpdate() at phar:///usr/local/bin/composer/src/Composer/Installer.php:279
 Composer\Installer->run() at phar:///usr/local/bin/composer/src/Composer/Command/UpdateCommand.php:248
 Composer\Command\UpdateCommand->execute() at phar:///usr/local/bin/composer/vendor/symfony/console/Command/Command.php:245
 Symfony\Component\Console\Command\Command->run() at phar:///usr/local/bin/composer/vendor/symfony/console/Application.php:835
 Symfony\Component\Console\Application->doRunCommand() at phar:///usr/local/bin/composer/vendor/symfony/console/Application.php:185
 Symfony\Component\Console\Application->doRun() at phar:///usr/local/bin/composer/src/Composer/Console/Application.php:336
 Composer\Console\Application->doRun() at phar:///usr/local/bin/composer/vendor/symfony/console/Application.php:117
 Symfony\Component\Console\Application->run() at phar:///usr/local/bin/composer/src/Composer/Console/Application.php:131
 Composer\Console\Application->run() at phar:///usr/local/bin/composer/bin/composer:83
 require() at /usr/local/bin/composer:29
```
