### PR TITLE
Fix PHP Parse errors in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,12 +37,18 @@ jobs:
             - name: "Checkout code"
               uses: actions/checkout@v4
 
-            - name: "Install PHP with extensions"
+            - name: "Install PHP"
               uses: shivammathur/setup-php@v2
               with:
                   coverage: "none"
                   php-version: ${{ matrix.php }}
                   tools: composer:${{ matrix.composer }}
+
+            - if: matrix.php == '7.1'
+              name: "Lint PHP files"
+              run: |
+                find src/ -name '*.php' | xargs -n1 php -l
+                find tests/ -name '*.php' | xargs -n1 php -l
 
             - name: "Validate composer.json"
               run: "composer validate --strict --no-check-lock"
@@ -71,7 +77,3 @@ jobs:
                 fi
 
             - run: vendor/bin/simple-phpunit
-
-            - if: matrix.php == '7.1'
-              name: "Lint PHP files"
-              run: find src/ -name '*.php' | xargs -n1 php -l

--- a/tests/Configurator/AddLinesConfiguratorTest.php
+++ b/tests/Configurator/AddLinesConfiguratorTest.php
@@ -142,7 +142,7 @@ EOF
 
     // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
     .enableStimulusBridge('./assets/controllers.json')
-EOF,
+EOF
             ],
         ]);
 
@@ -191,7 +191,7 @@ EOF;
                 'content' => <<<EOF
 
     // some new line
-EOF,
+EOF
             ],
         ]);
 
@@ -375,7 +375,7 @@ EOF
 import * as Turbo from '@hotwired/turbo';
 
 console.log(Turbo);
-EOF,
+EOF
         ];
 
         yield 'found_top' => [
@@ -391,7 +391,7 @@ EOF
 import './bootstrap';
 
 console.log(Turbo);
-EOF,
+EOF
         ];
 
         yield 'found_bottom' => [
@@ -407,7 +407,7 @@ EOF
 import * as Turbo from '@hotwired/turbo';
 import './bootstrap';
 
-EOF,
+EOF
         ];
 
         yield 'not_found' => [
@@ -424,7 +424,7 @@ import * as Turbo from '@hotwired/turbo';
 import './bootstrap';
 
 console.log(Turbo);
-EOF,
+EOF
         ];
 
         yield 'found_twice_in_file' => [
@@ -442,7 +442,7 @@ import * as Turbo from '@hotwired/turbo';
 import './bootstrap';
 
 console.log(Turbo);
-EOF,
+EOF
         ];
     }
 
@@ -535,7 +535,7 @@ import * as Turbo from '@hotwired/turbo';
 console.log('bootstrap.js');
 
 console.log('on the bottom');
-EOF,
+EOF
             ],
         ];
 

--- a/tests/Update/DiffHelperTest.php
+++ b/tests/Update/DiffHelperTest.php
@@ -118,7 +118,7 @@ index ea34452..daaeb63 100644
 -# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 -# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
  # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
-EOF,
+EOF
             ],
         ];
 
@@ -169,7 +169,7 @@ index 5e80e77..c319176 100644
 +        #server_version: '13'
      orm:
          auto_generate_proxy_classes: true
-EOF,
+EOF
             ],
         ];
 
@@ -220,7 +220,7 @@ index 0000000..34c2ebc
 +    dbal:
 +        # "TEST_TOKEN" is typically set by ParaTest
 +        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
-EOF,
+EOF
             ],
         ];
 
@@ -273,7 +273,7 @@ index 5e80e77..c319176 100644
 +        #server_version: '13'
      orm:
          auto_generate_proxy_classes: true
-EOF,
+EOF
             ],
         ];
 
@@ -328,7 +328,7 @@ index 8ae31a3..17299e2 100644
 -            type: pool
 -            pool: doctrine.system_cache_pool
          query_cache_driver:
-EOF,
+EOF
             ],
         ];
     }

--- a/tests/Update/RecipePatcherTest.php
+++ b/tests/Update/RecipePatcherTest.php
@@ -103,7 +103,7 @@ index b3b20af..4e66429 100644
 \ No newline at end of file
 +Updated file2
 \ No newline at end of file
-EOF,
+EOF
         ];
 
         yield 'file_created_in_update_because_missing' => [
@@ -118,7 +118,7 @@ index 0000000..b78ca63
 @@ -0,0 +1 @@
 +New file
 \ No newline at end of file
-EOF,
+EOF
         ];
 
         yield 'file_created_in_update_because_null' => [
@@ -133,7 +133,7 @@ index 0000000..b78ca63
 @@ -0,0 +1 @@
 +New file
 \ No newline at end of file
-EOF,
+EOF
         ];
 
         yield 'file_deleted_in_update_because_missing' => [
@@ -491,7 +491,7 @@ APP_SECRET=cd0019c56963e76bacd77eee67e1b222
 # For an SQL-HEAVY database, use: "sqlheavy:///%kernel.project_dir%/var/data.db"
 DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db
 ###< doctrine/doctrine-bundle ###
-EOF,
+EOF
             ],
 
             // package.json
@@ -536,7 +536,7 @@ EOF
         "@symfony/webpack-encore": "^1.7.0"
     }
 }
-EOF,
+EOF
             ],
 
             // config/packages/webpack_encore.yaml
@@ -557,7 +557,7 @@ webpack_encore:
     output_path: '%kernel.project_dir%/public/build'
     # If multiple builds are defined (as shown below), you can disable the default build:
     # output_path: false
-EOF,
+EOF
             ],
 
             // config/packages/security.yaml


### PR DESCRIPTION
PHP 7.1 and PHP 7.2 don't support a comma after a heredoc end (T_END_HEREDOC)