### PR TITLE
ci: add PHP 8.5 default run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
                   - php: '8.3'
                   - php: '8.4'
                   - php: '8.5'
+                  - php: '8.5'
                     mode: low-deps
 
         steps:


### PR DESCRIPTION
CI is only running in lowest deps for PHP 8.5

Is there a reason that there is no default run for PHP 8.5 ?