### PR TITLE
fix compatibility with Symfony 7

### DIFF
--- a/src/Command/RecipesCommand.php
+++ b/src/Command/RecipesCommand.php
@@ -56,7 +56,7 @@ class RecipesCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $installedRepo = $this->getComposer()->getRepositoryManager()->getLocalRepository();
 


### PR DESCRIPTION
```
PHP Fatal error:  Declaration of Symfony\Flex\Command\RecipesCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /home/runner/work/recipes/recipes/vendor/symfony/flex/src/Command/RecipesCommand.php on line 59
03:09:57 CRITICAL  [php] Fatal Compile Error: Declaration of Symfony\Flex\Command\RecipesCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int ["exception" => Symfony\Component\ErrorHandler\Error\FatalError { …}]
```