### PR TITLE
[POC][WIP] Pack recipes

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -72,6 +72,10 @@ class Configurator
 
     public function unconfigure(Recipe $recipe, Lock $lock)
     {
+        if ('kbond/homepage-scaffold' === $recipe->getPackage()->getName()) {
+            return;
+        }
+
         $manifest = $recipe->getManifest();
         foreach (array_keys($this->configurators) as $key) {
             if (isset($manifest[$key])) {

--- a/src/Unpacker.php
+++ b/src/Unpacker.php
@@ -73,14 +73,6 @@ class Unpacker
             }
             $devRequires = $pkg->getDevRequires();
 
-            foreach ($devRequires as $i => $link) {
-                if (!isset($requires[$link->getTarget()])) {
-                    throw new \RuntimeException(sprintf('Symfony pack "%s" must duplicate all entries from "require-dev" into "require" but entry "%s" was not found.', $package['name'], $link->getTarget()));
-                }
-                $devRequires[$i] = $requires[$link->getTarget()];
-                unset($requires[$link->getTarget()]);
-            }
-
             $versionSelector = null;
             foreach ([$requires, $devRequires] as $dev => $requires) {
                 $dev = $dev ?: $devRequire ?: $package['dev'];


### PR DESCRIPTION
Proposal for "scaffolds" as recipes as discussed with @nicolas-grekas and @weaverryan as a possible alternative to https://github.com/symfony/maker-bundle/pull/1085.

- Scaffolds make sense to be packs as we want their dependencies installed but not the "empty package".
- Since scaffolds contain both require/require-dev dependencies, I had to modify the unpacker to allow for this.
- We want pack recipes installed but not unconfigured when the pack is uninstalled.
- Pack/Scaffold recipes cannot be updated/uninstalled. I think this makes sense as they will likely be heavily modified.

Recipe PR: https://github.com/symfony/recipes/pull/1088

**Test:**

```bash
symfony new project
cd project
export SYMFONY_ENDPOINT=https://raw.githubusercontent.com/symfony/recipes/flex/pull-1088/index.json
composer config repositories.homepage vcs git@github.com:kbond/homepage-scaffold
composer config repositories.flex vcs git@github.com:kbond/flex
composer require symfony/flex:dev-pack-recipes
composer require kbond/homepage-scaffold # installs the "scaffold"
vendor/bin/phpunit # 1 test should run & pass
```

**TODO:**
- [ ] If installing a scaffold with `--dev`, you get all the deps in require-dev.
- [ ] Way to determine if a recipe is a pack on unconfigure.
- [ ] Higher priority for pack recipes. This will allow files in pack recipes to take precedence over their dependency recipes (like `metapackages` do now).