### PR TITLE
UpdateRecipesCommand: add `--next` option

### DIFF
--- a/src/Command/UpdateRecipesCommand.php
+++ b/src/Command/UpdateRecipesCommand.php
@@ -19,6 +19,7 @@ use Composer\Util\ProcessExecutor;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Flex\Configurator;
 use Symfony\Flex\Downloader;
@@ -57,6 +58,7 @@ class UpdateRecipesCommand extends BaseCommand
             ->setAliases(['recipes:update'])
             ->setDescription('Updates an already-installed recipe to the latest version.')
             ->addArgument('package', InputArgument::OPTIONAL, 'Recipe that should be updated.')
+            ->addOption('next', null, InputOption::VALUE_NONE, 'Update recipe of next outdated package.')
         ;
     }
 
@@ -81,7 +83,7 @@ class UpdateRecipesCommand extends BaseCommand
         $packageName = $input->getArgument('package');
         $symfonyLock = $this->flex->getLock();
         if (!$packageName) {
-            $packageName = $this->askForPackage($io, $symfonyLock);
+            $packageName = $this->getNextOrAskForPackage($io, $symfonyLock, $input->getOption('next'));
 
             if (null === $packageName) {
                 $io->writeError('All packages appear to be up-to-date!');
@@ -353,7 +355,7 @@ class UpdateRecipesCommand extends BaseCommand
         return $lines;
     }
 
-    private function askForPackage(IOInterface $io, Lock $symfonyLock): ?string
+    private function getNextOrAskForPackage(IOInterface $io, Lock $symfonyLock, bool $next = false): ?string
     {
         $installedRepo = $this->getComposer()->getRepositoryManager()->getLocalRepository();
 
@@ -373,6 +375,10 @@ class UpdateRecipesCommand extends BaseCommand
             $lockRef = $symfonyLock->get($name)['recipe']['ref'] ?? null;
 
             if (null !== $lockRef && $recipe->getRef() !== $lockRef && !$recipe->isAuto()) {
+                if ($next) {
+                    return $name;
+                }
+
                 $outdatedRecipes[] = $name;
             }
         }

--- a/tests/Command/UpdateRecipesCommandTest.php
+++ b/tests/Command/UpdateRecipesCommandTest.php
@@ -57,8 +57,10 @@ class UpdateRecipesCommandTest extends TestCase
      * that we can easily use to assert.
      *
      * @requires PHP >= 7.2
+     *
+     * @dataProvider provideCommandInput
      */
-    public function testCommandUpdatesRecipe()
+    public function testCommandUpdatesRecipe(array $input)
     {
         @mkdir(FLEX_TEST_DIR);
         (new Process(['git', 'init'], FLEX_TEST_DIR))->mustRun();
@@ -75,10 +77,10 @@ class UpdateRecipesCommandTest extends TestCase
         (new Process(['git', 'add', '-A'], FLEX_TEST_DIR))->mustRun();
         (new Process(['git', 'commit', '-m', 'setup of original console files'], FLEX_TEST_DIR))->mustRun();
 
-        (new Process([__DIR__.'/../../vendor/bin/composer', 'install'], FLEX_TEST_DIR))->mustRun();
+        (new Process([__DIR__.'/../../vendor/bin/composer', 'install', '--no-plugins'], FLEX_TEST_DIR))->mustRun();
 
         $command = $this->createCommandUpdateRecipes();
-        $command->execute(['package' => 'symfony/console']);
+        $command->execute($input);
 
         $this->assertSame(0, $command->getStatusCode());
         $this->assertStringContainsString('Recipe updated', $this->io->getOutput());
@@ -86,6 +88,14 @@ class UpdateRecipesCommandTest extends TestCase
         $this->assertStringNotContainsString('vendor/autoload.php', file_get_contents(FLEX_TEST_DIR.'/bin/console'));
         // assert the recipe was updated
         $this->assertStringNotContainsString('c6d02bdfba9da13c22157520e32a602dbee8a75c', file_get_contents(FLEX_TEST_DIR.'/symfony.lock'));
+    }
+
+    public function provideCommandInput()
+    {
+        return [
+            [['package' => 'symfony/console']],
+            [['--next' => true]],
+        ];
     }
 
     private function createCommandUpdateRecipes(): CommandTester

--- a/tests/Fixtures/update_recipes/composer.json
+++ b/tests/Fixtures/update_recipes/composer.json
@@ -3,11 +3,18 @@
     "license": "proprietary",
     "require": {
         "php": ">=7.1",
-        "symfony/console": "5.4.*"
+        "symfony/console": "5.4.*",
+        "symfony/flex": "@dev"
     },
     "config": {
         "allow-plugins": {
             "symfony/flex": true
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": ".."
+        }
+    ]
 }


### PR DESCRIPTION
With `symfony:recipes:update` you can update the recipes, but you have to do it one by one.
I suggest to add a `--next` option to update the next outdated package. So you do not need to select the next package interactively. 