### PR TITLE
Fixing problem where rootDir is ".", which strips all dots from the filename

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -332,7 +332,11 @@ class DockerComposeConfigurator extends AbstractConfigurator
 
         $updatedContents = [];
         foreach ($files as $file) {
-            $localPath = ltrim(str_replace($rootDir, '', $file), '/\\');
+            $localPath = $file;
+            if (0 === strpos($file, $rootDir)) {
+                $localPath = substr($file, \strlen($rootDir) + 1);
+            }
+            $localPath = ltrim($localPath, '/\\');
             $updatedContents[$localPath] = file_exists($file) ? file_get_contents($file) : null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/symfony/recipes/issues/1120

In a normal siutation, `$rootDir` is `.`. The intention of this code is to strip the "rootDir" from the START of the `$file` path, so that we are left with only the relative path. The `.` + `str_replace()` was too greedy, and was causing things like `docker-composeryaml`.

The test uses an absolute root dir, and replicating the `.` would be tricky. But I tested this locally and the fix works.

Cheers!