### PR TITLE
Leverage COMPOSER_PREFER_DEV_OVER_PRERELEASE when possible

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Flex;
 
+use Composer\Command\BaseConfigCommand;
 use Composer\Command\GlobalCommand;
 use Composer\Composer;
 use Composer\Console\Application;
@@ -76,7 +77,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
     private $operations = [];
     private $lock;
     private $displayThanksReminder = 0;
-    private $ignoreUnstableReleases = false;
+    private $ignorePreleases = false;
     private $reinstall;
     private static $activated = true;
     private static $aliasResolveCommands = [
@@ -182,7 +183,12 @@ class Flex implements PluginInterface, EventSubscriberInterface
                 }
             }
 
-            $this->ignoreUnstableReleases = $input->hasParameterOption('--prefer-lowest', true) && $input->hasParameterOption('--prefer-stable', true);
+            if (class_exists(BaseConfigCommand::class)) {
+                // composer 2.9+
+                $_SERVER['COMPOSER_PREFER_DEV_OVER_PRERELEASE'] = '1';
+            } else {
+                $this->ignorePreleases = $input->hasParameterOption('--prefer-lowest', true) && $input->hasParameterOption('--prefer-stable', true);
+            }
 
             $addCommand = 'add'.(method_exists($app, 'addCommand') ? 'Command' : '');
             $app->$addCommand(new Command\RecipesCommand($this, $this->lock, $rfs));
@@ -195,8 +201,8 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
         $symfonyRequire = preg_replace('/\.x$/', '.x-dev', getenv('SYMFONY_REQUIRE') ?: ($composer->getPackage()->getExtra()['symfony']['require'] ?? ''));
 
-        if ($symfonyRequire || $this->ignoreUnstableReleases) {
-            $this->filter = new PackageFilter($io, $symfonyRequire, $this->downloader, $this->ignoreUnstableReleases);
+        if ($symfonyRequire || $this->ignorePreleases) {
+            $this->filter = new PackageFilter($io, $symfonyRequire, $this->downloader, $this->ignorePreleases);
         }
     }
 

--- a/src/PackageFilter.php
+++ b/src/PackageFilter.php
@@ -30,16 +30,16 @@ class PackageFilter
     private $symfonyConstraints;
     private $downloader;
     private $io;
-    private $ignoreUnstableReleases;
+    private $ignorePreleases;
 
-    public function __construct(IOInterface $io, string $symfonyRequire, Downloader $downloader, bool $ignoreUnstableReleases = false)
+    public function __construct(IOInterface $io, string $symfonyRequire, Downloader $downloader, bool $ignorePreleases = false)
     {
         $this->versionParser = new VersionParser();
         $this->symfonyRequire = $symfonyRequire;
         $this->symfonyConstraints = '' !== $symfonyRequire ? $this->versionParser->parseConstraints($symfonyRequire) : null;
         $this->downloader = $downloader;
         $this->io = $io;
-        $this->ignoreUnstableReleases = $ignoreUnstableReleases;
+        $this->ignorePreleases = $ignorePreleases;
     }
 
     /**
@@ -50,7 +50,7 @@ class PackageFilter
      */
     public function removeLegacyPackages(array $data, RootPackageInterface $rootPackage, array $lockedPackages): array
     {
-        if ($this->ignoreUnstableReleases) {
+        if ($this->ignorePreleases) {
             $filteredPackages = [];
             foreach ($data as $package) {
                 if (\in_array($package->getStability(), ['stable', 'dev'], true)) {

--- a/tests/PackageFilterTest.php
+++ b/tests/PackageFilterTest.php
@@ -210,7 +210,7 @@ class PackageFilterTest extends TestCase
         ]]];
     }
 
-    public function testIgnoreUnstableReleasesFiltersPreReleases()
+    public function testIgnorePreleases()
     {
         $io = new NullIO();
         $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();
@@ -229,7 +229,7 @@ class PackageFilterTest extends TestCase
         $this->assertSame([$stablePkg, $devPkg], $result);
     }
 
-    public function testWithoutIgnoreUnstableReleasesKeepsAll()
+    public function testWithoutIgnorePreleases()
     {
         $io = new NullIO();
         $downloader = $this->getMockBuilder(Downloader::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
This leverages https://github.com/composer/composer/pull/12585

The code added in https://github.com/symfony/flex/pull/1066 remains as a fallback.