### PR TITLE
feat: Make DockerComposeConfigurator compatible with "false" string

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -101,7 +101,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
         }
 
         if (null !== $dockerPreference = $composer->getPackage()->getExtra()['symfony']['docker'] ?? null) {
-            self::$configureDockerRecipes = $dockerPreference;
+            self::$configureDockerRecipes = filter_var($dockerPreference, \FILTER_VALIDATE_BOOLEAN);
 
             return self::$configureDockerRecipes;
         }


### PR DESCRIPTION
This fixes #1060 

With this MR `DockerComposeConfigurator` will recognize `"false"` string a proper boolean.

I use `filter_var` function, I think this is a good solution because it requires only a single method call to fix the issue. 

With `filter_var` function:

* true, 1, "true", "yes", "1", and "on" are recognized as `true` as well.
* any other value is `false`.

Additionally this function is already used in the same method some lines below:

https://github.com/symfony/flex/blob/423c36e369361003dc31ef11c5f15fb589e52c01/src/Configurator/DockerComposeConfigurator.php#L115-L117

