### PR TITLE
Fixes Fatal Error: Declaration of Symfony\Flex\ParallelDownloader

### DIFF
--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -103,7 +103,7 @@ class ParallelDownloader extends RemoteFilesystem
         }
     }
 
-    public function getOptions()
+    public function getOptions(): array
     {
         $options = array_replace_recursive(parent::getOptions(), $this->nextOptions);
         $this->nextOptions = [];
@@ -121,7 +121,7 @@ class ParallelDownloader extends RemoteFilesystem
     /**
      * {@inheritdoc}
      */
-    public function getLastHeaders()
+    public function getLastHeaders(): array
     {
         return $this->lastHeaders ?? parent::getLastHeaders();
     }
@@ -129,7 +129,7 @@ class ParallelDownloader extends RemoteFilesystem
     /**
      * {@inheritdoc}
      */
-    public function copy($originUrl, $fileUrl, $fileName, $progress = true, $options = [])
+    public function copy($originUrl, $fileUrl, $fileName, $progress = true, $options = []): bool
     {
         $options = array_replace_recursive($this->nextOptions, $options);
         $this->nextOptions = [];
@@ -156,7 +156,7 @@ class ParallelDownloader extends RemoteFilesystem
     /**
      * @internal
      */
-    public function callbackGet($notificationCode, $severity, $message, $messageCode, $bytesTransferred, $bytesMax, $nativeDownload = true)
+    public function callbackGet($notificationCode, $severity, $message, $messageCode, $bytesTransferred, $bytesMax, $nativeDownload = true): void
     {
         if (!$nativeDownload && \STREAM_NOTIFY_SEVERITY_ERR === $severity) {
             throw new TransportException($message, $messageCode);


### PR DESCRIPTION
Fatal Error: Declaration of Symfony\Flex\ParallelDownloader::copy must be compatible with Composer\Util\RemoteFilesystem::copy

Add return types to be compatible with composer changes

Newest version of composer added return types to these functions (@see https://github.com/composer/composer/commit/a16ed3d0ed6a137d11231ed77d3545998584d2e8). Now you get Fatal Errors when using new composer:
Declaration of Symfony\Flex\ParallelDownloader::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = Array) must be compatible with Composer\Util\RemoteFilesystem::copy($originUrl, $fileUrl, $fileName, $progress = true, $options = Array): bool