### PR TITLE
fix: deprecations triggered by debug class loader

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -104,6 +104,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
     ];
     private $filter;
 
+    /**
+     * @return void
+     */
     public function activate(Composer $composer, IOInterface $io)
     {
         if (!\extension_loaded('openssl')) {
@@ -291,6 +294,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
+    /**
+     * @return void
+     */
     public function deactivate(Composer $composer, IOInterface $io)
     {
         self::$activated = false;
@@ -594,6 +600,9 @@ class Flex implements PluginInterface, EventSubscriberInterface
         }
     }
 
+    /**
+     * @return void
+     */
     public function uninstall(Composer $composer, IOInterface $io)
     {
         $this->lock->delete();

--- a/src/InformationOperation.php
+++ b/src/InformationOperation.php
@@ -57,6 +57,8 @@ class InformationOperation implements OperationInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getOperationType()
     {
@@ -65,6 +67,8 @@ class InformationOperation implements OperationInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function show($lock)
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -65,6 +65,9 @@ class Response implements \JsonSerializable
         return $response;
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {


### PR DESCRIPTION
Fixes following errors:

```
21:05:05 INFO      [php] User Deprecated: Method "Composer\Plugin\PluginInterface::activate()" might add "void" as a native return type declaration in the future. Do the same in implementation "Symfony\Flex\Flex" now to avoid errors or add an explicit @return annotation to suppress this message.
21:05:05 INFO      [php] User Deprecated: Method "Composer\Plugin\PluginInterface::deactivate()" might add "void" as a native return type declaration in the future. Do the same in implementation "Symfony\Flex\Flex" now to avoid errors or add an explicit @return annotation to suppress this message.
21:05:05 INFO      [php] User Deprecated: Method "Composer\Plugin\PluginInterface::uninstall()" might add "void" as a native return type declaration in the future. Do the same in implementation "Symfony\Flex\Flex" now to avoid errors or add an explicit @return annotation to suppress this message.
21:05:05 INFO      [php] User Deprecated: Method "JsonSerializable::jsonSerialize()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Symfony\Flex\Response" now to avoid errors or add an explicit @return annotation to suppress this message.
21:05:05 INFO      [php] User Deprecated: Method "Composer\DependencyResolver\Operation\OperationInterface::getOperationType()" might add "string" as a native return type declaration in the future. Do the same in implementation "Symfony\Flex\InformationOperation" now to avoid errors or add an explicit @return annotation to suppress this message.
21:05:05 INFO      [php] User Deprecated: Method "Composer\DependencyResolver\Operation\OperationInterface::show()" might add "string" as a native return type declaration in the future. Do the same in implementation "Symfony\Flex\InformationOperation" now to avoid errors or add an explicit @return annotation to suppress this message.
```