### PR TITLE
[recipes:update] Fixing bug where files failed to delete that were modified previously

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
             matrix:
                 include:
                   - php: '7.1'
+                    composer: 2.2.x
                   - php: '7.2'
                   - php: '7.3'
                   - php: '7.4'
@@ -33,11 +34,11 @@ jobs:
               uses: actions/checkout@v2.3.3
 
             - name: "Install PHP with extensions"
-              uses: shivammathur/setup-php@2.7.0
+              uses: shivammathur/setup-php@2.18.0
               with:
                   coverage: "none"
                   php-version: ${{ matrix.php }}
-                  tools: composer:v2
+                  tools: composer:${{ matrix.composer }}
 
             - name: "Validate composer.json"
               run: "composer validate --strict --no-check-lock"

--- a/src/Configurator/BundlesConfigurator.php
+++ b/src/Configurator/BundlesConfigurator.php
@@ -44,20 +44,20 @@ class BundlesConfigurator extends AbstractConfigurator
 
     public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
     {
-        $originalBundles = $this->configureBundles($originalConfig);
+        $originalBundles = $this->configureBundles($originalConfig, true);
         $recipeUpdate->setOriginalFile(
             $this->getLocalConfFile(),
             $this->buildContents($originalBundles)
         );
 
-        $newBundles = $this->configureBundles($newConfig);
+        $newBundles = $this->configureBundles($newConfig, true);
         $recipeUpdate->setNewFile(
             $this->getLocalConfFile(),
             $this->buildContents($newBundles)
         );
     }
 
-    private function configureBundles(array $bundles): array
+    private function configureBundles(array $bundles, bool $resetEnvironments = false): array
     {
         $file = $this->getConfFile();
         $registered = $this->load($file);
@@ -70,7 +70,15 @@ class BundlesConfigurator extends AbstractConfigurator
         }
         foreach ($classes as $class => $envs) {
             // do not override existing configured envs for a bundle
-            if (!isset($registered[$class])) {
+            if (!isset($registered[$class]) || $resetEnvironments) {
+                if ($resetEnvironments) {
+                    // used during calculating an "upgrade"
+                    // here, we want to "undo" the bundle's configuration entirely
+                    // then re-add it fresh, in case some environments have been
+                    // removed in an updated version of the recipe
+                    $registered[$class] = [];
+                }
+
                 foreach ($envs as $env) {
                     $registered[$class][$env] = true;
                 }

--- a/src/Update/RecipePatch.php
+++ b/src/Update/RecipePatch.php
@@ -15,12 +15,14 @@ class RecipePatch
 {
     private $patch;
     private $blobs;
+    private $deletedFiles;
     private $removedPatches;
 
-    public function __construct(string $patch, array $blobs, array $removedPatches = [])
+    public function __construct(string $patch, array $blobs, array $deletedFiles, array $removedPatches = [])
     {
         $this->patch = $patch;
         $this->blobs = $blobs;
+        $this->deletedFiles = $deletedFiles;
         $this->removedPatches = $removedPatches;
     }
 
@@ -32,6 +34,11 @@ class RecipePatch
     public function getBlobs(): array
     {
         return $this->blobs;
+    }
+
+    public function getDeletedFiles(): array
+    {
+        return $this->deletedFiles;
     }
 
     /**

--- a/src/Update/RecipePatcher.php
+++ b/src/Update/RecipePatcher.php
@@ -38,40 +38,15 @@ class RecipePatcher
      */
     public function applyPatch(RecipePatch $patch): bool
     {
-        if (!$patch->getPatch()) {
-            // nothing to do!
-            return true;
-        }
+        $withConflicts = $this->_applyPatchFile($patch);
 
-        $addedBlobs = $this->addMissingBlobs($patch->getBlobs());
-
-        $patchPath = $this->rootDir.'/_flex_recipe_update.patch';
-        file_put_contents($patchPath, $patch->getPatch());
-
-        try {
-            $this->execute('git update-index --refresh', $this->rootDir);
-
-            $output = '';
-            $statusCode = $this->processExecutor->execute('git apply "_flex_recipe_update.patch" -3', $output, $this->rootDir);
-
-            if (0 === $statusCode) {
-                // successful with no conflicts
-                return true;
-            }
-
-            if (false !== strpos($this->processExecutor->getErrorOutput(), 'with conflicts')) {
-                // successful with conflicts
-                return false;
-            }
-
-            throw new \LogicException('Error applying the patch: '.$this->processExecutor->getErrorOutput());
-        } finally {
-            unlink($patchPath);
-            // clean up any temporary blobs
-            foreach ($addedBlobs as $filename) {
-                unlink($filename);
+        foreach ($patch->getDeletedFiles() as $deletedFile) {
+            if (file_exists($this->rootDir.'/'.$deletedFile)) {
+                $this->execute(sprintf('git rm %s', ProcessExecutor::escape($deletedFile)), $this->rootDir);
             }
         }
+
+        return $withConflicts;
     }
 
     public function generatePatch(array $originalFiles, array $newFiles): RecipePatch
@@ -84,10 +59,13 @@ class RecipePatcher
             return null !== $file;
         });
 
-        // find removed files and add them so they will be deleted
+        $deletedFiles = [];
+        // find removed files & record that they are deleted
+        // unset them from originalFiles to avoid unnecessary blobs being added
         foreach ($originalFiles as $file => $contents) {
             if (!isset($newFiles[$file])) {
-                $newFiles[$file] = null;
+                $deletedFiles[] = $file;
+                unset($originalFiles[$file]);
             }
         }
 
@@ -130,6 +108,7 @@ class RecipePatcher
             return new RecipePatch(
                 $patchString,
                 $blobs,
+                $deletedFiles,
                 $removedPatches
             );
         } finally {
@@ -222,5 +201,43 @@ class RecipePatcher
         $hashEnd = substr($hash, 2);
 
         return '.git/objects/'.$hashStart.'/'.$hashEnd;
+    }
+
+    private function _applyPatchFile(RecipePatch $patch)
+    {
+        if (!$patch->getPatch()) {
+            // nothing to do!
+            return true;
+        }
+
+        $addedBlobs = $this->addMissingBlobs($patch->getBlobs());
+
+        $patchPath = $this->rootDir.'/_flex_recipe_update.patch';
+        file_put_contents($patchPath, $patch->getPatch());
+
+        try {
+            $this->execute('git update-index --refresh', $this->rootDir);
+
+            $output = '';
+            $statusCode = $this->processExecutor->execute('git apply "_flex_recipe_update.patch" -3', $output, $this->rootDir);
+
+            if (0 === $statusCode) {
+                // successful with no conflicts
+                return true;
+            }
+
+            if (false !== strpos($this->processExecutor->getErrorOutput(), 'with conflicts')) {
+                // successful with conflicts
+                return false;
+            }
+
+            throw new \LogicException('Error applying the patch: '.$this->processExecutor->getErrorOutput());
+        } finally {
+            unlink($patchPath);
+            // clean up any temporary blobs
+            foreach ($addedBlobs as $filename) {
+                unlink($filename);
+            }
+        }
     }
 }

--- a/tests/Configurator/BundlesConfiguratorTest.php
+++ b/tests/Configurator/BundlesConfiguratorTest.php
@@ -176,7 +176,7 @@ EOF
 
 return [
     BarBundle::class => ['prod' => false, 'all' => true],
-    FooBundle::class => ['dev' => true, 'test' => true],
+    FooBundle::class => ['all' => true],
     BazBundle::class => ['all' => true],
     NewBundle::class => ['all' => true],
 ];

--- a/tests/Update/RecipePatchTest.php
+++ b/tests/Update/RecipePatchTest.php
@@ -20,12 +20,14 @@ class RecipePatchTest extends TestCase
     {
         $thePatch = 'the patch';
         $blobs = ['blob1', 'blob2', 'beware of the blob'];
+        $deletedFiles = ['old_file.txt'];
         $removedPatches = ['foo' => 'some diff'];
 
-        $patch = new RecipePatch($thePatch, $blobs, $removedPatches);
+        $patch = new RecipePatch($thePatch, $blobs, $deletedFiles, $removedPatches);
 
         $this->assertSame($thePatch, $patch->getPatch());
         $this->assertSame($blobs, $patch->getBlobs());
+        $this->assertSame($deletedFiles, $patch->getDeletedFiles());
         $this->assertSame($removedPatches, $patch->getRemovedPatches());
     }
 }


### PR DESCRIPTION
Hi!

This fixes TWO `recipes:update` bugs:

## Bug 1️⃣ : sometimes deleted files caused patch to fail

Small bug fix. The mystery is how I didn't catch this before... and how nobody seems to have hit this. The problem is fairly simple:

A) The user gets a file (a long time ago) from a recipe (e.g. `config/bootstrap.php`).
B) The user modifies (and commits) some change.
C) A recipe update *deletes* that file.

This, oddly, fails because the patch can't be applied. For example, when `config/packages/dev/framework.yaml` is deleted in `symfony/framework-bundle` recipe, this patch is correctly generated

```diff
diff --git a/config/routes/dev/framework.yaml b/config/routes/dev/framework.yaml
deleted file mode 100644
index bcbbf13..0000000
--- a/config/routes/dev/framework.yaml
+++ /dev/null
@@ -1,3 +0,0 @@
-_errors:
-    resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
-    prefix: /_error
```

However, if the user's `framework.yaml` doesn't look EXACTLY like this, the patch will fail (not with a conflict like you might expect, it just completely fails to apply). 

The fix is quite simple: if a recipe update is *deleting* a file, instead of generating a "delete patch" for it, we run `git rm <filename>`. The downside is that the user won't get a nice "file conflict" if they ever modified the file... but apparently that is not possible. And the user will still review this change before they commit.

## Bug 2️⃣  : `bundles.php` environments didn't change

If an upgraded recipe changed the environments that a bundle is configured in (e.g. https://github.com/symfony/recipes/pull/940/files), this was previously not taken into account: the update did not update the environments. Fixed now.

Tested locally on a fairly complex project.

Thanks!