### PR TITLE
fix jsonPath in ComposerScriptsConfigurator::update

### DIFF
--- a/src/Configurator/ComposerScriptsConfigurator.php
+++ b/src/Configurator/ComposerScriptsConfigurator.php
@@ -14,7 +14,6 @@ namespace Symfony\Flex\Configurator;
 use Composer\Factory;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
-use Symfony\Component\Filesystem\Path;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 use Symfony\Flex\Update\RecipeUpdate;
@@ -52,9 +51,9 @@ class ComposerScriptsConfigurator extends AbstractConfigurator
         $json = new JsonFile(Factory::getComposerFile());
         $jsonPath = $json->getPath();
         if (str_starts_with($jsonPath, $recipeUpdate->getRootDir())) {
-            $jsonPath = substr($jsonPath, strlen($recipeUpdate->getRootDir()));
+            $jsonPath = substr($jsonPath, \strlen($recipeUpdate->getRootDir()));
         }
-        $jsonPath = ltrim($jsonPath, '/\\'); 
+        $jsonPath = ltrim($jsonPath, '/\\');
 
         $recipeUpdate->setOriginalFile(
             $jsonPath,

--- a/src/Configurator/ComposerScriptsConfigurator.php
+++ b/src/Configurator/ComposerScriptsConfigurator.php
@@ -50,7 +50,11 @@ class ComposerScriptsConfigurator extends AbstractConfigurator
     public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
     {
         $json = new JsonFile(Factory::getComposerFile());
-        $jsonPath = Path::makeRelative($json->getPath(), $recipeUpdate->getRootDir());
+        $jsonPath = $json->getPath();
+        if (str_starts_with($jsonPath, $recipeUpdate->getRootDir())) {
+            $jsonPath = substr($jsonPath, strlen($recipeUpdate->getRootDir()));
+        }
+        $jsonPath = ltrim($jsonPath, '/\\'); 
 
         $recipeUpdate->setOriginalFile(
             $jsonPath,

--- a/src/Configurator/ComposerScriptsConfigurator.php
+++ b/src/Configurator/ComposerScriptsConfigurator.php
@@ -17,6 +17,7 @@ use Composer\Json\JsonManipulator;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 use Symfony\Flex\Update\RecipeUpdate;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -49,7 +50,7 @@ class ComposerScriptsConfigurator extends AbstractConfigurator
     public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void
     {
         $json = new JsonFile(Factory::getComposerFile());
-        $jsonPath = ltrim(str_replace($recipeUpdate->getRootDir(), '', $json->getPath()), '/\\');
+        $jsonPath = Path::makeRelative($json->getPath(), $recipeUpdate->getRootDir());
 
         $recipeUpdate->setOriginalFile(
             $jsonPath,

--- a/src/Configurator/ComposerScriptsConfigurator.php
+++ b/src/Configurator/ComposerScriptsConfigurator.php
@@ -14,10 +14,10 @@ namespace Symfony\Flex\Configurator;
 use Composer\Factory;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Flex\Lock;
 use Symfony\Flex\Recipe;
 use Symfony\Flex\Update\RecipeUpdate;
-use Symfony\Component\Filesystem\Path;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>


### PR DESCRIPTION
Fixes https://github.com/symfony/flex/issues/1010

https://github.com/symfony/flex/blob/bec213c39511eda66663baa2ee7440c65f89c695/src/Configurator/ComposerScriptsConfigurator.php#L52

In case when root dir = ".", it replaces the dot in filename, and then applying the patch is broken with: 
```
NOTE:
  The file composerjson was not updated because it doesn't exist in your app.
```

Change to using Path::makeRelative for proper result.
