### PR TITLE
Correctly resolve the lock alias

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -34,11 +34,11 @@ class PackageResolver
         $packages = [];
         foreach ($arguments as $i => $argument) {
             if ((false !== $pos = strpos($argument, ':')) || (false !== $pos = strpos($argument, '='))) {
-                $package = $this->resolvePackageName(substr($argument, 0, $pos), $i);
+                $package = $this->resolvePackageName(substr($argument, 0, $pos), $i, $isRequire);
                 $version = substr($argument, $pos + 1);
                 $packages[] = $package.':'.$version;
             } else {
-                $packages[] = $this->resolvePackageName($argument, $i);
+                $packages[] = $this->resolvePackageName($argument, $i, $isRequire);
             }
         }
 
@@ -84,9 +84,15 @@ class PackageResolver
         return ':'.$version;
     }
 
-    private function resolvePackageName(string $argument, int $position): string
+    private function resolvePackageName(string $argument, int $position, bool $isRequire): string
     {
-        if (false !== strpos($argument, '/') || preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument) || preg_match('{(?<=[a-z0-9_/-])\*|\*(?=[a-z0-9_/-])}i', $argument) || \in_array($argument, ['lock', 'mirrors', 'nothing', ''])) {
+        $skippedPackages = ['mirrors', 'nothing', ''];
+
+        if (!$isRequire) {
+            $skippedPackages[] = 'lock';
+        }
+
+        if (false !== strpos($argument, '/') || preg_match(PlatformRepository::PLATFORM_PACKAGE_REGEX, $argument) || preg_match('{(?<=[a-z0-9_/-])\*|\*(?=[a-z0-9_/-])}i', $argument) || \in_array($argument, $skippedPackages)) {
             return $argument;
         }
 

--- a/tests/PackageResolverTest.php
+++ b/tests/PackageResolverTest.php
@@ -20,9 +20,9 @@ class PackageResolverTest extends TestCase
     /**
      * @dataProvider getPackages
      */
-    public function testResolve($packages, $resolved)
+    public function testResolve($packages, $resolved, bool $isRequire = false)
     {
-        $this->assertEquals($resolved, $this->getResolver()->resolve($packages));
+        $this->assertEquals($resolved, $this->getResolver()->resolve($packages, $isRequire));
     }
 
     public function getPackages()
@@ -31,6 +31,16 @@ class PackageResolverTest extends TestCase
             [
                 ['cli'],
                 ['symfony/console'],
+            ],
+            [
+                ['lock'],
+                ['lock'],
+                false,
+            ],
+            [
+                ['lock'],
+                ['symfony/lock'],
+                true,
             ],
             [
                 ['cli', 'symfony/workflow'],
@@ -116,6 +126,7 @@ class PackageResolverTest extends TestCase
                 'console' => 'symfony/console',
                 'translation' => 'symfony/translation',
                 'validator' => 'symfony/validator',
+                'lock' => 'symfony/lock',
             ]);
 
         return new PackageResolver($downloader);


### PR DESCRIPTION
`composer require lock` doesn't resolve the `lock` alias because the package name resolution is skipped when the package argument is `lock`. This PR bypasses this specifically for the `require` command, so that `composer require lock` correctly resolved the alias, but `composer update lock` still skips the name resolution.

Reference: https://github.com/symfony/recipes/issues/1150