### PR TITLE
New "add-lines" configurator for simple file patching + importmap support

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -25,6 +25,7 @@ class Configurator
     private $io;
     private $options;
     private $configurators;
+    private $postInstallConfigurators;
     private $cache;
 
     public function __construct(Composer $composer, IOInterface $io, Options $options)
@@ -45,6 +46,9 @@ class Configurator
             'dockerfile' => Configurator\DockerfileConfigurator::class,
             'docker-compose' => Configurator\DockerComposeConfigurator::class,
         ];
+        $this->postInstallConfigurators = [
+            'add-lines' => Configurator\AddLinesConfigurator::class,
+        ];
     }
 
     public function install(Recipe $recipe, Lock $lock, array $options = [])
@@ -57,11 +61,25 @@ class Configurator
         }
     }
 
+    /**
+     * Run after all recipes have been installed to run post-install configurators.
+     */
+    public function postInstall(Recipe $recipe, Lock $lock, array $options = [])
+    {
+        $manifest = $recipe->getManifest();
+        foreach (array_keys($this->postInstallConfigurators) as $key) {
+            if (isset($manifest[$key])) {
+                $this->get($key)->configure($recipe, $manifest[$key], $lock, $options);
+            }
+        }
+    }
+
     public function populateUpdate(RecipeUpdate $recipeUpdate): void
     {
         $originalManifest = $recipeUpdate->getOriginalRecipe()->getManifest();
         $newManifest = $recipeUpdate->getNewRecipe()->getManifest();
-        foreach (array_keys($this->configurators) as $key) {
+        $allConfigurators = array_merge($this->configurators, $this->postInstallConfigurators);
+        foreach (array_keys($allConfigurators) as $key) {
             if (!isset($originalManifest[$key]) && !isset($newManifest[$key])) {
                 continue;
             }
@@ -73,7 +91,10 @@ class Configurator
     public function unconfigure(Recipe $recipe, Lock $lock)
     {
         $manifest = $recipe->getManifest();
-        foreach (array_keys($this->configurators) as $key) {
+
+        $allConfigurators = array_merge($this->configurators, $this->postInstallConfigurators);
+
+        foreach (array_keys($allConfigurators) as $key) {
             if (isset($manifest[$key])) {
                 $this->get($key)->unconfigure($recipe, $manifest[$key], $lock);
             }
@@ -82,7 +103,7 @@ class Configurator
 
     private function get($key): AbstractConfigurator
     {
-        if (!isset($this->configurators[$key])) {
+        if (!isset($this->configurators[$key]) && !isset($this->postInstallConfigurators[$key])) {
             throw new \InvalidArgumentException(sprintf('Unknown configurator "%s".', $key));
         }
 
@@ -90,7 +111,7 @@ class Configurator
             return $this->cache[$key];
         }
 
-        $class = $this->configurators[$key];
+        $class = isset($this->configurators[$key]) ? $this->configurators[$key] : $this->postInstallConfigurators[$key];
 
         return $this->cache[$key] = new $class($this->composer, $this->io, $this->options);
     }

--- a/src/Configurator/AbstractConfigurator.php
+++ b/src/Configurator/AbstractConfigurator.php
@@ -43,7 +43,7 @@ abstract class AbstractConfigurator
 
     abstract public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void;
 
-    protected function write($messages)
+    protected function write($messages, $verbosity = IOInterface::VERBOSE)
     {
         if (!\is_array($messages)) {
             $messages = [$messages];
@@ -51,7 +51,7 @@ abstract class AbstractConfigurator
         foreach ($messages as $i => $message) {
             $messages[$i] = '    '.$message;
         }
-        $this->io->writeError($messages, true, IOInterface::VERBOSE);
+        $this->io->writeError($messages, true, $verbosity);
     }
 
     protected function isFileMarked(Recipe $recipe, string $file): bool

--- a/src/Configurator/AddLinesConfigurator.php
+++ b/src/Configurator/AddLinesConfigurator.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Symfony\Flex\Configurator;
+
+use Composer\IO\IOInterface;
+use Symfony\Flex\Lock;
+use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class AddLinesConfigurator extends AbstractConfigurator
+{
+    private const POSITION_TOP = 'top';
+    private const POSITION_BOTTOM = 'bottom';
+    private const POSITION_AFTER_TARGET = 'after_target';
+
+    private const VALID_POSITIONS = [
+        self::POSITION_TOP,
+        self::POSITION_BOTTOM,
+        self::POSITION_AFTER_TARGET,
+    ];
+
+    public function configure(Recipe $recipe, $config, Lock $lock, array $options = []): void
+    {
+        foreach ($config as $patch) {
+            if (!isset($patch['file'])) {
+                $this->write(sprintf('The "file" key is required for the "add-lines" configurator for recipe "%s". Skipping', $recipe->getName()));
+
+                continue;
+            }
+
+            if (isset($patch['requires']) && !$this->isPackageInstalled($patch['requires'])) {
+                continue;
+            }
+
+            if (!isset($patch['content'])) {
+                $this->write(sprintf('The "content" key is required for the "add-lines" configurator for recipe "%s". Skipping', $recipe->getName()));
+
+                continue;
+            }
+            $content = $patch['content'];
+
+            $file = $this->path->concatenate([$this->options->get('root-dir'), $patch['file']]);
+            $warnIfMissing = isset($patch['warn_if_missing']) && $patch['warn_if_missing'];
+            if (!is_file($file)) {
+                $this->write([
+                    sprintf('Could not add lines to file <info>%s</info> as it does not exist. Missing lines:', $patch['file']),
+                    '<comment>"""</comment>',
+                    $content,
+                    '<comment>"""</comment>',
+                    '',
+                ], $warnIfMissing ? IOInterface::NORMAL : IOInterface::VERBOSE);
+
+                continue;
+            }
+
+            $this->write(sprintf('Patching file "%s"', $patch['file']));
+
+            if (!isset($patch['position'])) {
+                $this->write(sprintf('The "position" key is required for the "add-lines" configurator for recipe "%s". Skipping', $recipe->getName()));
+
+                continue;
+            }
+            $position = $patch['position'];
+            if (!\in_array($position, self::VALID_POSITIONS, true)) {
+                $this->write(sprintf('The "position" key must be one of "%s" for the "add-lines" configurator for recipe "%s". Skipping', implode('", "', self::VALID_POSITIONS), $recipe->getName()));
+
+                continue;
+            }
+
+            if (self::POSITION_AFTER_TARGET === $position && !isset($patch['target'])) {
+                $this->write(sprintf('The "target" key is required when "position" is "%s" for the "add-lines" configurator for recipe "%s". Skipping', self::POSITION_AFTER_TARGET, $recipe->getName()));
+
+                continue;
+            }
+            $target = isset($patch['target']) ? $patch['target'] : null;
+
+            $this->patchFile($file, $content, $position, $target, $warnIfMissing);
+        }
+    }
+
+    public function unconfigure(Recipe $recipe, $config, Lock $lock): void
+    {
+        foreach ($config as $patch) {
+            if (!isset($patch['file'])) {
+                $this->write(sprintf('The "file" key is required for the "add-lines" configurator for recipe "%s". Skipping', $recipe->getName()));
+
+                continue;
+            }
+
+            // Ignore "requires": the target packages may have just become uninstalled.
+            // Checking for a "content" match is enough.
+
+            $file = $this->path->concatenate([$this->options->get('root-dir'), $patch['file']]);
+            if (!is_file($file)) {
+                continue;
+            }
+
+            if (!isset($patch['content'])) {
+                $this->write(sprintf('The "content" key is required for the "add-lines" configurator for recipe "%s". Skipping', $recipe->getName()));
+
+                continue;
+            }
+            $value = $patch['content'];
+
+            $this->unPatchFile($file, $value);
+        }
+    }
+
+    public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
+    {
+        $originalConfig = array_filter($originalConfig, function ($item) {
+            return !isset($item['requires']) || $this->isPackageInstalled($item['requires']);
+        });
+        $newConfig = array_filter($newConfig, function ($item) {
+            return !isset($item['requires']) || $this->isPackageInstalled($item['requires']);
+        });
+
+        $filterDuplicates = function (array $sourceConfig, array $comparisonConfig) {
+            $filtered = [];
+            foreach ($sourceConfig as $sourceItem) {
+                $found = false;
+                foreach ($comparisonConfig as $comparisonItem) {
+                    if ($sourceItem['file'] === $comparisonItem['file'] && $sourceItem['content'] === $comparisonItem['content']) {
+                        $found = true;
+                        break;
+                    }
+                }
+                if (!$found) {
+                    $filtered[] = $sourceItem;
+                }
+            }
+
+            return $filtered;
+        };
+
+        // remove any config where the file+value is the same before & after
+        $filteredOriginalConfig = $filterDuplicates($originalConfig, $newConfig);
+        $filteredNewConfig = $filterDuplicates($newConfig, $originalConfig);
+
+        $this->unconfigure($recipeUpdate->getOriginalRecipe(), $filteredOriginalConfig, $recipeUpdate->getLock());
+        $this->configure($recipeUpdate->getNewRecipe(), $filteredNewConfig, $recipeUpdate->getLock());
+    }
+
+    private function patchFile(string $file, string $value, string $position, ?string $target, bool $warnIfMissing)
+    {
+        $fileContents = file_get_contents($file);
+
+        if (false !== strpos($fileContents, $value)) {
+            return; // already includes value, skip
+        }
+
+        switch ($position) {
+            case self::POSITION_BOTTOM:
+                $fileContents .= "\n".$value;
+
+                break;
+            case self::POSITION_TOP:
+                $fileContents = $value."\n".$fileContents;
+
+                break;
+            case self::POSITION_AFTER_TARGET:
+                $lines = explode("\n", $fileContents);
+                $targetFound = false;
+                foreach ($lines as $key => $line) {
+                    if (false !== strpos($line, $target)) {
+                        array_splice($lines, $key + 1, 0, $value);
+                        $targetFound = true;
+
+                        break;
+                    }
+                }
+                $fileContents = implode("\n", $lines);
+
+                if (!$targetFound) {
+                    $this->write([
+                        sprintf('Could not add lines after "%s" as no such string was found in "%s". Missing lines:', $target, $file),
+                        '<comment>"""</comment>',
+                        $value,
+                        '<comment>"""</comment>',
+                        '',
+                    ], $warnIfMissing ? IOInterface::NORMAL : IOInterface::VERBOSE);
+                }
+
+                break;
+        }
+
+        file_put_contents($file, $fileContents);
+    }
+
+    private function unPatchFile(string $file, $value)
+    {
+        $fileContents = file_get_contents($file);
+
+        if (false === strpos($fileContents, $value)) {
+            return; // value already gone!
+        }
+
+        if (false !== strpos($fileContents, "\n".$value)) {
+            $value = "\n".$value;
+        } elseif (false !== strpos($fileContents, $value."\n")) {
+            $value = $value."\n";
+        }
+
+        $position = strpos($fileContents, $value);
+        $fileContents = substr_replace($fileContents, '', $position, \strlen($value));
+
+        file_put_contents($file, $fileContents);
+    }
+
+    private function isPackageInstalled($packages): bool
+    {
+        if (\is_string($packages)) {
+            $packages = [$packages];
+        }
+
+        $installedRepo = $this->composer->getRepositoryManager()->getLocalRepository();
+
+        foreach ($packages as $packageName) {
+            if (null === $installedRepo->findPackage($packageName, '*')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -473,6 +473,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $installContribs = $this->composer->getPackage()->getExtra()['symfony']['allow-contrib'] ?? false;
         $manifest = null;
         $originalComposerJsonHash = $this->getComposerJsonHash();
+        $postInstallRecipes = [];
         foreach ($recipes as $recipe) {
             if ('install' === $recipe->getJob() && !$installContribs && $recipe->isContrib()) {
                 $warning = $this->io->isInteractive() ? 'WARNING' : 'IGNORING';
@@ -519,6 +520,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
             switch ($recipe->getJob()) {
                 case 'install':
+                    $postInstallRecipes[] = $recipe;
                     $this->io->writeError(sprintf('  - Configuring %s', $this->formatOrigin($recipe)));
                     $this->configurator->install($recipe, $this->lock, [
                         'force' => $event instanceof UpdateEvent && $event->force(),
@@ -540,6 +542,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
                     $this->configurator->unconfigure($recipe, $this->lock);
                     break;
             }
+        }
+
+        foreach ($postInstallRecipes as $recipe) {
+            $this->configurator->postInstall($recipe, $this->lock, [
+                'force' => $event instanceof UpdateEvent && $event->force(),
+            ]);
         }
 
         if (null !== $manifest) {
@@ -572,16 +580,11 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $rootDir = realpath($rootDir);
         $vendorDir = trim((new Filesystem())->makePathRelative($this->config->get('vendor-dir'), $rootDir), '/');
 
-        $synchronizer = new PackageJsonSynchronizer($rootDir, $vendorDir);
+        $executor = new ScriptExecutor($this->composer, $this->io, $this->options);
+        $synchronizer = new PackageJsonSynchronizer($rootDir, $vendorDir, $executor);
 
         if ($synchronizer->shouldSynchronize()) {
             $lockData = $this->composer->getLocker()->getLockData();
-
-            if (method_exists($synchronizer, 'addPackageJsonLink') && 'string' === (new \ReflectionParameter([$synchronizer, 'addPackageJsonLink'], 'phpPackage'))->getType()->getName()) {
-                // support for smooth upgrades from older flex versions
-                $lockData['packages'] = array_column($lockData['packages'] ?? [], 'name');
-                $lockData['packages-dev'] = array_column($lockData['packages-dev'] ?? [], 'name');
-            }
 
             if ($synchronizer->synchronize(array_merge($lockData['packages'] ?? [], $lockData['packages-dev'] ?? []))) {
                 $this->io->writeError('<info>Synchronizing package.json with PHP packages</>');
@@ -773,7 +776,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $job = method_exists($operation, 'getOperationType') ? $operation->getOperationType() : $operation->getJobType();
 
             if (!isset($manifests[$name]) && isset($data['conflicts'][$name])) {
-                $this->io->writeError(sprintf('  - Skipping recipe for %s: all versions of the recipe conflict with your package versions.', $name), true, IOInterface::VERBOSE);
+                $this->io->writeError(sprintf('  - Skipping recipe for %s: all versions of the recipe conflict with your package versions.', $name));
                 continue;
             }
 
@@ -784,7 +787,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
                 if (!isset($newManifests[$name])) {
                     // no older recipe found
-                    $this->io->writeError(sprintf('  - Skipping recipe for %s: all versions of the recipe conflict with your package versions.', $name), true, IOInterface::VERBOSE);
+                    $this->io->writeError(sprintf('  - Skipping recipe for %s: all versions of the recipe conflict with your package versions.', $name));
 
                     continue 2;
                 }

--- a/src/PackageJsonSynchronizer.php
+++ b/src/PackageJsonSynchronizer.php
@@ -24,22 +24,30 @@ class PackageJsonSynchronizer
 {
     private $rootDir;
     private $vendorDir;
+    private $scriptExecutor;
     private $versionParser;
 
-    public function __construct(string $rootDir, string $vendorDir = 'vendor')
+    public function __construct(string $rootDir, string $vendorDir, ScriptExecutor $scriptExecutor)
     {
         $this->rootDir = $rootDir;
         $this->vendorDir = $vendorDir;
+        $this->scriptExecutor = $scriptExecutor;
         $this->versionParser = new VersionParser();
     }
 
     public function shouldSynchronize(): bool
     {
-        return $this->rootDir && file_exists($this->rootDir.'/package.json');
+        return $this->rootDir && (file_exists($this->rootDir.'/package.json') || file_exists($this->rootDir.'/importmap.php'));
     }
 
     public function synchronize(array $phpPackages): bool
     {
+        if (file_exists($this->rootDir.'/importmap.php')) {
+            $this->synchronizeForAssetMapper($phpPackages);
+
+            return false;
+        }
+
         try {
             JsonFile::parseJson(file_get_contents($this->rootDir.'/package.json'));
         } catch (ParsingException $e) {
@@ -51,26 +59,33 @@ class PackageJsonSynchronizer
 
         $dependencies = [];
 
-        foreach ($phpPackages as $k => $phpPackage) {
-            if (\is_string($phpPackage)) {
-                // support for smooth upgrades from older flex versions
-                $phpPackages[$k] = $phpPackage = [
-                    'name' => $phpPackage,
-                    'keywords' => ['symfony-ux'],
-                ];
-            }
-
-            foreach ($this->resolvePackageDependencies($phpPackage) as $dependency => $constraint) {
+        $phpPackages = $this->normalizePhpPackages($phpPackages);
+        foreach ($phpPackages as $phpPackage) {
+            foreach ($this->resolvePackageJsonDependencies($phpPackage) as $dependency => $constraint) {
                 $dependencies[$dependency][$phpPackage['name']] = $constraint;
             }
         }
 
-        $didChangePackageJson = $this->registerDependencies($dependencies) || $didChangePackageJson;
+        $didChangePackageJson = $this->registerDependenciesInPackageJson($dependencies) || $didChangePackageJson;
 
         // Register controllers and entrypoints in controllers.json
-        $this->registerWebpackResources($phpPackages);
+        $this->updateControllersJsonFile($phpPackages);
 
         return $didChangePackageJson;
+    }
+
+    private function synchronizeForAssetMapper(array $phpPackages): void
+    {
+        $importMapEntries = [];
+        $phpPackages = $this->normalizePhpPackages($phpPackages);
+        foreach ($phpPackages as $phpPackage) {
+            foreach ($this->resolveImportMapPackages($phpPackage) as $name => $dependencyConfig) {
+                $importMapEntries[$name] = $dependencyConfig;
+            }
+        }
+
+        $this->updateImportMap($importMapEntries);
+        $this->updateControllersJsonFile($phpPackages);
     }
 
     private function removeObsoletePackageJsonLinks(): bool
@@ -102,7 +117,7 @@ class PackageJsonSynchronizer
         return $didChangePackageJson;
     }
 
-    private function resolvePackageDependencies($phpPackage): array
+    private function resolvePackageJsonDependencies($phpPackage): array
     {
         $dependencies = [];
 
@@ -110,7 +125,9 @@ class PackageJsonSynchronizer
             return $dependencies;
         }
 
-        $dependencies['@'.$phpPackage['name']] = 'file:'.substr($packageJson->getPath(), 1 + \strlen($this->rootDir), -13);
+        if ($packageJson->read()['symfony']['needsPackageAsADependency'] ?? true) {
+            $dependencies['@'.$phpPackage['name']] = 'file:'.substr($packageJson->getPath(), 1 + \strlen($this->rootDir), -13);
+        }
 
         foreach ($packageJson->read()['peerDependencies'] ?? [] as $peerDependency => $constraint) {
             $dependencies[$peerDependency] = $constraint;
@@ -119,7 +136,48 @@ class PackageJsonSynchronizer
         return $dependencies;
     }
 
-    private function registerDependencies(array $flexDependencies): bool
+    private function resolveImportMapPackages($phpPackage): array
+    {
+        if (!$packageJson = $this->resolvePackageJson($phpPackage)) {
+            return [];
+        }
+
+        $dependencies = [];
+
+        foreach ($packageJson->read()['symfony']['importmap'] ?? [] as $importMapName => $constraintConfig) {
+            if (\is_array($constraintConfig)) {
+                $constraint = $constraintConfig['version'] ?? [];
+                $preload = $constraintConfig['preload'] ?? false;
+                $package = $constraintConfig['package'] ?? $importMapName;
+            } else {
+                $constraint = $constraintConfig;
+                $preload = false;
+                $package = $importMapName;
+            }
+
+            if (0 === strpos($constraint, 'path:')) {
+                $path = substr($constraint, 5);
+                $path = str_replace('%PACKAGE%', \dirname($packageJson->getPath()), $path);
+
+                $dependencies[$importMapName] = [
+                    'path' => $path,
+                    'preload' => $preload,
+                ];
+
+                continue;
+            }
+
+            $dependencies[$importMapName] = [
+                'version' => $constraint,
+                'package' => $package,
+                'preload' => $preload,
+            ];
+        }
+
+        return $dependencies;
+    }
+
+    private function registerDependenciesInPackageJson(array $flexDependencies): bool
     {
         $didChangePackageJson = false;
 
@@ -180,7 +238,59 @@ class PackageJsonSynchronizer
         }
     }
 
-    private function registerWebpackResources(array $phpPackages)
+    /**
+     * @param array<string, array{path?: string, preload: bool, package?: string, version?: string}> $importMapEntries
+     */
+    private function updateImportMap(array $importMapEntries): void
+    {
+        if (!$importMapEntries) {
+            return;
+        }
+
+        $importMapData = include $this->rootDir.'/importmap.php';
+
+        foreach ($importMapEntries as $name => $importMapEntry) {
+            if (isset($importMapData[$name])) {
+                continue;
+            }
+
+            if (isset($importMapEntry['path'])) {
+                $arguments = [$name, '--path='.$importMapEntry['path']];
+                if ($importMapEntry['preload']) {
+                    $arguments[] = '--preload';
+                }
+                $this->scriptExecutor->execute(
+                    'symfony-cmd',
+                    'importmap:require',
+                    $arguments
+                );
+
+                continue;
+            }
+
+            if (isset($importMapEntry['version'])) {
+                $packageName = $importMapEntry['package'].'@'.$importMapEntry['version'];
+                if ($importMapEntry['package'] !== $name) {
+                    $packageName .= '='.$name;
+                }
+                $arguments = [$packageName];
+                if ($importMapEntry['preload']) {
+                    $arguments[] = '--preload';
+                }
+                $this->scriptExecutor->execute(
+                    'symfony-cmd',
+                    'importmap:require',
+                    $arguments
+                );
+
+                continue;
+            }
+
+            throw new \InvalidArgumentException(sprintf('Invalid importmap entry: "%s".', var_export($importMapEntry, true)));
+        }
+    }
+
+    private function updateControllersJsonFile(array $phpPackages)
     {
         if (!file_exists($controllersJsonPath = $this->rootDir.'/assets/controllers.json')) {
             return;
@@ -262,5 +372,20 @@ class PackageJsonSynchronizer
         }
 
         return null;
+    }
+
+    private function normalizePhpPackages(array $phpPackages): array
+    {
+        foreach ($phpPackages as $k => $phpPackage) {
+            if (\is_string($phpPackage)) {
+                // support for smooth upgrades from older flex versions
+                $phpPackages[$k] = $phpPackage = [
+                    'name' => $phpPackage,
+                    'keywords' => ['symfony-ux'],
+                ];
+            }
+        }
+
+        return $phpPackages;
     }
 }

--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -42,10 +42,10 @@ class ScriptExecutor
     /**
      * @throws ScriptExecutionException if the executed command returns a non-0 exit code
      */
-    public function execute(string $type, string $cmd)
+    public function execute(string $type, string $cmd, array $arguments = [])
     {
         $parsedCmd = $this->options->expandTargetDir($cmd);
-        if (null === $expandedCmd = $this->expandCmd($type, $parsedCmd)) {
+        if (null === $expandedCmd = $this->expandCmd($type, $parsedCmd, $arguments)) {
             return;
         }
 
@@ -77,13 +77,13 @@ class ScriptExecutor
         }
     }
 
-    private function expandCmd(string $type, string $cmd)
+    private function expandCmd(string $type, string $cmd, array $arguments)
     {
         switch ($type) {
             case 'symfony-cmd':
-                return $this->expandSymfonyCmd($cmd);
+                return $this->expandSymfonyCmd($cmd, $arguments);
             case 'php-script':
-                return $this->expandPhpScript($cmd);
+                return $this->expandPhpScript($cmd, $arguments);
             case 'script':
                 return $cmd;
             default:
@@ -91,7 +91,7 @@ class ScriptExecutor
         }
     }
 
-    private function expandSymfonyCmd(string $cmd)
+    private function expandSymfonyCmd(string $cmd, array $arguments)
     {
         $repo = $this->composer->getRepositoryManager()->getLocalRepository();
         if (!$repo->findPackage('symfony/console', class_exists(MatchAllConstraint::class) ? new MatchAllConstraint() : new EmptyConstraint())) {
@@ -105,10 +105,10 @@ class ScriptExecutor
             $console .= ' --ansi';
         }
 
-        return $this->expandPhpScript($console.' '.$cmd);
+        return $this->expandPhpScript($console.' '.$cmd, $arguments);
     }
 
-    private function expandPhpScript(string $cmd): string
+    private function expandPhpScript(string $cmd, array $scriptArguments): string
     {
         $phpFinder = new PhpExecutableFinder();
         if (!$php = $phpFinder->find(false)) {
@@ -117,7 +117,7 @@ class ScriptExecutor
 
         $arguments = $phpFinder->findArguments();
 
-        if ($env = (string) (getenv('COMPOSER_ORIGINAL_INIS'))) {
+        if ($env = (string) getenv('COMPOSER_ORIGINAL_INIS')) {
             $paths = explode(\PATH_SEPARATOR, $env);
             $ini = array_shift($paths);
         } else {
@@ -133,7 +133,8 @@ class ScriptExecutor
         }
 
         $phpArgs = implode(' ', array_map([ProcessExecutor::class, 'escape'], $arguments));
+        $scriptArgs = implode(' ', array_map([ProcessExecutor::class, 'escape'], $scriptArguments));
 
-        return ProcessExecutor::escape($php).($phpArgs ? ' '.$phpArgs : '').' '.$cmd;
+        return ProcessExecutor::escape($php).($phpArgs ? ' '.$phpArgs : '').' '.$cmd.($scriptArgs ? ' '.$scriptArgs : '');
     }
 }

--- a/tests/Configurator/AddLinesConfiguratorTest.php
+++ b/tests/Configurator/AddLinesConfiguratorTest.php
@@ -1,0 +1,591 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Flex\Tests\Configurator;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Package\Package;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Repository\RepositoryManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Flex\Configurator\AddLinesConfigurator;
+use Symfony\Flex\Lock;
+use Symfony\Flex\Options;
+use Symfony\Flex\Recipe;
+use Symfony\Flex\Update\RecipeUpdate;
+
+class AddLinesConfiguratorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $filesystem = new Filesystem();
+        $filesystem->remove(FLEX_TEST_DIR);
+    }
+
+    public function testFileDoesNotExistSkipped()
+    {
+        $this->runConfigure([
+            ['file' => 'non-existent.php', 'content' => ''],
+        ]);
+        $this->assertFileDoesNotExist(FLEX_TEST_DIR.'/non-existent.php');
+    }
+
+    public function testLinesAddedToTopOfFile()
+    {
+        $this->saveFile('assets/app.js', <<<EOF
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+        );
+
+        $this->runConfigure([
+            [
+                'file' => 'assets/app.js',
+                'position' => 'top',
+                'content' => "import './bootstrap';",
+            ],
+        ]);
+        $actualContents = $this->readFile('assets/app.js');
+        $this->assertSame(<<<EOF
+import './bootstrap';
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+            ,
+            $actualContents);
+    }
+
+    public function testLinesAddedToBottomOfFile()
+    {
+        $this->saveFile('assets/app.js', <<<EOF
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+        );
+
+        $this->runConfigure([
+            [
+                'file' => 'assets/app.js',
+                'position' => 'bottom',
+                'content' => "import './bootstrap';",
+            ],
+        ]);
+        $actualContents = $this->readFile('assets/app.js');
+        $this->assertSame(<<<EOF
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+import './bootstrap';
+EOF
+            ,
+            $actualContents);
+    }
+
+    public function testLinesAddedAfterTarget()
+    {
+        $this->saveFile('webpack.config.js', <<<EOF
+const Encore = require('@symfony/webpack-encore');
+
+Encore
+    .setOutputPath('public/build/')
+    .setPublicPath('/build')
+
+    .addEntry('app', './assets/app.js')
+
+    // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
+    .splitEntryChunks()
+;
+
+module.exports = Encore.getWebpackConfig();
+EOF
+        );
+
+        $this->runConfigure([
+            [
+                'file' => 'webpack.config.js',
+                'position' => 'after_target',
+                'target' => '.addEntry(\'app\', \'./assets/app.js\')',
+                'content' => <<<EOF
+
+    // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
+    .enableStimulusBridge('./assets/controllers.json')
+EOF
+            ],
+        ]);
+
+        $actualContents = $this->readFile('webpack.config.js');
+        $this->assertSame(<<<EOF
+const Encore = require('@symfony/webpack-encore');
+
+Encore
+    .setOutputPath('public/build/')
+    .setPublicPath('/build')
+
+    .addEntry('app', './assets/app.js')
+
+    // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
+    .enableStimulusBridge('./assets/controllers.json')
+
+    // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
+    .splitEntryChunks()
+;
+
+module.exports = Encore.getWebpackConfig();
+EOF
+            ,
+            $actualContents);
+    }
+
+    public function testSkippedIfTargetCannotBeFound()
+    {
+        $originalContent = <<<EOF
+const Encore = require('@symfony/webpack-encore');
+
+Encore
+    .setOutputPath('public/build/')
+;
+
+module.exports = Encore.getWebpackConfig();
+EOF;
+
+        $this->saveFile('webpack.config.js', $originalContent);
+
+        $this->runConfigure([
+            [
+                'file' => 'webpack.config.js',
+                'position' => 'after_target',
+                'target' => '.addEntry(\'app\', \'./assets/app.js\')',
+                'content' => <<<EOF
+
+    // some new line
+EOF
+            ],
+        ]);
+
+        $this->assertSame($originalContent, $this->readFile('webpack.config.js'));
+    }
+
+    public function testPatchIgnoredIfValueAlreadyExists()
+    {
+        $originalContents = <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+EOF;
+
+        $this->saveFile('assets/app.js', $originalContents);
+
+        $this->runConfigure([
+            [
+                'file' => 'assets/app.js',
+                'position' => 'top',
+                'content' => "import './bootstrap';",
+            ],
+        ]);
+        $actualContents = $this->readFile('assets/app.js');
+        $this->assertSame($originalContents, $actualContents);
+    }
+
+    public function testLinesAddedToMultipleFiles()
+    {
+        $this->saveFile('assets/app.js', <<<EOF
+import * as Turbo from '@hotwired/turbo';
+EOF
+        );
+
+        $this->saveFile('assets/bootstrap.js', <<<EOF
+console.log('bootstrap.js');
+EOF
+        );
+
+        $this->runConfigure([
+            [
+                'file' => 'assets/app.js',
+                'position' => 'top',
+                'content' => "import './bootstrap';",
+            ],
+            [
+                'file' => 'assets/bootstrap.js',
+                'position' => 'bottom',
+                'content' => "console.log('on the bottom');",
+            ],
+        ]);
+
+        $this->assertSame(<<<EOF
+import './bootstrap';
+import * as Turbo from '@hotwired/turbo';
+EOF
+            ,
+            $this->readFile('assets/app.js'));
+
+        $this->assertSame(<<<EOF
+console.log('bootstrap.js');
+console.log('on the bottom');
+EOF
+            ,
+            $this->readFile('assets/bootstrap.js'));
+    }
+
+    public function testLineSkippedIfRequiredPackageMissing()
+    {
+        $this->saveFile('assets/app.js', <<<EOF
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+        );
+
+        $composer = $this->createComposerMockWithPackagesInstalled([]);
+        $this->runConfigure([
+            [
+                'file' => 'assets/app.js',
+                'position' => 'top',
+                'content' => "import './bootstrap';",
+                'requires' => 'symfony/invented-package',
+            ],
+        ], $composer);
+        $actualContents = $this->readFile('assets/app.js');
+        $this->assertSame(<<<EOF
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+            ,
+            $actualContents);
+    }
+
+    public function testLineProcessedIfRequiredPackageIsPresent()
+    {
+        $this->saveFile('assets/app.js', <<<EOF
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+        );
+
+        $composer = $this->createComposerMockWithPackagesInstalled([
+            'symfony/installed-package',
+        ]);
+
+        $this->runConfigure([
+            [
+                'file' => 'assets/app.js',
+                'position' => 'top',
+                'content' => "import './bootstrap';",
+                'requires' => 'symfony/installed-package',
+            ],
+        ], $composer);
+
+        $actualContents = $this->readFile('assets/app.js');
+        $this->assertSame(<<<EOF
+import './bootstrap';
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+            ,
+            $actualContents);
+    }
+
+    /**
+     * @dataProvider getUnconfigureTests
+     */
+    public function testUnconfigure(string $originalContents, string $value, string $expectedContents)
+    {
+        $this->saveFile('assets/app.js', $originalContents);
+
+        $this->runUnconfigure([
+            [
+                'file' => 'assets/app.js',
+                'content' => $value,
+            ],
+        ]);
+        $actualContents = $this->readFile('assets/app.js');
+        $this->assertSame($expectedContents, $actualContents);
+    }
+
+    public function getUnconfigureTests()
+    {
+        yield 'found_middle' => [
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+EOF
+            ,
+            "import './bootstrap';",
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+        ];
+
+        yield 'found_top' => [
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+EOF
+            ,
+            "import * as Turbo from '@hotwired/turbo';",
+            <<<EOF
+import './bootstrap';
+
+console.log(Turbo);
+EOF
+        ];
+
+        yield 'found_bottom' => [
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+EOF
+            ,
+            'console.log(Turbo);',
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+EOF
+        ];
+
+        yield 'not_found' => [
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+EOF
+            ,
+            "console.log('not found');",
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+EOF
+        ];
+
+        yield 'found_twice_in_file' => [
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+console.log(Turbo);
+EOF
+            ,
+            'console.log(Turbo);',
+            <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+EOF
+        ];
+    }
+
+    /**
+     * @dataProvider getUpdateTests
+     */
+    public function testUpdate(array $originalFiles, array $originalConfig, array $newConfig, array $expectedFiles)
+    {
+        foreach ($originalFiles as $filename => $contents) {
+            $this->saveFile($filename, $contents);
+        }
+
+        $composer = $this->createComposerMockWithPackagesInstalled([
+            'symfony/installed-package',
+        ]);
+        $configurator = $this->createConfigurator($composer);
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+
+        $recipeUpdate = new RecipeUpdate($recipe, $recipe, $lock, FLEX_TEST_DIR);
+        $configurator->update($recipeUpdate, $originalConfig, $newConfig);
+
+        foreach ($expectedFiles as $filename => $contents) {
+            $this->assertSame($contents, $this->readFile($filename));
+        }
+    }
+
+    public function getUpdateTests()
+    {
+        $appJs = <<<EOF
+import * as Turbo from '@hotwired/turbo';
+import './bootstrap';
+
+console.log(Turbo);
+EOF;
+
+        $bootstrapJs = <<<EOF
+console.log('bootstrap.js');
+
+console.log('on the bottom');
+EOF;
+
+        yield 'recipe_changes_patch_contents' => [
+            ['assets/app.js' => $appJs],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './bootstrap';"],
+            ],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './stimulus_bootstrap';"],
+            ],
+            ['assets/app.js' => <<<EOF
+import './stimulus_bootstrap';
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+            ],
+        ];
+
+        yield 'recipe_file_and_value_same_before_and_after' => [
+            ['assets/app.js' => $appJs],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import * as Turbo from '@hotwired/turbo';"],
+            ],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import * as Turbo from '@hotwired/turbo';"],
+            ],
+            ['assets/app.js' => $appJs],
+        ];
+
+        yield 'different_files_unconfigures_old_and_configures_new' => [
+            ['assets/app.js' => $appJs, 'assets/bootstrap.js' => $bootstrapJs],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import * as Turbo from '@hotwired/turbo';"],
+            ],
+            [
+                ['file' => 'assets/bootstrap.js', 'position' => 'top', 'content' => "import * as Turbo from '@hotwired/turbo';"],
+            ],
+            [
+                'assets/app.js' => <<<EOF
+import './bootstrap';
+
+console.log(Turbo);
+EOF
+                ,
+                'assets/bootstrap.js' => <<<EOF
+import * as Turbo from '@hotwired/turbo';
+console.log('bootstrap.js');
+
+console.log('on the bottom');
+EOF
+            ],
+        ];
+
+        yield 'recipe_changes_but_ignored_because_package_not_installed' => [
+            ['assets/app.js' => $appJs],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './bootstrap';", 'requires' => 'symfony/not-installed'],
+            ],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './stimulus_bootstrap';", 'requires' => 'symfony/not-installed'],
+            ],
+            ['assets/app.js' => $appJs],
+        ];
+
+        yield 'recipe_changes_are_applied_if_required_package_installed' => [
+            ['assets/app.js' => $appJs],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './bootstrap';", 'requires' => 'symfony/installed-package'],
+            ],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './stimulus_bootstrap';", 'requires' => 'symfony/installed-package'],
+            ],
+            ['assets/app.js' => <<<EOF
+import './stimulus_bootstrap';
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+            ],
+        ];
+    }
+
+    private function runConfigure(array $config, Composer $composer = null)
+    {
+        $configurator = $this->createConfigurator($composer);
+
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $configurator->configure($recipe, $config, $lock);
+    }
+
+    private function runUnconfigure(array $config)
+    {
+        $configurator = $this->createConfigurator();
+
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+        $configurator->unconfigure($recipe, $config, $lock);
+    }
+
+    private function createConfigurator(Composer $composer = null)
+    {
+        return new AddLinesConfigurator(
+            $composer ?: $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
+        );
+    }
+
+    private function saveFile(string $filename, string $contents)
+    {
+        $path = FLEX_TEST_DIR.'/'.$filename;
+        if (!file_exists(\dirname($path))) {
+            @mkdir(\dirname($path), 0777, true);
+        }
+        file_put_contents($path, $contents);
+    }
+
+    private function readFile(string $filename): string
+    {
+        return file_get_contents(FLEX_TEST_DIR.'/'.$filename);
+    }
+
+    private function createComposerMockWithPackagesInstalled(array $packages)
+    {
+        $repository = $this->getMockBuilder(InstalledRepositoryInterface::class)->getMock();
+        $repository->expects($this->any())
+            ->method('findPackage')
+            ->willReturnCallback(function ($name) use ($packages) {
+                if (\in_array($name, $packages)) {
+                    return new Package($name, '1.0.0', '1.0.0');
+                }
+
+                return null;
+            });
+        $repositoryManager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();
+        $repositoryManager->expects($this->any())
+            ->method('getLocalRepository')
+            ->willReturn($repository);
+        $composer = $this->getMockBuilder(Composer::class)->getMock();
+        $composer->expects($this->any())
+            ->method('getRepositoryManager')
+            ->willReturn($repositoryManager);
+
+        return $composer;
+    }
+}

--- a/tests/Fixtures/packageJson/vendor/symfony/new-package/assets/package.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/new-package/assets/package.json
@@ -9,7 +9,14 @@
                 }
             }
         },
-        "entrypoints": ["admin.js"]
+        "entrypoints": ["admin.js"],
+        "importmap": {
+            "@hotcake": "^1.9.0",
+            "@symfony/new-package": {
+                "version": "path:%PACKAGE%/dist/loader.js",
+                "preload": true
+            }
+        }
     },
     "peerDependencies": {
         "@hotcookies": "^1.1"

--- a/tests/Fixtures/packageJson/vendor/symfony/package-no-file-package/assets/package.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/package-no-file-package/assets/package.json
@@ -1,0 +1,8 @@
+{
+    "symfony": {
+        "needsPackageAsADependency": false
+    },
+    "peerDependencies": {
+        "@hotcookies": "^1.1"
+    }
+}


### PR DESCRIPTION
Hi!

Today, WebpackEncoreBundle's recipe contains the UX/Stimulus files. Soon, I will introduce a new StimulusBundle - https://github.com/weaverryan/stimulus-bundle - so that the WebpackEncoreBundle can be used without Stimulus and (more importantly) the `stimulus_()` functions can be used with AssetMapper (i.e. without Encore).

This makes the recipe setup more... interesting :). This PR adds 2 things:

## importmap support in `JsonSynchronizer`

`JsonSynchronizer` now has 2 modes, based on the presence/absence of the `importmap.php` file. If that file is present, then:

* A) A new [symfony.importmap](https://github.com/weaverryan/stimulus-bundle/blob/148f6f9412e7063f9945d0947f206081d3311d7a/assets/package.json#L8-L11) config is read from the bundle's `package.json` file and these are added to the `importmap.php` file by running the `bin/console importmap:require` command. The `path:` prefix is used to refer to a "local" file in the bundle. Sometimes the importmap entries will be different than what's needed for `package.json`, hence having both configs.

* B) The `controllers.json` file is updated like normal

Also, a new [symfony.needsPackageAsADependency](https://github.com/weaverryan/stimulus-bundle/blob/148f6f9412e7063f9945d0947f206081d3311d7a/assets/package.json#LL7C10-L7C35) config key was added specifically for StimulusBundle. If `true`, no `file:/vendor/...` package will be added to `package.json` when using Encore.

## add-lines Configurator

The new `add-lines` configurator is able to add entire lines to the `top`, `bottom` of `after_target` of existing files (if they exist). Example usage:

```json
"add-lines": [
    {
        "file": "webpack.config.js",
        "content": "\n    // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)\n    .enableStimulusBridge('./assets/controllers.json')",
        "position": "after_target",
        "target": ".splitEntryChunks()"
    },
    {
        "file": "assets/app.js",
        "content": "import './bootstrap.js';",
        "position": "top",
        "warn_if_missing": true
    }
]
```

There is also a `requires` key to only run if another package is installed. This is needed because StimulusBundle will need a [different assets/bootstrap.js](https://github.com/weaverryan/recipes/blob/3ab0e996ae22af665ec83bf0634f1163b533bc36/symfony/stimulus-bundle/1.0/manifest.json#L23-L33) based on if Encore vs AssetMapper is installed

Cheers!