### PR TITLE
fix: Correctly inherit the Composer restarted process settings

### DIFF
--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -16,6 +16,7 @@ use Composer\EventDispatcher\ScriptExecutionException;
 use Composer\IO\IOInterface;
 use Composer\Semver\Constraint\MatchAllConstraint;
 use Composer\Util\ProcessExecutor;
+use Composer\XdebugHandler\PhpConfig;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -116,20 +117,8 @@ class ScriptExecutor
 
         $arguments = $phpFinder->findArguments();
 
-        if ($env = (string) getenv('COMPOSER_ORIGINAL_INIS')) {
-            $paths = explode(\PATH_SEPARATOR, $env);
-            $ini = array_shift($paths);
-        } else {
-            $ini = php_ini_loaded_file();
-        }
-
-        if ($ini) {
-            $arguments[] = '--php-ini='.$ini;
-        }
-
-        if ($memoryLimit = (string) getenv('COMPOSER_MEMORY_LIMIT')) {
-            $arguments[] = "-d memory_limit={$memoryLimit}";
-        }
+        $phpConfig = new PhpConfig();
+        $phpConfig->usePersistent();
 
         $phpArgs = implode(' ', array_map([ProcessExecutor::class, 'escape'], $arguments));
         $scriptArgs = implode(' ', array_map([ProcessExecutor::class, 'escape'], $scriptArguments));


### PR DESCRIPTION
> [!WARNING]
> Note: this PR is more of draft. I am not confident I understand fully
the issue neither that this is the right fix (and I could not test it). Do NOT assume this code just works.

After a lot of digging in https://github.com/box-project/box/issues/988, @maartendekeizer could identify the root of the issue.

My understanding is that Flex tries to detect if the current PHP process was restarted by Composer and forwards its restarted settings to the sub-processes it is going to launch. There is currently two things done:

- #91 which if took code from SensioDistributionBundle.
- #899 which kind of followed the suite.

    I suspect the mentioned code predates `composer/xdebug-handler`. Now
with this package, there is two things to take into account:

- The `composer/xdebug-handler` API is likely much safer, more robust and a lot less hacky to use.
- There is other applications that can restart a PHP process. As an example Box restarts the PHP process to be able to correct the `phar.readonly` setting that cannot be changed at runtime. It matters as the restarted process by be executing a Composer command.

As mentioned in the warning, I could not test this, not even run the tests locally, so I would be careful about this PR. I just wanted to give a base about a potential fix with context about the original issue encountered.

On my side to not have to wait on Flex and avoid the users to have to update it to have the fix, Box launches its Composer commands with `COMPOSER_ORIGINAL_INIS=''` to avoid Flex to trigger the problematic piece of code.