### PR TITLE
Do not synchronize package.json if symfony/flex is not installed

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -600,6 +600,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     private function synchronizePackageJson(string $rootDir)
     {
+        if (!$this->downloader->isEnabled()) {
+            $this->io->writeError('<warning>Synchronizing package.json is disabled: "symfony/flex" not found in the root composer.json</>');
+
+            return;
+        }
+
         $rootDir = realpath($rootDir);
         $vendorDir = trim((new Filesystem())->makePathRelative($this->config->get('vendor-dir'), $rootDir), '/');
 


### PR DESCRIPTION
Just as the project is not configured and no recipes are loaded if symfony/flex is not in the root `composer.json`, the `package.json` should not be synchronized in this case.