### PR TITLE
[MakefileConfigurator] Fix indentation of `help` target

### DIFF
--- a/src/Configurator/MakefileConfigurator.php
+++ b/src/Configurator/MakefileConfigurator.php
@@ -73,6 +73,7 @@ class MakefileConfigurator extends AbstractConfigurator
         if (!file_exists($makefile)) {
             $envKey = $this->options->get('runtime')['env_var_name'] ?? 'APP_ENV';
             $dotenvPath = $this->options->get('runtime')['dotenv_path'] ?? '.env';
+            $tab = "\t";
             file_put_contents(
                 $this->options->get('root-dir').'/Makefile',
                 <<<EOF
@@ -83,7 +84,7 @@ class MakefileConfigurator extends AbstractConfigurator
                     .DEFAULT_GOAL := help
                     .PHONY: help
                     help:
-                        @awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z-]+:.*?## .*$$/ {printf "\033[32m%-15s\033[0m %s\\n", $$1, $$2}' Makefile | sort
+                    {$tab}@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z-]+:.*?## .*$$/ {printf "\033[32m%-15s\033[0m %s\\n", $$1, $$2}' Makefile | sort
 
                     EOF
             );

--- a/tests/Configurator/MakefileConfiguratorTest.php
+++ b/tests/Configurator/MakefileConfiguratorTest.php
@@ -231,4 +231,29 @@ endif
 EOF
         ], $recipeUpdate->getNewFiles());
     }
+
+    public function testConfigureCreatesBoilerplateWithTabIndentation()
+    {
+        $configurator = new MakefileConfigurator(
+            $this->getMockBuilder(Composer::class)->getMock(),
+            $this->getMockBuilder(IOInterface::class)->getMock(),
+            new Options(['root-dir' => FLEX_TEST_DIR])
+        );
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $recipe->expects($this->any())->method('getName')->willReturn('FooBundle');
+
+        $makefile = FLEX_TEST_DIR.'/Makefile';
+        @unlink($makefile);
+
+        $configurator->configure($recipe, ['foo: ## Do foo'], $lock);
+
+        $this->assertFileExists($makefile);
+        $contents = file_get_contents($makefile);
+        $this->assertStringContainsString("ifndef APP_ENV\n    include .env\nendif", $contents);
+        $this->assertStringContainsString('.DEFAULT_GOAL := help', $contents);
+        $this->assertStringContainsString('.PHONY: help', $contents);
+        $this->assertStringContainsString("help:\n\t@awk", $contents, 'The help target must use a tab for indentation, not spaces');
+    }
 }


### PR DESCRIPTION
When working on https://github.com/symfony/recipes-contrib/pull/1936, that contains a Makefile, I noticed that the Makefile boilerplate generated in 2.x (1.x not affected) contains 4 spaces instead of a tabulation in the task `help`.

With the spaces:
<img width="1048" height="66" alt="image" src="https://github.com/user-attachments/assets/17d4c96e-86ec-4cb0-b483-c91934f3bfc5" />

With the tabulation:
<img width="1046" height="71" alt="image" src="https://github.com/user-attachments/assets/30e54682-c005-4570-9759-838f926a876a" />

Note: I didn't tested the fix, I'm assuming it works 🤞🏻 