### PR TITLE
Fix relative URLs in index.json not working

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -224,8 +224,8 @@ class Downloader
                         break;
                     }
 
-                    if (isset($links['recipes_template_relative'])) {
-                        $links['recipes_template'] = preg_replace('{[^/\?]*+(?=\?|$)}', $links['recipes_template_relative'], $endpoint, 1);
+                    if (isset($links['recipe_template_relative'])) {
+                        $links['recipe_template'] = preg_replace('{[^/\?]*+(?=\?|$)}', $links['recipe_template_relative'], $endpoint, 1);
                     }
 
                     $urls[] = strtr($links['recipe_template'], [


### PR DESCRIPTION
Hello, 
This PR fixes #897.  It relates also to #872. @nicolas-grekas  
I found out that in [index.json](https://raw.githubusercontent.com/symfony/recipes-contrib/flex/main/index.json), the name of the attribute is _recipe_template_relative_, and not _recipes_template_relative_ as expected in the source code.
And we should also set _recipe_template_ , instead of _recipes_template_.
Regards,