### PR TITLE
Fix testEnvCanBeReferenced for dotenv deferred resolution

### DIFF
--- a/tests/Command/DumpEnvCommandTest.php
+++ b/tests/Command/DumpEnvCommandTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Flex\Tests\Command;
 
 use Composer\Config;
 use Composer\Console\Application;
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Flex\Command\DumpEnvCommand;
@@ -109,10 +111,14 @@ class DumpEnvCommandTest extends TestCase
 
         $this->assertFileExists($envLocal);
 
+        // With dotenv >= 6.4.35/7.4.7/8.0.7, variable resolution is deferred so BAR=$FOO
+        // resolves using .env's FOO value. With older versions, eager resolution uses system env.
+        $deferredResolution = InstalledVersions::satisfies(new VersionParser(), 'symfony/dotenv', '^6.4.35 | ^7.4.7 | >=8.0.7');
+
         $vars = require $envLocal;
         $this->assertSame([
             'APP_ENV' => 'prod',
-            'BAR' => 'Foo',
+            'BAR' => $deferredResolution ? '123' : 'Foo',
             'FOO' => '123',
         ], $vars);
 


### PR DESCRIPTION
`symfony/dotenv` >= 6.4.35/7.4.7/8.0.7 introduced deferred variable resolution (symfony/symfony#63496): variables like `BAR=$FOO` are now resolved after all `.env` files are loaded, using `$_ENV['FOO']` (set by `populate()` from `.env`) rather than the system env at dump time.

This caused `testEnvCanBeReferenced` to fail: `BAR` now resolves to `'123'` (from `.env`) instead of `'Foo'` (from `$_SERVER` via the runtime PHP expression).

The test is updated to use `InstalledVersions::satisfies()` to assert the correct expected value depending on the installed dotenv version, keeping compatibility with both old and new behavior.