### PR TITLE
fix(recipes:update): github api now requires is:pull-request parameter

### DIFF
--- a/src/GithubApi.php
+++ b/src/GithubApi.php
@@ -128,7 +128,7 @@ class GithubApi
 
     public function getPullRequestForCommit(string $commit, string $repo): ?array
     {
-        $data = $this->requestGitHubApi('https://api.github.com/search/issues?q='.$commit);
+        $data = $this->requestGitHubApi('https://api.github.com/search/issues?q='.$commit.'+is:pull-request');
 
         if (0 === \count($data['items'])) {
             return null;


### PR DESCRIPTION
This fix is related to issue #974.

While running `recipes:update`  I got this error:

```shell
Calculating CHANGELOG...
In CurlDownloader.php line 630:

  The "https://api.github.com/search/issues?q=95e75e5e424c5f5f611cc57073e399baaf287570" file could not be downloaded (HTTP/2 422 ):                                  
  {"message":"Query must include 'is:issue' or 'is:pull-request'","documentation_url":"https://docs.github.com/rest/search/search#search-issues-and-pull-requests"}
```

According to github's [documentation](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-issues-and-pull-requests) : `Requests that don't include the is:issue or is:pull-request qualifier will receive an HTTP 422 Unprocessable Entity response`. 