### PR TITLE
Fix ignoring unstable releases with --prefer-lowest and --prefer-stable

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -31,7 +31,6 @@ use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
-use Composer\Package\BasePackage;
 use Composer\Package\Locker;
 use Composer\Package\Package;
 use Composer\Plugin\PluginEvents;
@@ -77,6 +76,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
     private $operations = [];
     private $lock;
     private $displayThanksReminder = 0;
+    private $ignoreUnstableReleases = false;
     private $reinstall;
     private static $activated = true;
     private static $aliasResolveCommands = [
@@ -126,16 +126,8 @@ class Flex implements PluginInterface, EventSubscriberInterface
             Flex::$storedOperations = [];
         }
 
-        $symfonyRequire = preg_replace('/\.x$/', '.x-dev', getenv('SYMFONY_REQUIRE') ?: ($composer->getPackage()->getExtra()['symfony']['require'] ?? ''));
-
         $rfs = $composer->getLoop()->getHttpDownloader();
-
         $this->downloader = $downloader = new Downloader($composer, $io, $rfs);
-
-        if ($symfonyRequire) {
-            $this->filter = new PackageFilter($io, $symfonyRequire, $this->downloader);
-        }
-
         $this->configurator = new Configurator($composer, $io, $this->options);
 
         $disable = true;
@@ -190,12 +182,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                 }
             }
 
-            if ($input->hasParameterOption('--prefer-lowest', true)) {
-                // When prefer-lowest is set and no stable version has been released,
-                // we consider "dev" more stable than "alpha", "beta" or "RC". This
-                // allows testing lowest versions with potential fixes applied.
-                BasePackage::$stabilities['dev'] = 1 + BasePackage::STABILITY_STABLE;
-            }
+            $this->ignoreUnstableReleases = $input->hasParameterOption('--prefer-lowest', true) && $input->hasParameterOption('--prefer-stable', true);
 
             $addCommand = 'add'.(method_exists($app, 'addCommand') ? 'Command' : '');
             $app->$addCommand(new Command\RecipesCommand($this, $this->lock, $rfs));
@@ -204,6 +191,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
             $app->$addCommand(new Command\DumpEnvCommand($this->config, $this->options));
 
             break;
+        }
+
+        $symfonyRequire = preg_replace('/\.x$/', '.x-dev', getenv('SYMFONY_REQUIRE') ?: ($composer->getPackage()->getExtra()['symfony']['require'] ?? ''));
+
+        if ($symfonyRequire || $this->ignoreUnstableReleases) {
+            $this->filter = new PackageFilter($io, $symfonyRequire, $this->downloader, $this->ignoreUnstableReleases);
         }
     }
 

--- a/src/PackageFilter.php
+++ b/src/PackageFilter.php
@@ -30,14 +30,16 @@ class PackageFilter
     private $symfonyConstraints;
     private $downloader;
     private $io;
+    private $ignoreUnstableReleases;
 
-    public function __construct(IOInterface $io, string $symfonyRequire, Downloader $downloader)
+    public function __construct(IOInterface $io, string $symfonyRequire, Downloader $downloader, bool $ignoreUnstableReleases = false)
     {
         $this->versionParser = new VersionParser();
         $this->symfonyRequire = $symfonyRequire;
-        $this->symfonyConstraints = $this->versionParser->parseConstraints($symfonyRequire);
+        $this->symfonyConstraints = '' !== $symfonyRequire ? $this->versionParser->parseConstraints($symfonyRequire) : null;
         $this->downloader = $downloader;
         $this->io = $io;
+        $this->ignoreUnstableReleases = $ignoreUnstableReleases;
     }
 
     /**
@@ -48,6 +50,16 @@ class PackageFilter
      */
     public function removeLegacyPackages(array $data, RootPackageInterface $rootPackage, array $lockedPackages): array
     {
+        if ($this->ignoreUnstableReleases) {
+            $filteredPackages = [];
+            foreach ($data as $package) {
+                if (\in_array($package->getStability(), ['stable', 'dev'], true)) {
+                    $filteredPackages[] = $package;
+                }
+            }
+            $data = $filteredPackages;
+        }
+
         if (!$this->symfonyConstraints || !$data) {
             return $data;
         }

--- a/tests/PackageFilterTest.php
+++ b/tests/PackageFilterTest.php
@@ -17,8 +17,10 @@ use Composer\Package\Link;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackage;
+use Composer\Package\RootPackageInterface;
 use Composer\Semver\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
+use Symfony\Flex\Downloader;
 use Symfony\Flex\PackageFilter;
 
 /**
@@ -206,5 +208,55 @@ class PackageFilterTest extends TestCase
         yield 'root-constraints-are-preserved' => [$packages, $packages, '~2.8', ['splits' => [
             'symfony/bar' => ['2.8', '3.0'],
         ]]];
+    }
+
+    public function testIgnoreUnstableReleasesFiltersPreReleases()
+    {
+        $io = new NullIO();
+        $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();
+        $filter = new PackageFilter($io, '', $downloader, true);
+
+        $stablePkg = $this->createPackageMock('pkg/stable', 'stable');
+        $devPkg = $this->createPackageMock('pkg/dev', 'dev');
+        $alphaPkg = $this->createPackageMock('pkg/alpha', 'alpha');
+        $betaPkg = $this->createPackageMock('pkg/beta', 'beta');
+        $rcPkg = $this->createPackageMock('pkg/rc', 'RC');
+
+        $root = $this->getMockBuilder(RootPackageInterface::class)->disableOriginalConstructor()->getMock();
+
+        $result = $filter->removeLegacyPackages([$stablePkg, $devPkg, $alphaPkg, $betaPkg, $rcPkg], $root, []);
+
+        $this->assertSame([$stablePkg, $devPkg], $result);
+    }
+
+    public function testWithoutIgnoreUnstableReleasesKeepsAll()
+    {
+        $io = new NullIO();
+        $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();
+        $filter = new PackageFilter($io, '', $downloader, false);
+
+        $packages = [
+            $this->createPackageMock('pkg/stable', 'stable'),
+            $this->createPackageMock('pkg/dev', 'dev'),
+            $this->createPackageMock('pkg/alpha', 'alpha'),
+            $this->createPackageMock('pkg/beta', 'beta'),
+            $this->createPackageMock('pkg/rc', 'RC'),
+        ];
+
+        $root = $this->getMockBuilder(RootPackageInterface::class)->disableOriginalConstructor()->getMock();
+
+        $result = $filter->removeLegacyPackages($packages, $root, []);
+
+        $this->assertSame($packages, $result);
+    }
+
+    private function createPackageMock(string $name, string $stability): PackageInterface
+    {
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package->method('getName')->willReturn($name);
+        $package->method('getVersion')->willReturn('1.0.0');
+        $package->method('getStability')->willReturn($stability);
+
+        return $package;
     }
 }


### PR DESCRIPTION
This is a behavior that has been broken about one year ago by [a change is composer](https://github.com/composer/composer/commit/685add70ec84d18075a202686288304db0d6d265).

The attached implementation is way more robust since it uses a documented hook for plugins.

I tried to explain why this behavior should be the default also for composer without success so far, see:
https://github.com/composer/composer/pull/12581

This is a must when testing lowest deps seriously, backed by years of practice :)