### PR TITLE
Handle phpunit.xml.dist as an alias of phpunit.dist.xml

### DIFF
--- a/src/Command/InstallRecipesCommand.php
+++ b/src/Command/InstallRecipesCommand.php
@@ -130,7 +130,7 @@ class InstallRecipesCommand extends BaseCommand
             rename($dotenvPath, $dotenvPath.'.local');
             $pipes = [];
             proc_close(proc_open(\sprintf('git mv %s %s > %s 2>&1 || %s %1$s %2$s', ProcessExecutor::escape($dotenvFile.'.dist'), ProcessExecutor::escape($dotenvFile), $win ? 'NUL' : '/dev/null', $win ? 'rename' : 'mv'), $pipes, $pipes, $this->rootDir));
-            if (file_exists($this->rootDir.'/phpunit.xml.dist')) {
+            if (file_exists($this->rootDir.'/phpunit.xml.dist') || file_exists($this->rootDir.'/phpunit.dist.xml')) {
                 touch($dotenvPath.'.test');
             }
         }

--- a/src/Configurator/CopyFromPackageConfigurator.php
+++ b/src/Configurator/CopyFromPackageConfigurator.php
@@ -72,7 +72,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
         foreach ($manifest as $source => $target) {
             $target = $this->options->expandTargetDir($target);
             if ('/' === substr($source, -1)) {
-                $files = array_merge($files, $this->getFilesForDir($this->path->concatenate([$from, $source]), $this->path->concatenate([$target])));
+                $files = array_merge($files, $this->getFilesForDir($this->path->concatenate([$from, $source]), $target));
 
                 continue;
             }
@@ -118,7 +118,7 @@ class CopyFromPackageConfigurator extends AbstractConfigurator
      */
     public function copyFile(string $source, string $target, array $options)
     {
-        $target = $this->options->get('root-dir').'/'.$target;
+        $target = $this->options->get('root-dir').'/'.$this->options->expandTargetDir($target);
         if (is_dir($source)) {
             // directory will be created when a file is copied to it
             return;

--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -108,7 +108,7 @@ class EnvConfigurator extends AbstractConfigurator
 
     private function configurePhpUnit(Recipe $recipe, $vars, bool $update)
     {
-        foreach (['phpunit.xml.dist', 'phpunit.xml'] as $file) {
+        foreach (['phpunit.xml.dist', 'phpunit.dist.xml', 'phpunit.xml'] as $file) {
             $phpunit = $this->options->get('root-dir').'/'.$file;
             if (!is_file($phpunit)) {
                 continue;
@@ -173,7 +173,7 @@ class EnvConfigurator extends AbstractConfigurator
 
     private function unconfigurePhpUnit(Recipe $recipe, $vars)
     {
-        foreach (['phpunit.xml.dist', 'phpunit.xml'] as $file) {
+        foreach (['phpunit.dist.xml', 'phpunit.xml.dist', 'phpunit.xml'] as $file) {
             $phpunit = $this->options->get('root-dir').'/'.$file;
             if (!is_file($phpunit)) {
                 continue;
@@ -223,7 +223,7 @@ class EnvConfigurator extends AbstractConfigurator
     private function getContentsAfterApplyingRecipe(string $rootDir, Recipe $recipe, array $vars): array
     {
         $dotenvPath = $this->options->get('runtime')['dotenv_path'] ?? '.env';
-        $files = '' === $this->suffix ? [$dotenvPath, $dotenvPath.'.dist', 'phpunit.xml.dist', 'phpunit.xml'] : [$dotenvPath.'.'.$this->suffix];
+        $files = '' === $this->suffix ? [$dotenvPath, $dotenvPath.'.dist', 'phpunit.dist.xml', 'phpunit.xml.dist', 'phpunit.xml'] : [$dotenvPath.'.'.$this->suffix];
 
         if (0 === \count($vars)) {
             return array_fill_keys($files, null);

--- a/src/Options.php
+++ b/src/Options.php
@@ -36,7 +36,7 @@ class Options
 
     public function expandTargetDir(string $target): string
     {
-        return preg_replace_callback('{%(.+?)%}', function ($matches) {
+        $result = preg_replace_callback('{%(.+?)%}', function ($matches) {
             $option = str_replace('_', '-', strtolower($matches[1]));
             if (!isset($this->options[$option])) {
                 return $matches[0];
@@ -44,6 +44,22 @@ class Options
 
             return rtrim($this->options[$option], '/');
         }, $target);
+
+        $phpunitDistFiles = [
+            'phpunit.xml.dist' => true,
+            'phpunit.dist.xml' => true,
+        ];
+
+        $rootDir = $this->get('root-dir');
+
+        if (null === $rootDir || !isset($phpunitDistFiles[$result]) || !is_dir($rootDir) || file_exists($rootDir.'/'.$result)) {
+            return $result;
+        }
+
+        unset($phpunitDistFiles[$result]);
+        $otherPhpunitDistFile = key($phpunitDistFiles);
+
+        return file_exists($rootDir.'/'.$otherPhpunitDistFile) ? $otherPhpunitDistFile : $result;
     }
 
     public function shouldWriteFile(string $file, bool $overwrite): bool


### PR DESCRIPTION
Should smoothen the transition from phpunit.xml.dist to phpunit.dist.xml

Tested on a small app where the file is renamed between installation and removal of phpunit/phpunit, flex tracks the move successfully.