### PR TITLE
feat: Allow multiple lines addition with array for add-lines Configurator

### DIFF
--- a/src/Configurator/AddLinesConfigurator.php
+++ b/src/Configurator/AddLinesConfigurator.php
@@ -164,9 +164,13 @@ class AddLinesConfigurator extends AbstractConfigurator
         }
     }
 
-    private function getPatchedContents(string $file, string $value, string $position, ?string $target, bool $warnIfMissing): string
+    private function getPatchedContents(string $file, string|array $value, string $position, ?string $target, bool $warnIfMissing): string
     {
         $fileContents = $this->readFile($file);
+
+        if (\is_array($value)) {
+            $value = implode(\PHP_EOL, $value);
+        }
 
         if (false !== strpos($fileContents, $value)) {
             return $fileContents; // already includes value, skip

--- a/tests/Configurator/AddLinesConfiguratorTest.php
+++ b/tests/Configurator/AddLinesConfiguratorTest.php
@@ -566,6 +566,70 @@ console.log(Turbo);
 EOF
             ],
         ];
+
+        yield 'recipe_changes_with_multiline_string' => [
+            ['assets/app.js' => $appJsOriginal],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './bootstrap';"],
+            ],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './stimulus_bootstrap';\nimport { useIntersection } from 'stimulus-use';"],
+            ],
+            ['assets/app.js' => <<<EOF
+import './stimulus_bootstrap';
+import { useIntersection } from 'stimulus-use';
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+            ],
+        ];
+
+        yield 'recipe_changes_with_multiline_array' => [
+            ['assets/app.js' => $appJsOriginal],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './bootstrap';"],
+            ],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => [
+                    "import './stimulus_bootstrap';",
+                    "import { useIntersection } from 'stimulus-use';",
+                ]],
+            ],
+            ['assets/app.js' => <<<EOF
+import './stimulus_bootstrap';
+import { useIntersection } from 'stimulus-use';
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+            ],
+        ];
+
+        yield 'recipe_changes_with_complex_multiline_array' => [
+            ['assets/app.js' => $appJsOriginal],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => "import './bootstrap';"],
+            ],
+            [
+                ['file' => 'assets/app.js', 'position' => 'top', 'content' => [
+                    "import './stimulus_bootstrap';",
+                    "import { useIntersection } from 'stimulus-use';",
+                    '',
+                    "  console.log(years['2025'] !== years['0225']);",
+                ]],
+            ],
+            ['assets/app.js' => <<<EOF
+import './stimulus_bootstrap';
+import { useIntersection } from 'stimulus-use';
+
+  console.log(years['2025'] !== years['0225']);
+import * as Turbo from '@hotwired/turbo';
+
+console.log(Turbo);
+EOF
+            ],
+        ];
     }
 
     private function runConfigure(array $config, ?Composer $composer = null)


### PR DESCRIPTION
Adding multiple lines via the add-lines configurator is currently complex due to the JSON format. This PR introduces support for adding multiple lines through an array.

The array is processed in a straightforward manner using an implode with ~~PHP_EOL~~ `\n`. This approach has minimal impact on the existing code, avoids any regressions, and only modifies a private method. It also maintains compatibility with multi-line strings using "\n".

Test scenarios have been added to ensure proper functionality and validate the new feature.