### PR TITLE
Avoid errors with an older global install of Flex

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -544,10 +544,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
             }
         }
 
-        foreach ($postInstallRecipes as $recipe) {
-            $this->configurator->postInstall($recipe, $this->lock, [
-                'force' => $event instanceof UpdateEvent && $event->force(),
-            ]);
+        if (method_exists($this->configurator, 'postInstall')) {
+            foreach ($postInstallRecipes as $recipe) {
+                $this->configurator->postInstall($recipe, $this->lock, [
+                    'force' => $event instanceof UpdateEvent && $event->force(),
+                ]);
+            }
         }
 
         if (null !== $manifest) {


### PR DESCRIPTION
Hi!

When I tried 2.3.0 locally, I it exploded, complaining about:

> Call to undefined method Symfony\Flex\Configurator::postInstall()
The reason is that I have a global `symfony/flex` install, which was NOT on 2.3.0. And so... I guess (?) your global `symfony/flex` is used when originally creating a new project / installing `symfony/flex` into a project... at least partially? It's a bit opaque to me, but this may be needed to avoid issues.

Btw, the fix for this is running `composer global up symfony/flex`.