### PR TITLE
Decouple psr-http-message-bridge from extra.symfony.require for versions before 6.4

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -75,6 +75,10 @@ class Cache extends BaseCache
                     continue;
                 }
 
+                if ('symfony/psr-http-message-bridge' === $name && 6.4 > $normalizedVersion) {
+                    continue;
+                }
+
                 $constraint = new Constraint('==', $normalizedVersion);
 
                 if ($rootConstraint && $rootConstraint->matches($constraint)) {

--- a/src/PackageFilter.php
+++ b/src/PackageFilter.php
@@ -80,6 +80,7 @@ class PackageFilter
                 !isset($knownVersions['splits'][$name])
                 || array_intersect($versions, $lockedVersions[$name] ?? [])
                 || (isset($rootConstraints[$name]) && !Intervals::haveIntersections($this->symfonyConstraints, $rootConstraints[$name]))
+                || ('symfony/psr-http-message-bridge' === $name && 6.4 > $versions[0])
             )) {
                 $filteredPackages[] = $package;
                 continue;


### PR DESCRIPTION
Should fix issues like https://github.com/getsentry/sentry-symfony/pull/750 and https://github.com/symfony/recipes/issues/1236

Before 6.4, the bridge was not in `symfony/symfony` so that `extra.symfony.require` shouldn't apply to earlier versions.

We *could* improve the API and flex to handle this concern at a more generic level, but this is so rare that I suggest hard-coding the rule in flex.