### PR TITLE
Add recipe provider which loads recipes directly from the bundle.

### DIFF
--- a/src/Command/UpdateRecipesCommand.php
+++ b/src/Command/UpdateRecipesCommand.php
@@ -21,12 +21,12 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Flex\Configurator;
-use Symfony\Flex\Downloader;
 use Symfony\Flex\Flex;
 use Symfony\Flex\GithubApi;
 use Symfony\Flex\InformationOperation;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
+use Symfony\Flex\RecipeProviderInterface;
 use Symfony\Flex\Update\RecipePatcher;
 use Symfony\Flex\Update\RecipeUpdate;
 
@@ -34,16 +34,16 @@ class UpdateRecipesCommand extends BaseCommand
 {
     /** @var Flex */
     private $flex;
-    private $downloader;
+    private RecipeProviderInterface $recipeProvider;
     private $configurator;
     private $rootDir;
     private $githubApi;
     private $processExecutor;
 
-    public function __construct(/* cannot be type-hinted */ $flex, Downloader $downloader, $httpDownloader, Configurator $configurator, string $rootDir)
+    public function __construct(/* cannot be type-hinted */ $flex, RecipeProviderInterface $recipeProvider, $httpDownloader, Configurator $configurator, string $rootDir)
     {
         $this->flex = $flex;
-        $this->downloader = $downloader;
+        $this->recipeProvider = $recipeProvider;
         $this->configurator = $configurator;
         $this->rootDir = $rootDir;
         $this->githubApi = new GithubApi($httpDownloader);
@@ -268,7 +268,7 @@ class UpdateRecipesCommand extends BaseCommand
         if (null !== $recipeRef) {
             $operation->setSpecificRecipeVersion($recipeRef, $recipeVersion);
         }
-        $recipes = $this->downloader->getRecipes([$operation]);
+        $recipes = $this->recipeProvider->getRecipes([$operation]);
 
         if (0 === \count($recipes['manifests'] ?? [])) {
             return null;

--- a/src/CompositeRecipeProvider.php
+++ b/src/CompositeRecipeProvider.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Symfony\Flex;
+
+class CompositeRecipeProvider implements RecipeProviderInterface
+{
+    /**
+     * @var RecipeProviderInterface[]
+     */
+    private array $recipeProviders;
+
+    /**
+     * @param RecipeProviderInterface[] $recipeProviders
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(array $recipeProviders)
+    {
+        $this->recipeProviders = array_reduce(
+            $recipeProviders,
+            function (array $providers, RecipeProviderInterface $provider) {
+                if (self::class == $provider::class) {
+                    throw new \InvalidArgumentException('You cannot add an instance of this provider to itself.');
+                }
+                $providers[$provider::class] = $provider;
+
+                return $providers;
+            },
+            []);
+    }
+
+    /**
+     * This method adds an instance RecipeProviderInterface to this provider.
+     * You can only have one instance per class registered in this provider.
+     *
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function add(RecipeProviderInterface $recipeProvider): self
+    {
+        if (self::class == $recipeProvider::class) {
+            throw new \InvalidArgumentException('You cannot add an instance of this provider to itself.');
+        }
+        if (isset($this->recipeProviders[$recipeProvider::class])) {
+            throw new \InvalidArgumentException('Given Provider has been added already.');
+        }
+        $this->recipeProviders[] = $recipeProvider;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEnabled(): bool
+    {
+        return array_reduce($this->recipeProviders, function (bool $isEnabled, RecipeProviderInterface $provider) { return $provider->isEnabled() && $isEnabled; }, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function disable(): void
+    {
+        array_walk($this->recipeProviders, function (RecipeProviderInterface $provider) { $provider->disable(); });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getVersions(): array
+    {
+        return array_reduce($this->recipeProviders, function (array $carry, RecipeProviderInterface $provider) { return array_merge($carry, $provider->getVersions()); }, []);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAliases(): array
+    {
+        return array_reduce($this->recipeProviders, function (array $carry, RecipeProviderInterface $provider) { return array_merge($carry, $provider->getAliases()); }, []);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRecipes(array $operations): array
+    {
+        return array_reduce($this->recipeProviders, function (array $carry, RecipeProviderInterface $provider) use ($operations) { return array_merge_recursive($carry, $provider->getRecipes($operations)); }, []);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function removeRecipeFromIndex(string $packageName, string $version): void
+    {
+        array_walk($this->recipeProviders, function (RecipeProviderInterface $provider) use ($packageName, $version) { $provider->removeRecipeFromIndex($packageName, $version); });
+    }
+
+    public function getSessionId(): string
+    {
+        return implode(' ', array_reduce(
+            $this->recipeProviders,
+            function (array $carry, RecipeProviderInterface $provider) {
+                $carry[] = $provider::class.'=>'.$provider->getSessionId();
+
+                return $carry;
+            },
+            []));
+    }
+}

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -13,7 +13,6 @@ namespace Symfony\Flex;
 
 use Composer\Cache;
 use Composer\Composer;
-use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\IO\IOInterface;
@@ -26,7 +25,7 @@ use Composer\Util\Loop;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class Downloader
+class Downloader implements RecipeProviderInterface
 {
     private const DEFAULT_ENDPOINTS = [
         'https://raw.githubusercontent.com/symfony/recipes/flex/main/index.json',
@@ -95,29 +94,44 @@ class Downloader
         $this->composer = $composer;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getSessionId(): string
     {
         return $this->sess;
     }
 
-    public function isEnabled()
+    /**
+     * {@inheritDoc}
+     */
+    public function isEnabled(): bool
     {
         return $this->enabled;
     }
 
-    public function disable()
+    /**
+     * {@inheritDoc}
+     */
+    public function disable(): void
     {
         $this->enabled = false;
     }
 
-    public function getVersions()
+    /**
+     * {@inheritDoc}
+     */
+    public function getVersions(): array
     {
         $this->initialize();
 
         return self::$versions ?? self::$versions = current($this->get([$this->legacyEndpoint.'/versions.json']));
     }
 
-    public function getAliases()
+    /**
+     * {@inheritDoc}
+     */
+    public function getAliases(): array
     {
         $this->initialize();
 
@@ -125,9 +139,7 @@ class Downloader
     }
 
     /**
-     * Downloads recipes.
-     *
-     * @param OperationInterface[] $operations
+     * {@inheritDoc}
      */
     public function getRecipes(array $operations): array
     {
@@ -307,11 +319,9 @@ class Downloader
     }
 
     /**
-     * Used to "hide" a recipe version so that the next most-recent will be returned.
-     *
-     * This is used when resolving "conflicts".
+     * {@inheritDoc}
      */
-    public function removeRecipeFromIndex(string $packageName, string $version)
+    public function removeRecipeFromIndex(string $packageName, string $version): void
     {
         unset($this->index[$packageName][$version]);
     }

--- a/src/LocalRecipeProvider.php
+++ b/src/LocalRecipeProvider.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Symfony\Flex;
+
+use Composer\Composer;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Json\JsonFile;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+class LocalRecipeProvider implements RecipeProviderInterface
+{
+    private bool $enabled = true;
+    private Composer $composer;
+
+    private array $versions = [];
+
+    public function __construct(Composer $composer)
+    {
+        $this->composer = $composer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function disable(): void
+    {
+        $this->enabled = false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getVersions(): array
+    {
+        return $this->versions;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRecipes(array $operations): array
+    {
+        $data = [];
+        foreach ($operations as $operation) {
+            $package = $operation instanceof UpdateOperation ? $operation->getTargetPackage() : $operation->getPackage();
+
+            $installPath = $this->composer->getInstallationManager()->getInstallPath($package);
+            $jsonFile = new JsonFile($installPath.\DIRECTORY_SEPARATOR.'manifest.json');
+            if ($jsonFile->exists()) {
+                $manifest = $jsonFile->read();
+                if (isset($manifest['manifest']['copy-from-recipe'])) {
+                    $copyFolders = array_keys($manifest['manifest']['copy-from-recipe']);
+                    foreach ($copyFolders as $folder) {
+                        $folderPattern = $installPath.\DIRECTORY_SEPARATOR.$folder;
+                        $dir_iterator = new RecursiveDirectoryIterator($folderPattern);
+                        $iterator = new RecursiveIteratorIterator($dir_iterator, RecursiveIteratorIterator::SELF_FIRST);
+                        /** @var SplFileInfo $file */
+                        foreach ($iterator as $file) {
+                            if (is_file($file->getPathname())) {
+                                $manifest['files'][str_replace($installPath.\DIRECTORY_SEPARATOR, '', $file->getPathname())] = [
+                                    'contents' => file_get_contents($file->getPathname()),
+                                    'executable' => is_executable($file->getPathname()), ];
+                            }
+                        }
+                    }
+                }
+                $manifest['origin'] = $installPath;
+                $manifest['is_contrib'] = false;
+                $manifest['version'] = $package->getVersion();
+                $manifest['package'] = $package->getName();
+                $data['manifests'][$package->getName()] = $manifest;
+                $data['locks'][$package->getName()]['recipe']['ref'] = $manifest['ref'];
+                $data['locks'][$package->getName()]['version'] = $package->getVersion();
+
+                if (!isset($this->versions[$package->getName()])) {
+                    $this->versions[$package->getName()] = [];
+                }
+                $this->versions[$package->getName()][] = $package->getVersion();
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function removeRecipeFromIndex(string $packageName, string $version): void
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSessionId(): string
+    {
+        return 'none';
+    }
+}

--- a/src/PackageFilter.php
+++ b/src/PackageFilter.php
@@ -28,15 +28,15 @@ class PackageFilter
     private $versionParser;
     private $symfonyRequire;
     private $symfonyConstraints;
-    private $downloader;
+    private $recipeProvider;
     private $io;
 
-    public function __construct(IOInterface $io, string $symfonyRequire, Downloader $downloader)
+    public function __construct(IOInterface $io, string $symfonyRequire, RecipeProviderInterface $recipeProvider)
     {
         $this->versionParser = new VersionParser();
         $this->symfonyRequire = $symfonyRequire;
         $this->symfonyConstraints = $this->versionParser->parseConstraints($symfonyRequire);
-        $this->downloader = $downloader;
+        $this->recipeProvider = $recipeProvider;
         $this->io = $io;
     }
 
@@ -118,8 +118,8 @@ class PackageFilter
             return $this->versions;
         }
 
-        $versions = $this->downloader->getVersions();
-        $this->downloader = null;
+        $versions = $this->recipeProvider->getVersions();
+        $this->recipeProvider = null;
         $okVersions = [];
 
         if (!isset($versions['splits'])) {

--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -21,11 +21,11 @@ use Composer\Repository\PlatformRepository;
 class PackageResolver
 {
     private static $SYMFONY_VERSIONS = ['lts', 'previous', 'stable', 'next', 'dev'];
-    private $downloader;
+    private RecipeProviderInterface $recipeProvider;
 
-    public function __construct(Downloader $downloader)
+    public function __construct(RecipeProviderInterface $recipeProvider)
     {
-        $this->downloader = $downloader;
+        $this->recipeProvider = $recipeProvider;
     }
 
     public function resolve(array $arguments = [], bool $isRequire = false): array
@@ -58,7 +58,7 @@ class PackageResolver
             return $version ? ':'.$version : '';
         }
 
-        $versions = $this->downloader->getVersions();
+        $versions = $this->recipeProvider->getVersions();
 
         if (!isset($versions['splits'][$package])) {
             return $version ? ':'.$version : '';
@@ -90,7 +90,7 @@ class PackageResolver
             return $argument;
         }
 
-        $aliases = $this->downloader->getAliases();
+        $aliases = $this->recipeProvider->getAliases();
 
         if (isset($aliases[$argument])) {
             $argument = $aliases[$argument];
@@ -116,7 +116,7 @@ class PackageResolver
     private function throwAlternatives(string $argument, int $position)
     {
         $alternatives = [];
-        foreach ($this->downloader->getAliases() as $alias => $package) {
+        foreach ($this->recipeProvider->getAliases() as $alias => $package) {
             $lev = levenshtein($argument, $alias);
             if ($lev <= \strlen($argument) / 3 || ('' !== $argument && false !== strpos($alias, $argument))) {
                 $alternatives[$package][] = $alias;

--- a/src/RecipeProviderInterface.php
+++ b/src/RecipeProviderInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Flex;
+
+use Composer\DependencyResolver\Operation\OperationInterface;
+
+interface RecipeProviderInterface
+{
+    /**
+     * If this RecipeProviderInterface is enabled or not.
+     */
+    public function isEnabled(): bool;
+
+    /**
+     * Disable this RecipeProviderInterface.
+     */
+    public function disable(): void;
+
+    public function getVersions(): array;
+
+    public function getAliases(): array;
+
+    /**
+     * Downloads recipes.
+     *
+     * @param OperationInterface[] $operations
+     */
+    public function getRecipes(array $operations): array;
+
+    /**
+     * Used to "hide" a recipe version so that the next most-recent will be returned.
+     *
+     * This is used when resolving "conflicts".
+     */
+    public function removeRecipeFromIndex(string $packageName, string $version): void;
+
+    public function getSessionId(): string;
+}

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -464,7 +464,7 @@ EOF
             $flex->config = $composer->getConfig();
             $flex->io = $io;
             $flex->configurator = $configurator;
-            $flex->downloader = $downloader;
+            $flex->recipeProvider = $downloader;
             $flex->runningCommand = function () {
             };
             $flex->options = new Options(['config-dir' => 'config', 'var-dir' => 'var', 'root-dir' => '.']);


### PR DESCRIPTION
This feature adds a "LocalRecipeProvider", that also looks in installed bundles for installable recipes.

I couldn't unit test this, as phpunit throws errors, when I try to run it.
`PHP Parse error:  syntax error, unexpected '=' in /opt/project/vendor/symfony/string/Resources/functions.php on line 34`

Also I don't know the requirements for a pull request.

If there are any, that I have missed, please let me know.