### PR TITLE
Add --no-changelog option to recipes:update

### DIFF
--- a/src/Command/UpdateRecipesCommand.php
+++ b/src/Command/UpdateRecipesCommand.php
@@ -19,6 +19,7 @@ use Composer\Util\ProcessExecutor;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Flex\Configurator;
 use Symfony\Flex\Downloader;
@@ -57,6 +58,7 @@ class UpdateRecipesCommand extends BaseCommand
             ->setAliases(['recipes:update'])
             ->setDescription('Updates an already-installed recipe to the latest version.')
             ->addArgument('package', InputArgument::OPTIONAL, 'Recipe that should be updated.')
+            ->addOption('no-changelog', null, InputOption::VALUE_NONE, 'Do not generate the changelog after updating the recipe.')
         ;
     }
 
@@ -247,7 +249,7 @@ class UpdateRecipesCommand extends BaseCommand
             }
         }
 
-        if ($patch->getPatch()) {
+        if ($patch->getPatch() && !$input->getOption('no-changelog')) {
             $io->write('');
             $io->write('  Calculating CHANGELOG...', false);
             $changelog = $this->generateChangelog($originalRecipe);

--- a/tests/Command/UpdateRecipesCommandTest.php
+++ b/tests/Command/UpdateRecipesCommandTest.php
@@ -52,13 +52,42 @@ class UpdateRecipesCommandTest extends TestCase
         $filesystem->remove(FLEX_TEST_DIR);
     }
 
-    /**
-     * Skip 7.1, simply because there isn't a newer recipe version available
-     * that we can easily use to assert.
-     *
-     * @requires PHP >= 7.2
-     */
     public function testCommandUpdatesRecipe()
+    {
+        $this->prepareRecipeUpdateFixture();
+
+        $command = $this->createCommandUpdateRecipes();
+        $command->execute(['package' => 'symfony/console']);
+
+        $this->assertSame(0, $command->getStatusCode());
+        $this->assertStringContainsString('Recipe updated', $this->io->getOutput());
+        // assert bin/console has changed
+        $this->assertStringNotContainsString('vendor/autoload.php', file_get_contents(FLEX_TEST_DIR.'/bin/console'));
+        // assert the recipe was updated
+        $this->assertStringNotContainsString('c6d02bdfba9da13c22157520e32a602dbee8a75c', file_get_contents(FLEX_TEST_DIR.'/symfony.lock'));
+    }
+
+    public function testCommandUpdatesRecipeWithNoChangelog()
+    {
+        $this->prepareRecipeUpdateFixture();
+
+        $command = $this->createCommandUpdateRecipes();
+        $command->execute([
+            'package' => 'symfony/console',
+            '--no-changelog' => true,
+        ]);
+
+        $this->assertSame(0, $command->getStatusCode());
+        $this->assertStringContainsString('Recipe updated', $this->io->getOutput());
+        $this->assertStringNotContainsString('Calculating CHANGELOG', $this->io->getOutput());
+        $this->assertStringNotContainsString('No CHANGELOG could be calculated.', $this->io->getOutput());
+        // assert bin/console has changed
+        $this->assertStringNotContainsString('vendor/autoload.php', file_get_contents(FLEX_TEST_DIR.'/bin/console'));
+        // assert the recipe was updated
+        $this->assertStringNotContainsString('c6d02bdfba9da13c22157520e32a602dbee8a75c', file_get_contents(FLEX_TEST_DIR.'/symfony.lock'));
+    }
+
+    private function prepareRecipeUpdateFixture(): void
     {
         @mkdir(FLEX_TEST_DIR);
         (new Process(['git', 'init'], FLEX_TEST_DIR))->mustRun();
@@ -76,16 +105,6 @@ class UpdateRecipesCommandTest extends TestCase
         (new Process(['git', 'commit', '-m', 'setup of original console files'], FLEX_TEST_DIR))->mustRun();
 
         (new Process([__DIR__.'/../../vendor/bin/composer', 'install'], FLEX_TEST_DIR))->mustRun();
-
-        $command = $this->createCommandUpdateRecipes();
-        $command->execute(['package' => 'symfony/console']);
-
-        $this->assertSame(0, $command->getStatusCode());
-        $this->assertStringContainsString('Recipe updated', $this->io->getOutput());
-        // assert bin/console has changed
-        $this->assertStringNotContainsString('vendor/autoload.php', file_get_contents(FLEX_TEST_DIR.'/bin/console'));
-        // assert the recipe was updated
-        $this->assertStringNotContainsString('c6d02bdfba9da13c22157520e32a602dbee8a75c', file_get_contents(FLEX_TEST_DIR.'/symfony.lock'));
     }
 
     private function createCommandUpdateRecipes(): CommandTester


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #1081

Adds `--no-changelog` to `composer recipes:update` so the GitHub API-based changelog (PR list) can be skipped. This is useful when updating many recipes and hitting GH rate limits (see issue).