### PR TITLE
Remove `recipe` data from `symfony.lock` when the contrib recipe is not installed

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -420,6 +420,8 @@ class Flex implements PluginInterface, EventSubscriberInterface
                     'n'
                 );
                 if ('n' === $answer) {
+                    // Keep the package in lock but without recipe info, so the recipe can be applied later
+                    $this->lock->set($recipe->getName(), ['version' => $recipe->getPackage()->getPrettyVersion()]);
                     continue;
                 }
                 if ('a' === $answer) {

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -44,6 +44,11 @@ use Symfony\Flex\Response;
 
 class FlexTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        @unlink(__DIR__.'/Fixtures/symfony.lock');
+    }
+
     public function testPostInstall()
     {
         $data = [
@@ -122,6 +127,56 @@ EOF
         $flex->activate($composer, $io);
 
         $this->assertTrue(class_exists(Response::class, false));
+    }
+
+    public function testContribRecipeNotApprovedIsRemovedFromLock()
+    {
+        $data = [
+            'manifests' => [
+                'contrib/package' => [
+                    'manifest' => [
+                        'bundles' => [
+                            'Contrib\\Package\\ContribBundle' => ['all'],
+                        ],
+                    ],
+                    'origin' => 'contrib/package:1.0@github.com/symfony/recipes-contrib:main',
+                    'is_contrib' => true,
+                ],
+            ],
+            'locks' => [
+                'contrib/package' => [
+                    'recipe' => [
+                        'repo' => 'github.com/symfony/recipes-contrib',
+                        'version' => '1.0',
+                    ],
+                    'version' => '1.0.0',
+                ],
+            ],
+        ];
+
+        // Non-interactive mode with allow-contrib disabled (BufferIO is non-interactive by default)
+        $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
+
+        $package = new Package('contrib/package', '1.0.0', '1.0.0');
+        $rootPackage = $this->mockRootPackage([]); // no allow-contrib
+
+        $downloader = $this->mockDownloader($data);
+        $configurator = $this->getMockBuilder(Configurator::class)->disableOriginalConstructor()->getMock();
+        // Recipe should NOT be installed
+        $configurator->expects($this->never())->method('install');
+
+        $lock = new Lock(__DIR__.'/Fixtures/symfony.lock');
+        $composer = $this->mockComposer($this->mockLocker(), $rootPackage);
+        $flex = $this->mockFlexCustom($io, $composer, $configurator, $downloader, $lock);
+
+        $flex->record($this->mockPackageEvent($package));
+        $flex->install($this->mockFlexEvent());
+        $this->assertSame(['version' => '1.0.0'], $lock->get('contrib/package'));
+
+        // Verify the warning message was displayed
+        $output = $io->getOutput();
+        $this->assertStringContainsString('IGNORING', $output);
+        $this->assertStringContainsString('contrib/package', $output);
     }
 
     /**


### PR DESCRIPTION
Fix https://github.com/symfony/flex/issues/1076

I tested various composer commands with difference values of `symfony.lock` to find if I can apply a recipe after rejecting it.

## 1. If the package is removed from `symfony.lock` (rejected solution)

| Command | Install |
|---------|--------|
| `composer install` | ❌ |
| `composer update` | ✅ |
| `composer recipes:install` | ✅ |
| `composer recipes:install --force` | ✅ |
| `composer recipes:update` | ❌ |

## 2. If the package has no `recipe` in `symfony.lock` (this PR)

```json
    "doctrine/mongodb-odm-bundle": {
        "version": "5.5"
    }
```

| Command | Install |
|---------|--------|
| `composer install` | ❌ |
| `composer update` | ❌ |
| `composer recipes:install` | ❌ |
| `composer recipes:install --force` | ✅ |
| `composer recipes:update` | ❌ |

## 3. If the package has all the `recipe` informations in `symfony.lock` (before this PR)

```json
    "doctrine/mongodb-odm-bundle": {
        "version": "5.5",
        "recipe": {
            "repo": "github.com/symfony/recipes-contrib",
            "branch": "main",
            "version": "5.0",
            "ref": "e84b128ea886f70a430eb88de7ac8217611542cc"
        },
        "files": [
            "config/packages/doctrine_mongodb.yaml",
            "src/Document/.gitignore"
        ]
    },
```

| Command | Install |
|---------|--------|
| `composer install` | ❌ |
| `composer update` | ❌ |
| `composer recipes:install` | ❌ |
| `composer recipes:install --force` | ❌ |
| `composer recipes:update` | ❌ |