### PR TITLE
Add --yes flag to recipes:install command to overwrite all files without asking

### DIFF
--- a/src/Command/InstallRecipesCommand.php
+++ b/src/Command/InstallRecipesCommand.php
@@ -46,6 +46,7 @@ class InstallRecipesCommand extends BaseCommand
             ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Recipes that should be installed.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Overwrite existing files when a new version of a recipe is available')
             ->addOption('reset', null, InputOption::VALUE_NONE, 'Reset all recipes back to their initial state (should be combined with --force)')
+            ->addOption('yes', null, InputOption::VALUE_NONE, "Answer prompt questions with 'yes' for all questions.")
         ;
     }
 
@@ -135,7 +136,7 @@ class InstallRecipesCommand extends BaseCommand
             }
         }
 
-        $this->flex->update(new UpdateEvent($force, (bool) $input->getOption('reset')), $operations);
+        $this->flex->update(new UpdateEvent($force, (bool) $input->getOption('reset'), (bool) $input->getOption('yes')), $operations);
 
         if ($force) {
             $output = [

--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -124,8 +124,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
             return;
         }
 
-        $overwrite = $options['force'] ?? false;
-        if (!$this->options->shouldWriteFile($target, $overwrite)) {
+        if (!$this->options->shouldWriteFile($target, $options['force'] ?? false, $options['assumeYesForPrompts'] ?? false)) {
             return;
         }
 

--- a/src/Configurator/CopyFromRecipeConfigurator.php
+++ b/src/Configurator/CopyFromRecipeConfigurator.php
@@ -127,11 +127,10 @@ class CopyFromRecipeConfigurator extends AbstractConfigurator
 
     private function copyFile(string $to, string $contents, bool $executable, array $options): string
     {
-        $overwrite = $options['force'] ?? false;
         $basePath = $options['root-dir'] ?? '.';
         $copiedFile = $this->getLocalFilePath($basePath, $to);
 
-        if (!$this->options->shouldWriteFile($to, $overwrite)) {
+        if (!$this->options->shouldWriteFile($to, $options['force'] ?? false, $options['assumeYesForPrompts'] ?? false)) {
             return $copiedFile;
         }
 

--- a/src/Event/UpdateEvent.php
+++ b/src/Event/UpdateEvent.php
@@ -18,12 +18,14 @@ class UpdateEvent extends Event
 {
     private $force;
     private $reset;
+    private $assumeYesForPrompts;
 
-    public function __construct(bool $force, bool $reset)
+    public function __construct(bool $force, bool $reset, bool $assumeYesForPrompts)
     {
         $this->name = ScriptEvents::POST_UPDATE_CMD;
         $this->force = $force;
         $this->reset = $reset;
+        $this->assumeYesForPrompts = $assumeYesForPrompts;
     }
 
     public function force(): bool
@@ -34,5 +36,10 @@ class UpdateEvent extends Event
     public function reset(): bool
     {
         return $this->reset;
+    }
+
+    public function assumeYesForPrompts(): bool
+    {
+        return $this->assumeYesForPrompts;
     }
 }

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -447,6 +447,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                     $this->io->writeError(\sprintf('  - Configuring %s', $this->formatOrigin($recipe)));
                     $this->configurator->install($recipe, $this->lock, [
                         'force' => $event instanceof UpdateEvent && $event->force(),
+                        'assumeYesForPrompts' => $event instanceof UpdateEvent && $event->assumeYesForPrompts(),
                     ]);
                     $manifest = $recipe->getManifest();
                     if (isset($manifest['post-install-output'])) {
@@ -471,6 +472,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             foreach ($postInstallRecipes as $recipe) {
                 $this->configurator->postInstall($recipe, $this->lock, [
                     'force' => $event instanceof UpdateEvent && $event->force(),
+                    'assumeYesForPrompts' => $event instanceof UpdateEvent && $event->assumeYesForPrompts(),
                 ]);
             }
         }

--- a/src/Options.php
+++ b/src/Options.php
@@ -62,7 +62,7 @@ class Options
         return file_exists($rootDir.'/'.$otherPhpunitDistFile) ? $otherPhpunitDistFile : $result;
     }
 
-    public function shouldWriteFile(string $file, bool $overwrite): bool
+    public function shouldWriteFile(string $file, bool $overwrite, bool $skipQuestion): bool
     {
         if (isset($this->writtenFiles[$file])) {
             return false;
@@ -78,6 +78,10 @@ class Options
         }
 
         if (!filesize($file)) {
+            return true;
+        }
+
+        if ($skipQuestion) {
             return true;
         }
 

--- a/tests/Command/InstallRecipesCommandTest.php
+++ b/tests/Command/InstallRecipesCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests\Command;
+
+use Composer\Console\Application;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Flex\Command\InstallRecipesCommand;
+use Symfony\Flex\Event\UpdateEvent;
+use Symfony\Flex\Flex;
+
+class InstallRecipesCommandTest extends TestCase
+{
+    public function testCommandFlagsPassedDown()
+    {
+        $flex = $this->createMock(Flex::class);
+        $flex->method('update')->willReturnCallback(function (UpdateEvent $event) {
+            $this->assertTrue($event->reset());
+            $this->assertTrue($event->assumeYesForPrompts());
+        });
+
+        $command = new InstallRecipesCommand($flex, __DIR__);
+        $application = new Application();
+        $application->add($command);
+        $command = $application->find('symfony:recipes:install');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--reset' => true,
+            '--yes' => true,
+        ]);
+    }
+}

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests;
+
+use Composer\IO\IOInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+use Symfony\Flex\Options;
+
+class OptionsTest extends TestCase
+{
+    public function testShouldWrite()
+    {
+        @mkdir(FLEX_TEST_DIR);
+        (new Process(['git', 'init'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Unit test'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'config', 'user.email', ''], FLEX_TEST_DIR))->mustRun();
+
+        $filePath = FLEX_TEST_DIR.'/a.txt';
+        file_put_contents($filePath, 'a');
+        (new Process(['git', 'add', '-A'], FLEX_TEST_DIR))->mustRun();
+        (new Process(['git', 'commit', '-m', 'setup of original files'], FLEX_TEST_DIR))->mustRun();
+
+        file_put_contents($filePath, 'b');
+
+        $this->assertTrue((new Options([], null))->shouldWriteFile('non-existing-file.txt', false, false));
+        $this->assertFalse((new Options([], null))->shouldWriteFile($filePath, false, false));
+
+        // We don't have an IO, so we don't write the file
+        $this->assertFalse((new Options([], null))->shouldWriteFile($filePath, true, false));
+
+        // We have an IO, and it allowed to write the file
+        $io = $this->createMock(IOInterface::class);
+        $io->expects($this->once())->method('askConfirmation')->willReturn(true);
+        $this->assertTrue((new Options([], $io))->shouldWriteFile($filePath, true, false));
+
+        // We skip all questions, so we're able to write
+        $this->assertTrue((new Options([], null))->shouldWriteFile($filePath, true, true));
+    }
+}


### PR DESCRIPTION
When I run `recipes:install --reset --force -n` **no files are overwritten**, as the default as been set to false.

There is currently also no way to accept that, so I changed it back to `true`