### PR TITLE
Allow packs to embed their recipe

### DIFF
--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -83,7 +83,7 @@ class Recipe
 
     public function getURL(): string
     {
-        if (!$this->data['origin']) {
+        if (empty($this->data['origin'])) {
             return '';
         }
 


### PR DESCRIPTION
By making packs able to embed their recipe, we enable using them for scaffolding feature-full applications.

Note that such local recipes cannot be managed with any `composer recipes:*` command, and this is a feature :)

At the community scale, this might allow ppl to work around the central repository of recipes if authors maintain a pack next to their main lib. But this looks fair to me, especially with the noted limitation of packs' recipes. We do want to allow ppl to create scaffolds, even if it's for one lib.

(Note also that since #923, recipes bound to packs via the central repository are now update-able, so we don't need the `*-meta` repos anymore.)

On a technical level, this works as is:
1. `composer require the/pack` installs the pack and all its deps using the regular composer flow,
2. flex unpacks `the/pack` into the root `composer.json`,
3. flex turns the files in the `vendor/the/pack/` directory into a recipe and installs it,
4. flex tells composer to remove `the/pack`, thus removing `vendor/the/pack/`

:magic_wand:

One last note: embedded recipes escape the CI we have in place on the central repo. We might want to provide a callable GHA to make it easier for authors to verify them. This GHA could also check conflicts between the central repo and packs' recipes (overridden files typically), to ease propagate changes from the central repo to the overriding packs.