### PR TITLE
Add `create_if_missing` option to `add-lines` configurator

### DIFF
--- a/src/Configurator/AddLinesConfigurator.php
+++ b/src/Configurator/AddLinesConfigurator.php
@@ -129,8 +129,9 @@ class AddLinesConfigurator extends AbstractConfigurator
                 continue;
             }
             $target = isset($patch['target']) ? $patch['target'] : null;
+            $createIfMissing = isset($patch['create_if_missing']) ? $patch['create_if_missing'] : null;
 
-            $newContents = $this->getPatchedContents($file, $content, $position, $target, $warnIfMissing);
+            $newContents = $this->getPatchedContents($file, $content, $position, $target, $warnIfMissing, $createIfMissing);
             $this->fileContents[$file] = $newContents;
         }
     }
@@ -164,7 +165,7 @@ class AddLinesConfigurator extends AbstractConfigurator
         }
     }
 
-    private function getPatchedContents(string $file, string $value, string $position, ?string $target, bool $warnIfMissing): string
+    private function getPatchedContents(string $file, string $value, string $position, ?string $target, bool $warnIfMissing, ?string $createIfMissing = null): string
     {
         $fileContents = $this->readFile($file);
 
@@ -192,6 +193,15 @@ class AddLinesConfigurator extends AbstractConfigurator
                         break;
                     }
                 }
+
+                if (!$targetFound && null !== $createIfMissing) {
+                    // Insert the create_if_missing content at the end of the file, then add the value after the target
+                    $createIfMissingLines = explode("\n", $createIfMissing);
+                    $lines = array_merge($lines, $createIfMissingLines);
+                    $lines[] = $value;
+                    $targetFound = true;
+                }
+
                 $fileContents = implode("\n", $lines);
 
                 if (!$targetFound) {

--- a/tests/Configurator/AddLinesConfiguratorTest.php
+++ b/tests/Configurator/AddLinesConfiguratorTest.php
@@ -198,6 +198,66 @@ class AddLinesConfiguratorTest extends TestCase
         $this->assertSame($originalContent, $this->readFile('webpack.config.js'));
     }
 
+    public function testCreateIfMissingCreatesTargetAndAddsContent()
+    {
+        $this->copyFixture('ai_without_store.yaml', 'config/packages/ai.yaml');
+
+        $this->runConfigure([
+            [
+                'file' => 'config/packages/ai.yaml',
+                'position' => 'after_target',
+                'target' => '    store:',
+                'create_if_missing' => '    store:',
+                'content' => "        azuresearch:\n            default:\n                endpoint: '%env(AZURE_SEARCH_ENDPOINT)%'",
+            ],
+        ]);
+
+        $this->assertSame(
+            $this->loadFixture('ai_without_store_expected.yaml'),
+            $this->readFile('config/packages/ai.yaml')
+        );
+    }
+
+    public function testCreateIfMissingWithExistingTarget()
+    {
+        $this->copyFixture('ai_with_store.yaml', 'config/packages/ai.yaml');
+
+        $this->runConfigure([
+            [
+                'file' => 'config/packages/ai.yaml',
+                'position' => 'after_target',
+                'target' => '    store:',
+                'create_if_missing' => '    store:',
+                'content' => "        azuresearch:\n            default:\n                endpoint: '%env(AZURE_SEARCH_ENDPOINT)%'",
+            ],
+        ]);
+
+        $this->assertSame(
+            $this->loadFixture('ai_with_store_expected.yaml'),
+            $this->readFile('config/packages/ai.yaml')
+        );
+    }
+
+    public function testCreateIfMissingNotUsedWhenOptionNotSet()
+    {
+        $this->copyFixture('ai_without_store.yaml', 'config/packages/ai.yaml');
+
+        $this->runConfigure([
+            [
+                'file' => 'config/packages/ai.yaml',
+                'position' => 'after_target',
+                'target' => '    store:',
+                'content' => "        azuresearch:\n            default:\n                endpoint: '%env(AZURE_SEARCH_ENDPOINT)%'",
+            ],
+        ]);
+
+        // Content should remain unchanged since target was not found and no create_if_missing was provided
+        $this->assertSame(
+            $this->loadFixture('ai_without_store.yaml'),
+            $this->readFile('config/packages/ai.yaml')
+        );
+    }
+
     public function testPatchIgnoredIfValueAlreadyExists()
     {
         $originalContents = <<<JS
@@ -675,6 +735,16 @@ class AddLinesConfiguratorTest extends TestCase
     private function readFile(string $filename): string
     {
         return file_get_contents(FLEX_TEST_DIR.'/'.$filename);
+    }
+
+    private function loadFixture(string $filename): string
+    {
+        return rtrim(file_get_contents(__DIR__.'/Fixtures/AddLines/'.$filename), "\n");
+    }
+
+    private function copyFixture(string $fixtureName, string $targetPath): void
+    {
+        $this->saveFile($targetPath, $this->loadFixture($fixtureName));
     }
 
     private function createComposerMockWithPackagesInstalled(array $packages)

--- a/tests/Configurator/Fixtures/AddLines/ai_with_store.yaml
+++ b/tests/Configurator/Fixtures/AddLines/ai_with_store.yaml
@@ -1,0 +1,5 @@
+ai:
+    store:
+        pinecone:
+            default:
+                api_key: 'xxx'

--- a/tests/Configurator/Fixtures/AddLines/ai_with_store_expected.yaml
+++ b/tests/Configurator/Fixtures/AddLines/ai_with_store_expected.yaml
@@ -1,0 +1,8 @@
+ai:
+    store:
+        azuresearch:
+            default:
+                endpoint: '%env(AZURE_SEARCH_ENDPOINT)%'
+        pinecone:
+            default:
+                api_key: 'xxx'

--- a/tests/Configurator/Fixtures/AddLines/ai_without_store.yaml
+++ b/tests/Configurator/Fixtures/AddLines/ai_without_store.yaml
@@ -1,0 +1,4 @@
+ai:
+    platform:
+        default:
+            api_key: '%env(OPENAI_API_KEY)%'

--- a/tests/Configurator/Fixtures/AddLines/ai_without_store_expected.yaml
+++ b/tests/Configurator/Fixtures/AddLines/ai_without_store_expected.yaml
@@ -1,0 +1,8 @@
+ai:
+    platform:
+        default:
+            api_key: '%env(OPENAI_API_KEY)%'
+    store:
+        azuresearch:
+            default:
+                endpoint: '%env(AZURE_SEARCH_ENDPOINT)%'


### PR DESCRIPTION
## Why

In `symfony/ai` we basically have an "empty" `ai.yaml` file, as no stores are configured as default. When adding your first store you are not able to leverage the recipe otherwise.

cc @chr-hertel 

## Summary

This PR adds a `create_if_missing` option to the `add-lines` configurator. When using `position: after_target`, if the target is not found in the file, the content specified in `create_if_missing` will be appended to the file, followed by the regular `content`.

### Example usage:

```json
{
    "add-lines": [{
        "file": "config/packages/ai.yaml",
        "position": "after_target",
        "target": "    store:",
        "create_if_missing": "ai:\n    store:",
        "content": "        azuresearch:\n            default:\n                endpoint: '%env(AZURE_SEARCH_ENDPOINT)%'"
    }]
}
```

### Behavior:
- If `store:` exists → Content is added after it (existing behavior)
- If `store:` doesn't exist but `create_if_missing` is set → The `create_if_missing` content is appended to the file, followed by the `content`
- If `store:` doesn't exist and `create_if_missing` is not set → Warning is logged (existing behavior)