### PR TITLE
fix: Replace str_starts_with by strncmp (PHP7 compatibility)

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -151,7 +151,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
                 return ['compose.yaml' => $config];
             }
 
-            if (!str_starts_with($key, 'docker-')) {
+            if (strncmp($key, 'docker-', 7)) {
                 continue;
             }
 


### PR DESCRIPTION
Hi 👋

The [v1.21.0](https://github.com/symfony/flex/releases/tag/v1.21.0) tag release made a few hours ago started breaking compatibility with PHP7 because of the use of `str_starts_with`.

This PR replaces `str_starts_with` by `strncmp`, as suggested by the [rfc](https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions) 😃