### PR TITLE
Keep existing constraints in package.json

### DIFF
--- a/src/PackageJsonSynchronizer.php
+++ b/src/PackageJsonSynchronizer.php
@@ -13,6 +13,7 @@ namespace Symfony\Flex;
 
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
+use Composer\Semver\VersionParser;
 use Seld\JsonLint\ParsingException;
 
 /**
@@ -23,11 +24,13 @@ class PackageJsonSynchronizer
 {
     private $rootDir;
     private $vendorDir;
+    private $versionParser;
 
     public function __construct(string $rootDir, string $vendorDir = 'vendor')
     {
         $this->rootDir = $rootDir;
         $this->vendorDir = $vendorDir;
+        $this->versionParser = new VersionParser();
     }
 
     public function shouldSynchronize(): bool
@@ -136,8 +139,10 @@ class PackageJsonSynchronizer
                 $content['devDependencies'][$dependency] = $constraint;
                 $didChangePackageJson = true;
             } elseif ($constraint !== $content[$parentNode][$dependency]) {
-                $content[$parentNode][$dependency] = $constraint;
-                $didChangePackageJson = true;
+                if ($this->shouldUpdateConstraint($content[$parentNode][$dependency], $constraint)) {
+                    $content[$parentNode][$dependency] = $constraint;
+                    $didChangePackageJson = true;
+                }
             }
         }
 
@@ -161,6 +166,18 @@ class PackageJsonSynchronizer
         }
 
         return $didChangePackageJson;
+    }
+
+    private function shouldUpdateConstraint(string $existingConstraint, string $constraint)
+    {
+        try {
+            $existingConstraint = $this->versionParser->parseConstraints($existingConstraint);
+            $constraint = $this->versionParser->parseConstraints($constraint);
+
+            return !$existingConstraint->matches($constraint);
+        } catch (\UnexpectedValueException $e) {
+            return true;
+        }
     }
 
     private function registerWebpackResources(array $phpPackages)

--- a/tests/Fixtures/packageJson/stricter_constraints_package.json
+++ b/tests/Fixtures/packageJson/stricter_constraints_package.json
@@ -1,0 +1,11 @@
+{
+   "name": "symfony/fixture",
+   "devDependencies": {
+      "@hotcookies": "^2",
+      "@hotdogs": "^1.9",
+      "@symfony/existing-package": "file:vendor/symfony/existing-package/Resources/assets"
+   },
+   "browserslist": [
+      "defaults"
+   ]
+}

--- a/tests/PackageJsonSynchronizerTest.php
+++ b/tests/PackageJsonSynchronizerTest.php
@@ -245,4 +245,34 @@ class PackageJsonSynchronizerTest extends TestCase
             json_decode(file_get_contents($this->tempDir.'/package.json'), true)
         );
     }
+
+    public function testStricterConstraintsAreKeptNonMatchingAreReplaced()
+    {
+        (new Filesystem())->copy($this->tempDir.'/stricter_constraints_package.json', $this->tempDir.'/package.json', true);
+
+        $this->synchronizer->synchronize([
+            [
+                'name' => 'symfony/existing-package',
+                'keywords' => ['symfony-ux'],
+            ],
+        ]);
+
+        // Should keep existing constraints when stricter than packages ones
+        $this->assertSame(
+            [
+                'name' => 'symfony/fixture',
+                'devDependencies' => [
+                    // this satisfies the constraint, so it's kept
+                    '@hotcookies' => '^2',
+                    // this was too low, so it's replaced
+                    '@hotdogs' => '^2',
+                    '@symfony/existing-package' => 'file:vendor/symfony/existing-package/Resources/assets',
+                ],
+                'browserslist' => [
+                    'defaults',
+                ],
+            ],
+            json_decode(file_get_contents($this->tempDir.'/package.json'), true)
+        );
+    }
 }


### PR DESCRIPTION
When a dependency constraint is already set in the package.json, the PackageSynchroniser replaces it with even if the constraint is valid.

This PR changes this behaviour and let the constraint untouched if it matches the one provided by the PHP package.

Related issues:
* https://github.com/symfony/flex/issues/843
* https://github.com/symfony/flex/issues/938