### PR TITLE
Allow updating recipes without Git project

### DIFF
--- a/src/Update/GitRecipePatcher.php
+++ b/src/Update/GitRecipePatcher.php
@@ -16,18 +16,16 @@ use Composer\Util\ProcessExecutor;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
-class RecipePatcher
+class GitRecipePatcher
 {
-    private $rootDir;
-    private $filesystem;
-    private $io;
-    private $processExecutor;
+    protected $rootDir;
+    protected $filesystem;
+    protected $processExecutor;
 
     public function __construct(string $rootDir, IOInterface $io)
     {
         $this->rootDir = $rootDir;
         $this->filesystem = new Filesystem();
-        $this->io = $io;
         $this->processExecutor = new ProcessExecutor($io);
     }
 
@@ -143,7 +141,7 @@ class RecipePatcher
         }
     }
 
-    private function execute(string $command, string $cwd): string
+    protected function execute(string $command, string $cwd): string
     {
         $output = '';
         $statusCode = $this->processExecutor->execute($command, $output, $cwd);
@@ -244,7 +242,7 @@ class RecipePatcher
         }
     }
 
-    private function getIgnoredFiles(array $fileNames): array
+    protected function getIgnoredFiles(array $fileNames): array
     {
         $args = implode(' ', array_map([ProcessExecutor::class, 'escape'], $fileNames));
         $output = '';

--- a/src/Update/PlainRecipePatcher.php
+++ b/src/Update/PlainRecipePatcher.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Update;
+
+class PlainRecipePatcher extends GitRecipePatcher
+{
+    /**
+     * Applies the patch using the unix patch command.
+     */
+    public function applyPatch(RecipePatch $patch): bool
+    {
+        $withConflicts = $this->_applyPatchFile($patch);
+
+        foreach ($patch->getDeletedFiles() as $deletedFile) {
+            if ($this->filesystem->exists($this->rootDir.'/'.$deletedFile)) {
+                $this->filesystem->remove($this->rootDir.'/'.$deletedFile);
+            }
+        }
+
+        return $withConflicts;
+    }
+
+    private function _applyPatchFile(RecipePatch $patch)
+    {
+        if (!$patch->getPatch()) {
+            // nothing to do!
+            return true;
+        }
+
+        $patchPath = $this->rootDir.'/_flex_recipe_update.patch';
+        file_put_contents($patchPath, $patch->getPatch());
+
+        try {
+            $output = '';
+            $statusCode = $this->processExecutor->execute('patch -p1 -i "_flex_recipe_update.patch" -f', $output, $this->rootDir);
+
+            if (0 === $statusCode) {
+                // successful with no conflicts
+                return true;
+            }
+
+            throw new \LogicException('Error applying the patch: '.$output);
+        } finally {
+            unlink($patchPath);
+        }
+    }
+
+    protected function getIgnoredFiles(array $fileNames): array
+    {
+        return [];
+    }
+}

--- a/tests/Update/RecipePatcherTest.php
+++ b/tests/Update/RecipePatcherTest.php
@@ -15,8 +15,8 @@ use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
+use Symfony\Flex\Update\GitRecipePatcher;
 use Symfony\Flex\Update\RecipePatch;
-use Symfony\Flex\Update\RecipePatcher;
 
 class RecipePatcherTest extends TestCase
 {
@@ -52,7 +52,7 @@ class RecipePatcherTest extends TestCase
             (new Process(['git', 'commit', '-m', '"original files"'], FLEX_TEST_DIR))->mustRun();
         }
 
-        $patcher = new RecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
+        $patcher = new GitRecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
 
         $patch = $patcher->generatePatch($originalFiles, $newFiles);
         $this->assertSame($expectedPatch, rtrim($patch->getPatch(), "\n"));
@@ -189,7 +189,7 @@ EOF
         $this->getFilesystem()->remove(FLEX_TEST_DIR);
         $this->getFilesystem()->mkdir(FLEX_TEST_DIR);
 
-        $patcher = new RecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
+        $patcher = new GitRecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
 
         // try to update a file that does not exist in the project
         $patch = $patcher->generatePatch(['.env' => 'original contents'], ['.env' => 'new contents']);
@@ -217,7 +217,7 @@ EOF
             (new Process(['git', 'commit', '-m', 'Committing original files'], FLEX_TEST_DIR))->mustRun();
         }
 
-        $patcher = new RecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
+        $patcher = new GitRecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
         $hadConflicts = !$patcher->applyPatch($recipePatch);
 
         foreach ($expectedFiles as $file => $expectedContents) {
@@ -345,7 +345,7 @@ EOF
         (new Process(['git', 'add', '-A'], FLEX_TEST_DIR))->mustRun();
         (new Process(['git', 'commit', '-m', 'committing in app start files'], FLEX_TEST_DIR))->mustRun();
 
-        $patcher = new RecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
+        $patcher = new GitRecipePatcher(FLEX_TEST_DIR, $this->createMock(IOInterface::class));
         $originalFiles = [
             '.env' => $files['dot_env_clean']['original_recipe'],
             'package.json' => $files['package_json_conflict']['original_recipe'],


### PR DESCRIPTION
We want to migrate at Shopware our Zip Based Installation users to Composer. For that reason, we are building an own application which updates a project using Composer on shared hosters. 

People using Zip files to deploy their stuff are not using Git for their project 🙈 . So I just added the option to use normal Unix `patch` to patch the files of the changed files instead of expecting a Git repository there.

The Git way is still supported. I just fallback to `patch` when a git project is not present