### PR TITLE
Revert "Deprecate "flex-require" sections"

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -415,9 +415,6 @@ class Flex implements PluginInterface, EventSubscriberInterface
             if (!isset($json['flex-'.$type])) {
                 continue;
             }
-
-            $this->io->writeError(sprintf('<warning>Using section "flex-%s" in composer.json is deprecated, use "%1$s" instead.</>', $type));
-
             foreach ($json['flex-'.$type] as $package => $constraint) {
                 if ($symfonyVersion && '*' === $constraint && isset($versions['splits'][$package])) {
                     // replace unbounded constraints for symfony/* packages by extra.symfony.require


### PR DESCRIPTION
This reverts commit c36d11d1bca0a85dde6ca4d52bd4aceeb54dbd8f.

Reverting #927

While #907 allows reinstallling deps with flex enabled, this has two issues:
- composer 1 refuses to downgrade deps so it doesn't work there
- composer 2 downgrades from eg 6.1 to 5.4 when reinstalling with flex

While the issue on c1 can be fixed, in both cases composer will have resolved deps with the latest version for nothing, creating a slower than needed experience.