### PR TITLE
Fixes SYMFONY_REQUIRE environment variable [2.x]

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Flex;
 
-use Composer\Factory;
 use Composer\Package\Version\VersionParser;
 use Composer\Repository\PlatformRepository;
 
@@ -22,10 +21,12 @@ class PackageResolver
 {
     private static $SYMFONY_VERSIONS = ['lts', 'previous', 'stable', 'next', 'dev'];
     private $downloader;
+    private $symfonyRequire;
 
-    public function __construct(Downloader $downloader)
+    public function __construct(Downloader $downloader, string $symfonyRequire = '')
     {
         $this->downloader = $downloader;
+        $this->symfonyRequire = $symfonyRequire;
     }
 
     public function resolve(array $arguments = [], bool $isRequire = false): array
@@ -65,14 +66,10 @@ class PackageResolver
         }
 
         if (!$version || '*' === $version) {
-            try {
-                $config = @json_decode(file_get_contents(Factory::getComposerFile()), true);
-            } finally {
-                if (!$isRequire || !(isset($config['extra']['symfony']['require']) || isset($config['require']['symfony/framework-bundle']))) {
-                    return '';
-                }
+            if (!$isRequire || empty($this->symfonyRequire)) {
+                return '';
             }
-            $version = $config['extra']['symfony']['require'] ?? $config['require']['symfony/framework-bundle'];
+            $version = $this->symfonyRequire;
         } elseif ('dev' === $version) {
             $version = '^'.$versions['dev-name'].'@dev';
         } elseif ('next' === $version) {


### PR DESCRIPTION
Closes https://github.com/symfony/flex/issues/946 (`2.x`)

When requiring a package in `symfony/symfony`, Flex attempts to determine the `symfony.require` version in two different ways:
- `Symfony\Flex\PackageResolver`
  - Uses the value of `extra.symfony.require` defined in the root `composer.json`; or
  - Uses the version constraint for `symfony/framework-bundle` defined in the root `composer.json`; or
  - Applies no constraint (`SYMFONY_REQUIRE` environment variable is ignored)
- `Symfony\Flex\Flex`
  - Uses the value of `SYMFONY_REQUIRE` environment variable; or
  - Uses the in-memory value of the root package's `extra.symfony.require`; or
  - Applies no constraint (`symfony/framework-bundle` version constraint is ignored)

As a result of the above, when requiring packages in `symfony/symfony`, Flex may report a package restriction without applying it.

This PR ensures `Symfony\Flex\PackageResolver` and `Symfony\Flex\Flex` both use the same `symfony.require` version, determined in the following priority order:
- `SYMFONY_REQUIRE` environment variable; or
- In-memory value of `extra.symfony.require`; or
- In-memory value of the `symfony/framework-bundle` version constraint in the `requires` list (unless the `symfony/framework-bundle` version constraint given is `*`); or
- No version constraint applies

