### PR TITLE
[Unpacker] Copy "replace" and "provide" entries when unpacking a pack

### DIFF
--- a/src/Unpacker.php
+++ b/src/Unpacker.php
@@ -38,7 +38,7 @@ class Unpacker
         $this->versionParser = new VersionParser();
     }
 
-    public function unpack(Operation $op, ?Result $result = null, &$links = [], bool $devRequire = false): Result
+    public function unpack(Operation $op, ?Result $result = null, &$links = [], bool $devRequire = false, &$replaces = [], &$provides = []): Result
     {
         if (null === $result) {
             $result = new Result();
@@ -95,7 +95,7 @@ class Unpacker
                         if ('symfony-pack' === $subPkg->getType()) {
                             $subOp = new Operation(true, $op->shouldSort());
                             $subOp->addPackage($subPkg->getName(), $constraint, $dev);
-                            $result = $this->unpack($subOp, $result, $links, $dev);
+                            $result = $this->unpack($subOp, $result, $links, $dev, $replaces, $provides);
                             continue;
                         }
 
@@ -126,6 +126,13 @@ class Unpacker
                         ];
                     }
                 }
+            }
+
+            foreach ($pkg->getReplaces() as $link) {
+                $replaces[$link->getTarget()] = $link->getPrettyConstraint();
+            }
+            foreach ($pkg->getProvides() as $link) {
+                $provides[$link->getTarget()] = $link->getPrettyConstraint();
             }
         }
 
@@ -167,6 +174,18 @@ class Unpacker
 
             if (!$jsonManipulator->addLink($link['type'], $link['name'], $constraint->getPrettyString(), $op->shouldSort())) {
                 throw new \RuntimeException(\sprintf('Unable to unpack package "%s".', $link['name']));
+            }
+        }
+
+        foreach ($replaces as $name => $constraint) {
+            if (!isset($jsonStored['replace'][$name])) {
+                $jsonManipulator->addLink('replace', $name, $constraint, $op->shouldSort());
+            }
+        }
+
+        foreach ($provides as $name => $constraint) {
+            if (!isset($jsonStored['provide'][$name])) {
+                $jsonManipulator->addLink('provide', $name, $constraint, $op->shouldSort());
             }
         }
 

--- a/tests/Command/DumpEnvCommandTest.php
+++ b/tests/Command/DumpEnvCommandTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Flex\Tests\Command;
 
 use Composer\Config;
 use Composer\Console\Application;
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Flex\Command\DumpEnvCommand;
@@ -109,10 +111,14 @@ class DumpEnvCommandTest extends TestCase
 
         $this->assertFileExists($envLocal);
 
+        // With dotenv >= 6.4.35/7.4.7/8.0.7, variable resolution is deferred so BAR=$FOO
+        // resolves using .env's FOO value. With older versions, eager resolution uses system env.
+        $deferredResolution = InstalledVersions::satisfies(new VersionParser(), 'symfony/dotenv', '^6.4.35 | ^7.4.7 | >=8.0.7');
+
         $vars = require $envLocal;
         $this->assertSame([
             'APP_ENV' => 'prod',
-            'BAR' => 'Foo',
+            'BAR' => $deferredResolution ? '123' : 'Foo',
             'FOO' => '123',
         ], $vars);
 

--- a/tests/UnpackerTest.php
+++ b/tests/UnpackerTest.php
@@ -29,7 +29,7 @@ class UnpackerTest extends TestCase
      *
      *   - "real" package MUST be present ONLY in "require" section
      */
-    public function testDoNotDuplicateEntry(): void
+    public function testDoNotDuplicateEntry()
     {
         // Setup project
 
@@ -86,6 +86,82 @@ class UnpackerTest extends TestCase
         $this->assertArrayHasKey('require', $composerJson);
         $this->assertArrayHasKey('real', $composerJson['require']);
         $this->assertArrayNotHasKey('require-dev', $composerJson);
+
+        // Restore
+
+        if ($originalEnvComposer) {
+            $_SERVER['COMPOSER'] = $originalEnvComposer;
+        } else {
+            unset($_SERVER['COMPOSER']);
+        }
+        // composer 2.1 and lower support
+        putenv('COMPOSER='.$originalEnvComposer);
+        @unlink($composerJsonPath);
+    }
+
+    /**
+     * When unpacking a pack, its "replace" and "provide" entries must be
+     * copied to the root composer.json.
+     */
+    public function testUnpackCopiesReplaceAndProvide()
+    {
+        // Setup project
+
+        $composerJsonPath = FLEX_TEST_DIR.'/composer.json';
+
+        @mkdir(FLEX_TEST_DIR);
+        @unlink($composerJsonPath);
+        file_put_contents($composerJsonPath, '{}');
+
+        $originalEnvComposer = $_SERVER['COMPOSER'];
+        $_SERVER['COMPOSER'] = $composerJsonPath;
+        // composer 2.1 and lower support
+        putenv('COMPOSER='.$composerJsonPath);
+
+        // Setup packages
+
+        $realPkg = new Package('real', '1.0.0', '1.0.0');
+        $realPkgLink = new Link('lorem', 'real', new MatchAllConstraint(), 'wraps', '1.0.0');
+
+        $virtualPkg = new Package('pack_foo', '1.0.0', '1.0.0');
+        $virtualPkg->setType('symfony-pack');
+        $virtualPkg->setRequires(['real' => $realPkgLink]);
+        $virtualPkg->setReplaces([
+            'old/package' => new Link('pack_foo', 'old/package', new MatchAllConstraint(), 'replaces', 'self.version'),
+        ]);
+        $virtualPkg->setProvides([
+            'some/capability' => new Link('pack_foo', 'some/capability', new MatchAllConstraint(), 'provides', 'self.version'),
+        ]);
+
+        $packages = [$realPkg, $virtualPkg];
+
+        // Setup Composer
+
+        $repManager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();
+        $repManager->expects($this->any())->method('getLocalRepository')->willReturn(new InstalledArrayRepository($packages));
+
+        $composer = new Composer();
+        $composer->setRepositoryManager($repManager);
+
+        // Unpack
+
+        $resolver = $this->getMockBuilder(PackageResolver::class)->disableOriginalConstructor()->getMock();
+
+        $unpacker = new Unpacker($composer, $resolver);
+
+        $operation = new Operation(true, false);
+        $operation->addPackage('pack_foo', '*', false);
+
+        $unpacker->unpack($operation);
+
+        // Check
+
+        $composerJson = json_decode(file_get_contents($composerJsonPath), true);
+
+        $this->assertArrayHasKey('replace', $composerJson);
+        $this->assertArrayHasKey('old/package', $composerJson['replace']);
+        $this->assertArrayHasKey('provide', $composerJson);
+        $this->assertArrayHasKey('some/capability', $composerJson['provide']);
 
         // Restore
 


### PR DESCRIPTION
When a `symfony-pack` is unpacked, its `replace` and `provide` entries are now copied to the root `composer.json`, just like `require` entries already are.

Fixes #653