### PR TITLE
Fix testMemoryLimit on PHP installed using Nix

### DIFF
--- a/tests/ScriptExecutorTest.php
+++ b/tests/ScriptExecutorTest.php
@@ -39,7 +39,11 @@ final class ScriptExecutorTest extends TestCase
 
         $arguments = $phpFinder->findArguments();
         $ini = php_ini_loaded_file();
-        $arguments[] = "--php-ini={$ini}";
+
+        if (false !== $ini) {
+            $arguments[] = "--php-ini={$ini}";
+        }
+
         $arguments[] = "-d memory_limit={$memoryLimit}";
 
         $phpArgs = implode(' ', array_map([ProcessExecutor::class, 'escape'], $arguments));


### PR DESCRIPTION
With PHP from Nix `php_ini_loaded_file()` returns false as the setup does not have a root `php.ini`


The test just assert was just wrong

```
1) Symfony\Flex\Tests\ScriptExecutorTest::testMemoryLimit
Expectation failed for method name is "execute" when invoked zero or more times
Parameter 0 for invocation Composer\Util\ProcessExecutor::execute(''/nix/store/x8czkm08bkf1979pf...nd.php', Closure Object (...), null): int does not match expected value.
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-''/nix/store/x8czkm08bkf1979pfv1f4d9h2zgh8k9n-php-with-extensions-8.1.12/bin/php' '--php-ini=' '-d memory_limit=32M' ./command.php'
+''/nix/store/x8czkm08bkf1979pfv1f4d9h2zgh8k9n-php-with-extensions-8.1.12/bin/php' '-d memory_limit=32M' ./command.php'

/Users/shyim/Code/flex-plugin/src/ScriptExecutor.php:58
/Users/shyim/Code/flex-plugin/tests/ScriptExecutorTest.php:56
```