### PR TITLE
Deprecate "flex-require" sections

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -415,6 +415,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
             if (!isset($json['flex-'.$type])) {
                 continue;
             }
+
+            $this->io->writeError(sprintf('<warning>Using section "flex-%s" in composer.json is deprecated, use "%1$s" instead.</>', $type));
+
             foreach ($json['flex-'.$type] as $package => $constraint) {
                 if ($symfonyVersion && '*' === $constraint && isset($versions['splits'][$package])) {
                     // replace unbounded constraints for symfony/* packages by extra.symfony.require


### PR DESCRIPTION
They're not needed since #907 / flex v1.18.7