### PR TITLE
fix: wrong recipe history URL format

### DIFF
--- a/src/Command/RecipesCommand.php
+++ b/src/Command/RecipesCommand.php
@@ -226,7 +226,11 @@ class RecipesCommand extends BaseCommand
 
             // show commits since one second after the currently-installed recipe
             if (null !== $commitDate) {
-                $historyUrl .= '?since='.(new \DateTime($commitDate))->modify('+1 seconds')->format('c\Z');
+                $historyUrl .= '?since=';
+                $historyUrl .= (new \DateTime($commitDate))
+                    ->setTimezone(new \DateTimeZone('UTC'))
+                    ->modify('+1 seconds')
+                    ->format('Y-m-d\TH:i:s\Z');
             }
 
             $io->write('<info>recipe history</info>   : '.$historyUrl);


### PR DESCRIPTION
According to the GitHub [documentation](https://docs.github.com/en/rest/commits/commits), the format of the `since` query parameter should be `YYYY-MM-DDTHH:MM:SSZ`.

<details>
  <summary>Preview</summary>

### Before
<img width="500" alt="Capture d’écran 2024-03-01 à 20 10 36" src="https://github.com/symfony/flex/assets/4034907/92052dda-6f65-4804-9fae-0daa33c26989">

### After
<img width="500" alt="Capture d’écran 2024-03-01 à 20 11 00" src="https://github.com/symfony/flex/assets/4034907/5caa6261-be90-44ed-b203-66e447f31e7b">
</details>
