### PR TITLE
[UX][Bug] Avoid considering "false" as a truthy value for "synchronize_package_json"

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -497,7 +497,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     private function synchronizePackageJson(string $rootDir)
     {
-        if (!($this->composer->getPackage()->getExtra()['symfony/flex']['synchronize_package_json'] ?? true)) {
+        if (!(filter_var($this->composer->getPackage()->getExtra()['symfony/flex']['synchronize_package_json'] ?? true, FILTER_VALIDATE_BOOLEAN))) {
             $this->io->writeError('<info>Skip synchronizing package.json with PHP packages</>');
 
             return;

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -497,7 +497,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     private function synchronizePackageJson(string $rootDir)
     {
-        if (!(filter_var($this->composer->getPackage()->getExtra()['symfony/flex']['synchronize_package_json'] ?? true, \FILTER_VALIDATE_BOOLEAN))) {
+        if (!filter_var($this->composer->getPackage()->getExtra()['symfony/flex']['synchronize_package_json'] ?? true, \FILTER_VALIDATE_BOOLEAN)) {
             $this->io->writeError('<info>Skip synchronizing package.json with PHP packages</>');
 
             return;

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -497,7 +497,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
     private function synchronizePackageJson(string $rootDir)
     {
-        if (!(filter_var($this->composer->getPackage()->getExtra()['symfony/flex']['synchronize_package_json'] ?? true, FILTER_VALIDATE_BOOLEAN))) {
+        if (!(filter_var($this->composer->getPackage()->getExtra()['symfony/flex']['synchronize_package_json'] ?? true, \FILTER_VALIDATE_BOOLEAN))) {
             $this->io->writeError('<info>Skip synchronizing package.json with PHP packages</>');
 
             return;


### PR DESCRIPTION
The current command `composer config "extra.symfony/flex.synchronize_package.json" false` write a string containing `"false"`:

e.g.
```json
{
    {
        "symfony/flex": {
            "synchronize_package_json": "false",
        }
    }
}
```

It does not skip the `package.json` as expected so I suggest to add the `filter_var`, so for all those who use thed previous "wrong" command, it'll work as expected now.

ping @smnandre and @Kocal

related: https://github.com/symfony/ux/pull/3091