### PR TITLE
Add more entropy to the generated secret

### DIFF
--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -197,9 +197,24 @@ class EnvConfigurator extends AbstractConfigurator
         return $value;
     }
 
-    private function generateRandomBytes($length = 16)
+    private function generateRandomBytes($length = 16): string
     {
-        return bin2hex(random_bytes($length));
+        $base58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+        $length *= 2;
+
+        if (\PHP_VERSION_ID >= 80300) {
+            $randomizer = new \Random\Randomizer();
+
+            return $randomizer->getBytesFromString($base58, $length);
+        }
+
+        $max = \strlen($base58) - 1;
+        $str = '';
+        for ($i = 0; $i < $length; ++$i) {
+            $str .= $base58[random_int(0, $max)];
+        }
+
+        return $str;
     }
 
     private function getContentsAfterApplyingRecipe(string $rootDir, Recipe $recipe, array $vars): array

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -184,19 +184,19 @@ EOF
         ], $lock);
 
         $envContents = file_get_contents($env);
-        $this->assertMatchesRegularExpression('/#TRUSTED_SECRET_1=[a-z0-9]{64}/', $envContents);
-        $this->assertMatchesRegularExpression('/#TRUSTED_SECRET_2=[a-z0-9]{64}/', $envContents);
-        $this->assertMatchesRegularExpression('/#TRUSTED_SECRET_3=[a-z0-9]{64}/', $envContents);
-        $this->assertMatchesRegularExpression('/APP_SECRET=[a-z0-9]{32}/', $envContents);
+        $this->assertMatchesRegularExpression('/#TRUSTED_SECRET_1=[A-Za-z0-9]{64}/', $envContents);
+        $this->assertMatchesRegularExpression('/#TRUSTED_SECRET_2=[A-Za-z0-9]{64}/', $envContents);
+        $this->assertMatchesRegularExpression('/#TRUSTED_SECRET_3=[A-Za-z0-9]{64}/', $envContents);
+        $this->assertMatchesRegularExpression('/APP_SECRET=[A-Za-z0-9]{32}/', $envContents);
         @unlink($env);
 
         foreach ([$phpunitDist, $phpunit] as $file) {
             $fileContents = file_get_contents($file);
 
-            $this->assertMatchesRegularExpression('/<!-- env name="TRUSTED_SECRET_1" value="[a-z0-9]{64}" -->/', $fileContents);
-            $this->assertMatchesRegularExpression('/<!-- env name="TRUSTED_SECRET_2" value="[a-z0-9]{64}" -->/', $fileContents);
-            $this->assertMatchesRegularExpression('/<!-- env name="TRUSTED_SECRET_3" value="[a-z0-9]{64}" -->/', $fileContents);
-            $this->assertMatchesRegularExpression('/<env name="APP_SECRET" value="[a-z0-9]{32}"\/>/', $fileContents);
+            $this->assertMatchesRegularExpression('/<!-- env name="TRUSTED_SECRET_1" value="[A-Za-z0-9]{64}" -->/', $fileContents);
+            $this->assertMatchesRegularExpression('/<!-- env name="TRUSTED_SECRET_2" value="[A-Za-z0-9]{64}" -->/', $fileContents);
+            $this->assertMatchesRegularExpression('/<!-- env name="TRUSTED_SECRET_3" value="[A-Za-z0-9]{64}" -->/', $fileContents);
+            $this->assertMatchesRegularExpression('/<env name="APP_SECRET" value="[A-Za-z0-9]{32}"\/>/', $fileContents);
         }
     }
 


### PR DESCRIPTION
Increase the "randomness" of the generated secret by extending the used characters from hexadecimal to base58.

I opted for base58 to keep the secret readable.