### PR TITLE
fix: Replace str_starts_with by strncmp (PHP7 compatibility)

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -151,7 +151,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
                 return ['compose.yaml' => $config];
             }
 
-            if (!str_starts_with($key, 'docker-')) {
+            if (strncmp($key, 'docker-', 7)) {
                 continue;
             }
 

--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -31,7 +31,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
 {
     private $filesystem;
 
-    public static $configureDockerRecipes = null;
+    public static $configureDockerRecipes;
 
     public function __construct(Composer $composer, IOInterface $io, Options $options)
     {
@@ -194,12 +194,12 @@ class DockerComposeConfigurator extends AbstractConfigurator
         $dir = $rootDir;
         do {
             if (
-                $this->filesystem->exists($dockerComposeFile = sprintf('%s/%s', $dir, $file)) ||
+                $this->filesystem->exists($dockerComposeFile = sprintf('%s/%s', $dir, $file))
                 // Test with the ".yml" extension if the file doesn't end up with ".yaml"
-                $this->filesystem->exists($dockerComposeFile = substr($dockerComposeFile, 0, -3).'ml') ||
+                || $this->filesystem->exists($dockerComposeFile = substr($dockerComposeFile, 0, -3).'ml')
                 // Test with the legacy "docker-" suffix if "compose.ya?ml" doesn't exist
-                $this->filesystem->exists($dockerComposeFile = sprintf('%s/docker-%s', $dir, $file)) ||
-                $this->filesystem->exists($dockerComposeFile = substr($dockerComposeFile, 0, -3).'ml')
+                || $this->filesystem->exists($dockerComposeFile = sprintf('%s/docker-%s', $dir, $file))
+                || $this->filesystem->exists($dockerComposeFile = substr($dockerComposeFile, 0, -3).'ml')
             ) {
                 return $dockerComposeFile;
             }
@@ -260,7 +260,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
                 }
 
                 // Skip blank lines and comments
-                if (('' !== $ltrimedLine && 0 === strpos($ltrimedLine, '#')) || '' === trim($line)) {
+                if (('' !== $ltrimedLine && strncmp($ltrimedLine, '#', 1)) && '' !== trim($line)) {
                     continue;
                 }
 
@@ -349,7 +349,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
         $updatedContents = [];
         foreach ($files as $file) {
             $localPath = $file;
-            if (0 === strpos($file, $rootDir)) {
+            if (strncmp($file, $rootDir, \strlen($rootDir))) {
                 $localPath = substr($file, \strlen($rootDir) + 1);
             }
             $localPath = ltrim($localPath, '/\\');


### PR DESCRIPTION
Hi :wave:

The [v1.21.0](https://github.com/symfony/flex/releases/tag/v1.21.0) tag release made a few hours ago started breaking compatibility with PHP7 because of the use of `str_starts_with`.

This PR replaces `str_starts_with` by `strncmp`, as suggested by the [rfc](https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions) 😃 