### PR TITLE
Fix "null as array offset" deprecation in DockerComposeConfigurator

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -275,7 +275,9 @@ class DockerComposeConfigurator extends AbstractConfigurator
                 }
 
                 // Keep end in memory (check break line on previous line)
-                $endAt[$node] = !$i || '' !== trim($lines[$i - 1]) ? $i : $i - 1;
+                if (null !== $node) {
+                    $endAt[$node] = !$i || '' !== trim($lines[$i - 1]) ? $i : $i - 1;
+                }
                 $node = $matches[1];
                 if (!isset($nodesLines[$node])) {
                     $nodesLines[$node] = [];
@@ -285,7 +287,9 @@ class DockerComposeConfigurator extends AbstractConfigurator
                     $startAt[$node] = $i + 1;
                 }
             }
-            $endAt[$node] = \count($lines) + 1;
+            if (null !== $node) {
+                $endAt[$node] = \count($lines) + 1;
+            }
 
             foreach ($extra as $key => $value) {
                 if (isset($endAt[$key])) {


### PR DESCRIPTION
Fix #1079

## Summary

PHP 8.5 introduces a deprecation notice when `null` is used as an array offset:

> Using null as an array offset is deprecated, use an empty string instead

In `configureDockerCompose()`, `$node` is initialized to `null` and used as an array key in `$endAt[$node]` before being assigned — once at the first top-level key encounter during the parsing loop, and once after the loop when the file is empty (e.g. a freshly created `compose.yaml`).

## Fix

Guard both `$endAt[$node]` assignments with `null !== $node` checks, since there is no previous section to record an end position for.