### PR TITLE
Read from symfony.lock when checking for recipe updates

### DIFF
--- a/src/Command/RecipesCommand.php
+++ b/src/Command/RecipesCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex\Command;
 
 use Composer\Command\BaseCommand;
 use Composer\Downloader\TransportException;
+use Composer\Package\Package;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -61,19 +62,25 @@ class RecipesCommand extends BaseCommand
         // Inspect one or all packages
         $package = $input->getArgument('package');
         if (null !== $package) {
-            $packages = [0 => ['name' => strtolower($package)]];
+            $packages = [strtolower($package)];
         } else {
             $locker = $this->getComposer()->getLocker();
             $lockData = $locker->getLockData();
 
             // Merge all packages installed
-            $packages = array_merge($lockData['packages'], $lockData['packages-dev']);
+            $packages = array_column(array_merge($lockData['packages'], $lockData['packages-dev']), 'name');
+            $packages = array_unique(array_merge($packages, array_keys($this->symfonyLock->all())));
         }
 
         $operations = [];
-        foreach ($packages as $value) {
-            if (null === $pkg = $installedRepo->findPackage($value['name'], '*')) {
-                $this->getIO()->writeError(sprintf('<error>Package %s is not installed</error>', $value['name']));
+        foreach ($packages as $name) {
+            $pkg = $installedRepo->findPackage($name, '*');
+
+            if (!$pkg && $this->symfonyLock->has($name)) {
+                $pkgVersion = $this->symfonyLock->get($name)['version'];
+                $pkg = new Package($name, $pkgVersion, $pkgVersion);
+            } elseif (!$pkg) {
+                $this->getIO()->writeError(sprintf('<error>Package %s is not installed</error>', $name));
 
                 continue;
             }

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -245,7 +245,6 @@ class Downloader
             }
 
             if (null !== $this->endpoints) {
-                $data['locks'][$package->getName()]['version'] = $version;
                 continue;
             }
 


### PR DESCRIPTION
This PR ensures that recipes listed in symfony.lock are not removed unless a package is explicitly removed, fixing the experience with recipes brought by packs.

This also fixes unconfiguring auto-registered bundles (fix #920)

And this finally fixes listing all installed packages in symfony.lock, while only packages with actual recipes should be listed there (auto or not-auto recipes).