### PR TITLE
Prevent recipes bound to packs from being uninstalled when unpacking

### DIFF
--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -187,6 +187,7 @@ EOF
             ['name' => 'symfony/flex', 'type' => 'composer-plugin'],
             ['name' => 'symfony/framework-bundle', 'type' => 'library'],
             ['name' => 'symfony/webapp-meta', 'type' => 'metapackage'],
+            ['name' => 'symfony/webapp-pack', 'type' => 'symfony-pack'],
         ];
 
         $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
@@ -209,6 +210,7 @@ EOF
 
         $this->assertSame([
             'symfony/flex',
+            'symfony/webapp-pack',
             'symfony/webapp-meta',
             'symfony/framework-bundle',
             'symfony/console',


### PR DESCRIPTION
And make them have higher precedence than other recipes.

Right now we don't bind recipes to packs, but we have some ideas that could change that :)