### PR TITLE
feat: add ability to skip package.json synchronization

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -600,6 +600,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     private function synchronizePackageJson(string $rootDir)
     {
+        if (!($this->composer->getPackage()->getExtra()['symfony/flex']['synchronize_package_json'] ?? true)) {
+            $this->io->writeError('<info>Skip synchronizing package.json with PHP packages</>');
+
+            return;
+        }
+
         if (!$this->downloader->isEnabled()) {
             $this->io->writeError('<warning>Synchronizing package.json is disabled: "symfony/flex" not found in the root composer.json</>');
 

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -310,6 +310,47 @@ EOF
         $this->assertSame('2.3', $recipes['doctrine/doctrine-bundle']->getVersion());
     }
 
+    public function testInstallWithPackageJsonToSynchronizeSkipped()
+    {
+        $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
+        $rootPackage = $this->mockRootPackage([
+            'symfony/flex' => ['synchronize_package_json' => false],
+        ]);
+
+        $flex = $this->mockFlex($io, $rootPackage);
+        $flex->install($this->mockFlexEvent());
+
+        $this->assertStringContainsString(
+            'Skip synchronizing package.json with PHP packages',
+            $io->getOutput(),
+        );
+    }
+
+    /**
+     * @dataProvider getDataForTestInstallWithoutPackageJsonToSynchronizeSkipped
+     */
+    public function testInstallWithoutPackageJsonToSynchronizeSkipped(array $extra)
+    {
+        $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
+        $rootPackage = $this->mockRootPackage($extra);
+
+        $flex = $this->mockFlex($io, $rootPackage);
+        $flex->install($this->mockFlexEvent());
+
+        $this->assertStringNotContainsString(
+            'Skip synchronizing package.json with PHP packages',
+            $io->getOutput(),
+        );
+    }
+
+    public function getDataForTestInstallWithoutPackageJsonToSynchronizeSkipped(): array
+    {
+        return [
+            'default_behavior' => [[]],
+            'with_config_explicitly_set' => [['symfony/flex' => ['synchronize_package_json' => true]]],
+        ];
+    }
+
     public static function getTestPackages(): array
     {
         return [


### PR DESCRIPTION
For those who doesn't want the package.json synchronization, this PR offers to opt-out this behavior by setting the config below in extra section of composer.json:

```json
{
  "extra": {
    "symfony/flex": {
      "synchronize_package_json": false
    }
  }
}

```

fix https://github.com/symfony/flex/issues/1017