### PR TITLE
Fix recipe history url

### DIFF
--- a/src/Command/RecipesCommand.php
+++ b/src/Command/RecipesCommand.php
@@ -165,6 +165,10 @@ class RecipesCommand extends BaseCommand
         $lockBranch = $recipeLock['recipe']['branch'] ?? null;
         $lockVersion = $recipeLock['recipe']['version'] ?? $recipeLock['version'] ?? null;
 
+        if ('master' === $lockBranch && \in_array($lockRepo, ['github.com/symfony/recipes', 'github.com/symfony/recipes-contrib'])) {
+            $lockBranch = 'main';
+        }
+
         $status = '<comment>up to date</comment>';
         if ($recipe->isAuto()) {
             $status = '<comment>auto-generated recipe</comment>';


### PR DESCRIPTION
Recipes that are installed from the branch master now point to a history url that results in a 404.

Before:
<img width="955" alt="flex-before" src="https://user-images.githubusercontent.com/117380/206744288-5ccc312c-da35-4baa-9aab-7cee1f9025d9.png">

After:
<img width="955" alt="flex-after" src="https://user-images.githubusercontent.com/117380/206744512-76d733d8-c9cd-417f-9ed5-f45dde73345c.png">
