### PR TITLE
[Feature] Add options expansion to Add Lines Configuration

### DIFF
--- a/src/Configurator/AddLinesConfigurator.php
+++ b/src/Configurator/AddLinesConfigurator.php
@@ -97,7 +97,7 @@ class AddLinesConfigurator extends AbstractConfigurator
             }
             $content = $patch['content'];
 
-            $file = $this->path->concatenate([$this->options->get('root-dir'), $patch['file']]);
+            $file = $this->path->concatenate([$this->options->get('root-dir'), $this->options->expandTargetDir($patch['file'])]);
             $warnIfMissing = isset($patch['warn_if_missing']) && $patch['warn_if_missing'];
             if (!is_file($file)) {
                 $this->write([
@@ -147,7 +147,7 @@ class AddLinesConfigurator extends AbstractConfigurator
             // Ignore "requires": the target packages may have just become uninstalled.
             // Checking for a "content" match is enough.
 
-            $file = $this->path->concatenate([$this->options->get('root-dir'), $patch['file']]);
+            $file = $this->path->concatenate([$this->options->get('root-dir'), $this->options->expandTargetDir($patch['file'])]);
             if (!is_file($file)) {
                 continue;
             }

--- a/tests/Configurator/AddLinesConfiguratorTest.php
+++ b/tests/Configurator/AddLinesConfiguratorTest.php
@@ -67,6 +67,26 @@ EOF
             $actualContents);
     }
 
+    public function testExpandTargetDirWhenConfiguring()
+    {
+        $this->saveFile('config/file.txt', 'FirstLine');
+
+        $this->runConfigure([
+            [
+                'file' => '%CONFIG_DIR%/file.txt',
+                'position' => 'top',
+                'content' => 'NewFirstLine',
+            ],
+        ]);
+        $actualContents = $this->readFile('config/file.txt');
+        $this->assertSame(<<<EOF
+NewFirstLine
+FirstLine
+EOF
+            ,
+            $actualContents);
+    }
+
     public function testLinesAddedToBottomOfFile()
     {
         $this->saveFile('assets/app.js', <<<EOF
@@ -316,6 +336,28 @@ EOF
         ]);
         $actualContents = $this->readFile('assets/app.js');
         $this->assertSame($expectedContents, $actualContents);
+    }
+
+    public function testExpandTargetDirWhenUnconfiguring()
+    {
+        $this->saveFile('config/file.txt',
+            <<<EOF
+Line1
+Line2
+EOF
+        );
+
+        $this->runUnconfigure([
+            [
+                'file' => '%CONFIG_DIR%/file.txt',
+                'content' => 'Line1',
+            ],
+        ]);
+        $actualContents = $this->readFile('config/file.txt');
+        $this->assertSame(<<<EOF
+Line2
+EOF
+            , $actualContents);
     }
 
     public function getUnconfigureTests()


### PR DESCRIPTION
Hi!

I've got a chance to play with the new AddLines configurator and it's an extremely useful feature, thanks for introducing it!

There is one small thing that seems missing to me: support for placeholders that are available in the `copy-from-package` and `copy-from-recipe` configurators.

It's this feature:
```
These are the available placeholders: %BIN_DIR%, %CONF_DIR%, %CONFIG_DIR%, %SRC_DIR% %VAR_DIR% and %PUBLIC_DIR%.

Recipes must use these placeholders instead of hardcoding the paths to be truly reusable. The placeholder values can be overridden in the extra section of your composer.json file (where you can define your own placeholders too):
```
(this text comes from https://github.com/symfony/recipes)

This small PR makes it possible to use placeholders in the add-lines configurator.

I'm not sure about the target branch, please let me know if I should rebase to 1.x - also not sure if I should mention it in the doc somewhere.