### PR TITLE
Updating Recipe Fails When Project Located in Subfolder in Git Repository

### DIFF
--- a/tests/Update/RecipePatcherTest.php
+++ b/tests/Update/RecipePatcherTest.php
@@ -241,7 +241,6 @@ EOF
         $mainProjectPath = FLEX_TEST_DIR;
         $subProjectPath = FLEX_TEST_DIR.'/ProjectA';
 
-        ## init main project git repo
         (new Process(['git', 'init'], $mainProjectPath))->mustRun();
         (new Process(['git', 'config', 'user.name', 'Unit test'], $mainProjectPath))->mustRun();
         (new Process(['git', 'config', 'user.email', ''], $mainProjectPath))->mustRun();
@@ -280,7 +279,7 @@ EOF
 
     public function getApplyPatchTests(string $testMethodName): iterable
     {
-        $projectRootPath = ($testMethodName === "testApplyPatchOnSubfolder") ? "ProjectA/" : "";
+        $projectRootPath = ('testApplyPatchOnSubfolder' === $testMethodName) ? 'ProjectA/' : '';
         $files = $this->getFilesForPatching($projectRootPath);
         $dotEnvClean = $files['dot_env_clean'];
         $packageJsonConflict = $files['package_json_conflict'];
@@ -439,7 +438,7 @@ EOF
      *      * original_recipe
      *      * updated_recipe.
      */
-    private function getFilesForPatching(string $projectPath=""): array
+    private function getFilesForPatching(string $projectPath = ''): array
     {
         $files = [
             // .env


### PR DESCRIPTION
Closes #918 and #864 

Updating Recipe fails when symfony project is not in the root of git project. 
As a developer the most problematic thing is that it fails without any errors. Some files are just not updated.

There is a simple project with commands needed to reproduce to see what is happening before the fix: https://github.com/Peukku/symfony-flex-reproducer-918-project-root/

I think there are two reasons for this to happen:
* $patchString is created with git diff in tmpPath, which has a temporary flat git repository (with no path prefix), but applied bit later in project context where path would be needed. 
* Location of .git directory is assumed to be in project root, when it actually is in git root level. (or in .git/modules/[subproject] when using git submodules). The blobs do get written, but in the wrong location.

This PR uses git binary to resolve location of .git folder and current relative path to be used as the prefix for git diff.