### PR TITLE
Fix dump-env command when .env files reference other env vars

### DIFF
--- a/src/Command/DumpEnvCommand.php
+++ b/src/Command/DumpEnvCommand.php
@@ -55,6 +55,7 @@ class DumpEnvCommand extends BaseCommand
         }
 
         $path = $this->options->get('root-dir').'/'.($runtime['dotenv_path'] ?? '.env');
+        $GLOBALS['SYMFONY_DOTENV_VARS'] = [];
 
         if (!$env || !$input->getOption('empty')) {
             $vars = $this->loadEnv($path, $env, $runtime);
@@ -66,6 +67,18 @@ class DumpEnvCommand extends BaseCommand
         }
 
         $vars = var_export($vars, true);
+
+        foreach ($GLOBALS['SYMFONY_DOTENV_VARS'] as $k => $v) {
+            $k = var_export($k, true);
+            $vars = str_replace($v, "'.(\$_ENV[{$k}] ?? ".(str_starts_with($k, "'HTTP_") ? '' : "\$_SERVER[{$k}] ?? ")."'').'", $vars);
+        }
+        unset($GLOBALS['SYMFONY_DOTENV_VARS']);
+        $vars = strtr($vars, [
+            "''.(" => '(',
+            ").''.(" => ').(',
+            ").''" => ')',
+        ]);
+
         $vars = <<<EOF
             <?php
 
@@ -144,4 +157,15 @@ class DumpEnvCommand extends BaseCommand
 
         return $env;
     }
+}
+
+namespace Symfony\Component\Dotenv;
+
+function getenv(?string $name = null, bool $local_only = false): string|array|false
+{
+    if (null === $name) {
+        return \getenv($name, $local_only);
+    }
+
+    return $GLOBALS['SYMFONY_DOTENV_VARS'][$name] ??= md5(random_bytes(10));
 }

--- a/tests/Command/DumpEnvCommandTest.php
+++ b/tests/Command/DumpEnvCommandTest.php
@@ -29,9 +29,9 @@ class DumpEnvCommandTest extends TestCase
         @unlink($envLocal);
 
         $envContent = <<<EOF
-APP_ENV=dev
-APP_SECRET=abcdefgh123456789
-EOF;
+            APP_ENV=dev
+            APP_SECRET=abcdefgh123456789
+            EOF;
         file_put_contents($env, $envContent);
 
         $command = $this->createCommandDumpEnv();
@@ -60,9 +60,9 @@ EOF;
         @unlink($envLocal);
 
         $envContent = <<<EOF
-APP_ENV=dev
-APP_SECRET=abcdefgh123456789
-EOF;
+            APP_ENV=dev
+            APP_SECRET=abcdefgh123456789
+            EOF;
         file_put_contents($env, $envContent);
 
         $command = $this->createCommandDumpEnv();
@@ -94,9 +94,9 @@ EOF;
         @unlink($envLocal);
 
         $envContent = <<<'EOF'
-BAR=$FOO
-FOO=123
-EOF;
+            BAR=$FOO
+            FOO=123
+            EOF;
         file_put_contents($env, $envContent);
 
         $_SERVER['FOO'] = 'Foo';
@@ -179,9 +179,9 @@ EOF;
 
         file_put_contents($env, 'APP_ENV=dev');
         file_put_contents($envLocal, <<<EOF
-APP_ENV=test
-APP_SECRET=abcdefgh123456789
-EOF
+            APP_ENV=test
+            APP_SECRET=abcdefgh123456789
+            EOF
         );
 
         $command = $this->createCommandDumpEnv(['runtime' => ['test_envs' => []]]);
@@ -200,6 +200,39 @@ EOF
         unlink($env);
         unlink($envLocal);
         unlink($envLocalPhp);
+    }
+
+    public function testEnvVarReferenceInDumpedFile()
+    {
+        @mkdir(FLEX_TEST_DIR);
+        $env = FLEX_TEST_DIR.'/.env';
+        $envLocal = FLEX_TEST_DIR.'/.env.local.php';
+
+        @unlink($env);
+        @unlink($envLocal);
+
+        $envContent = <<<'EOF'
+            APP_ENV=prod
+            APP_SHARE_DIR=$APP_PROJECT_DIR/var/share
+            EOF;
+        file_put_contents($env, $envContent);
+
+        $command = $this->createCommandDumpEnv();
+        $command->execute(['env' => 'prod']);
+
+        $dumpedContent = file_get_contents($envLocal);
+        $this->assertStringContainsString("\$_ENV['APP_PROJECT_DIR']", $dumpedContent);
+        $this->assertStringContainsString("\$_SERVER['APP_PROJECT_DIR']", $dumpedContent);
+
+        $_ENV['APP_PROJECT_DIR'] = '/path/to/project';
+        $vars = require $envLocal;
+        $this->assertSame([
+            'APP_ENV' => 'prod',
+            'APP_SHARE_DIR' => '/path/to/project/var/share',
+        ], $vars);
+
+        unlink($env);
+        unlink($envLocal);
     }
 
     private function createCommandDumpEnv(array $options = [])


### PR DESCRIPTION
At the moment, running `composer dump-env` on a 7.4 project generates a broken `APP_SHARE_DIR`.
The reason is that since https://github.com/symfony/recipes/pull/1465 we define that var as `"$APP_PROJECT_DIR/var/share"`
Yet, when the command runs, all env vars are emptied to make the result context-free.

This fixes it by hooking into calls to the `getenv()` function.