### PR TITLE
AssetMapper: upgrade packages when needed

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -587,7 +587,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
         $vendorDir = trim((new Filesystem())->makePathRelative($this->config->get('vendor-dir'), $rootDir), '/');
 
         $executor = new ScriptExecutor($this->composer, $this->io, $this->options);
-        $synchronizer = new PackageJsonSynchronizer($rootDir, $vendorDir, $executor);
+        $synchronizer = new PackageJsonSynchronizer($rootDir, $vendorDir, $executor, $this->io);
 
         if ($synchronizer->shouldSynchronize()) {
             $lockData = $this->composer->getLocker()->getLockData();

--- a/tests/Fixtures/packageJson/elevated_dependencies_package.json
+++ b/tests/Fixtures/packageJson/elevated_dependencies_package.json
@@ -1,8 +1,8 @@
 {
    "name": "symfony/fixture",
    "dependencies": {
-      "@hotcookies": "^1.1|^2",
-      "@hotdogs": "^2",
+      "@hotcookies/bar": "^1.1|^2",
+      "@hotdogs/bun": "^2",
       "@symfony/existing-package": "file:vendor/symfony/existing-package/Resources/assets"
    },
    "devDependencies": {

--- a/tests/Fixtures/packageJson/stricter_constraints_package.json
+++ b/tests/Fixtures/packageJson/stricter_constraints_package.json
@@ -1,8 +1,8 @@
 {
    "name": "symfony/fixture",
    "devDependencies": {
-      "@hotcookies": "^2",
-      "@hotdogs": "^1.9",
+      "@hotcookies/bar": "^2",
+      "@hotdogs/bun": "^1.9",
       "@symfony/existing-package": "file:vendor/symfony/existing-package/Resources/assets"
    },
    "browserslist": [

--- a/tests/Fixtures/packageJson/vendor/symfony/existing-package/Resources/assets/package.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/existing-package/Resources/assets/package.json
@@ -12,7 +12,7 @@
         }
     },
     "peerDependencies": {
-        "@hotcookies": "^1.1|^2",
-        "@hotdogs": "^2"
+        "@hotcookies/bar": "^1.1|^2",
+        "@hotdogs/bun": "^2"
     }
 }

--- a/tests/Fixtures/packageJson/vendor/symfony/new-package/assets/package.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/new-package/assets/package.json
@@ -11,14 +11,13 @@
         },
         "entrypoints": ["admin.js"],
         "importmap": {
-            "@hotcake": "^1.9.0",
+            "@hotcake/foo": "^1.9.0",
             "@symfony/new-package": {
-                "version": "path:%PACKAGE%/dist/loader.js",
-                "preload": true
+                "version": "path:%PACKAGE%/dist/loader.js"
             }
         }
     },
     "peerDependencies": {
-        "@hotcookies": "^1.1"
+        "@hotcookies/bar": "^1.1"
     }
 }

--- a/tests/Fixtures/packageJson/vendor/symfony/package-no-file-package/assets/package.json
+++ b/tests/Fixtures/packageJson/vendor/symfony/package-no-file-package/assets/package.json
@@ -3,6 +3,6 @@
         "needsPackageAsADependency": false
     },
     "peerDependencies": {
-        "@hotcookies": "^1.1"
+        "@hotcookies/bar": "^1.1"
     }
 }


### PR DESCRIPTION
Hi!

The scenario:

* User installs `symfony/ux-autocomplete`. Flex adds `tom-select` at version `2.2.3` to `importmap.php`
* 3 months later, user upgrades `symfony/ux-autocomplete`. The new version now requires `tom-select` at `^2.5`.

If we do nothing, the user's `tom-select` is out of date and the user won't even know about it. The `^2.5` constraint is defined in the `symfony/ux-autocomplete` [package.json file](https://github.com/symfony/ux/blob/97fe2cd62e70e329b85570e0b797833882930754/src/Autocomplete/assets/package.json#L23), but nothing enforces that or notifies the user.

With this small change, during a composer update/require, we look at the dependencies of all UX packages and compare them against the version in `importmap.php`. If they do not match, the package is upgraded to a version that matches.

<img width="995" alt="Screenshot 2023-10-22 at 1 45 41 PM" src="https://github.com/symfony/flex/assets/121003/286e58b0-d73d-4d7a-bc19-f748b18f489b">

We're not creating a fully-fledge package management by any means, but we don't need to. With a few notifications and things like this, we can keep the user's dependencies in sync with each other.

Unrelated: don't forget about that really cool other PR #978 ;) 

Cheers!