### PR TITLE
[ComposerScriptsConfigurator] Auto-wire `@auto-scripts` into post-install-cmd and post-update-cmd

### DIFF
--- a/src/Configurator/ComposerScriptsConfigurator.php
+++ b/src/Configurator/ComposerScriptsConfigurator.php
@@ -74,6 +74,31 @@ class ComposerScriptsConfigurator extends AbstractConfigurator
         $manipulator = new JsonManipulator(file_get_contents($json->getPath()));
         $manipulator->addSubNode('scripts', 'auto-scripts', $autoScripts);
 
+        foreach (['post-install-cmd', 'post-update-cmd'] as $hook) {
+            $current = $jsonContents['scripts'][$hook] ?? null;
+            $wired = $this->ensureAutoScriptsHook($current);
+            if ($wired !== $current) {
+                $manipulator->addSubNode('scripts', $hook, $wired);
+            }
+        }
+
         return $manipulator->getContents();
+    }
+
+    private function ensureAutoScriptsHook($current): array
+    {
+        if (null === $current) {
+            return ['@auto-scripts'];
+        }
+
+        if (!\is_array($current)) {
+            $current = [$current];
+        }
+
+        if (!\in_array('@auto-scripts', $current, true)) {
+            $current[] = '@auto-scripts';
+        }
+
+        return $current;
     }
 }

--- a/tests/Configurator/ComposerScriptsConfiguratorTest.php
+++ b/tests/Configurator/ComposerScriptsConfiguratorTest.php
@@ -91,6 +91,159 @@ class ComposerScriptsConfiguratorTest extends TestCase
         );
     }
 
+    public function testConfigureAddsHooksWhenMissing()
+    {
+        file_put_contents(FLEX_TEST_DIR.'/composer.json', json_encode([
+            'scripts' => [
+                'auto-scripts' => [
+                    'cache:clear' => 'symfony-cmd',
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT));
+
+        $configurator = new ComposerScriptsConfigurator(
+            $this->createMock(Composer::class),
+            $this->createMock(IOInterface::class),
+            new Options(['root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+
+        $configurator->configure($recipe, [
+            'do:cool-stuff' => 'symfony-cmd',
+        ], $lock);
+        $this->assertEquals(<<<EOF
+            {
+                "scripts": {
+                    "auto-scripts": {
+                        "cache:clear": "symfony-cmd",
+                        "do:cool-stuff": "symfony-cmd"
+                    },
+                    "post-install-cmd": ["@auto-scripts"],
+                    "post-update-cmd": ["@auto-scripts"]
+                }
+            }
+
+            EOF,
+            file_get_contents(FLEX_TEST_DIR.'/composer.json')
+        );
+    }
+
+    public function testConfigureAppendsToExistingHookArray()
+    {
+        file_put_contents(FLEX_TEST_DIR.'/composer.json', json_encode([
+            'scripts' => [
+                'auto-scripts' => [
+                    'cache:clear' => 'symfony-cmd',
+                ],
+                'post-install-cmd' => ['@some-other'],
+                'post-update-cmd' => ['@some-other'],
+            ],
+        ], \JSON_PRETTY_PRINT));
+
+        $configurator = new ComposerScriptsConfigurator(
+            $this->createMock(Composer::class),
+            $this->createMock(IOInterface::class),
+            new Options(['root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+
+        $configurator->configure($recipe, [
+            'do:cool-stuff' => 'symfony-cmd',
+        ], $lock);
+        $this->assertEquals(<<<EOF
+            {
+                "scripts": {
+                    "auto-scripts": {
+                        "cache:clear": "symfony-cmd",
+                        "do:cool-stuff": "symfony-cmd"
+                    },
+                    "post-install-cmd": ["@some-other", "@auto-scripts"],
+                    "post-update-cmd": ["@some-other", "@auto-scripts"]
+                }
+            }
+
+            EOF,
+            file_get_contents(FLEX_TEST_DIR.'/composer.json')
+        );
+    }
+
+    public function testConfigureConvertsScalarHookToArray()
+    {
+        file_put_contents(FLEX_TEST_DIR.'/composer.json', json_encode([
+            'scripts' => [
+                'auto-scripts' => [
+                    'cache:clear' => 'symfony-cmd',
+                ],
+                'post-install-cmd' => '@some-other',
+                'post-update-cmd' => '@some-other',
+            ],
+        ], \JSON_PRETTY_PRINT));
+
+        $configurator = new ComposerScriptsConfigurator(
+            $this->createMock(Composer::class),
+            $this->createMock(IOInterface::class),
+            new Options(['root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+
+        $configurator->configure($recipe, [
+            'do:cool-stuff' => 'symfony-cmd',
+        ], $lock);
+        $this->assertEquals(<<<EOF
+            {
+                "scripts": {
+                    "auto-scripts": {
+                        "cache:clear": "symfony-cmd",
+                        "do:cool-stuff": "symfony-cmd"
+                    },
+                    "post-install-cmd": ["@some-other", "@auto-scripts"],
+                    "post-update-cmd": ["@some-other", "@auto-scripts"]
+                }
+            }
+
+            EOF,
+            file_get_contents(FLEX_TEST_DIR.'/composer.json')
+        );
+    }
+
+    public function testConfigureIsIdempotentWhenAutoScriptsAlreadyWired()
+    {
+        file_put_contents(FLEX_TEST_DIR.'/composer.json', json_encode([
+            'scripts' => [
+                'auto-scripts' => [
+                    'do:cool-stuff' => 'symfony-cmd',
+                ],
+                'post-install-cmd' => ['@auto-scripts'],
+                'post-update-cmd' => ['@auto-scripts'],
+            ],
+        ], \JSON_PRETTY_PRINT));
+
+        $configurator = new ComposerScriptsConfigurator(
+            $this->createMock(Composer::class),
+            $this->createMock(IOInterface::class),
+            new Options(['root-dir' => FLEX_TEST_DIR])
+        );
+
+        $recipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $lock = $this->getMockBuilder(Lock::class)->disableOriginalConstructor()->getMock();
+
+        $configurator->configure($recipe, [
+            'do:cool-stuff' => 'symfony-cmd',
+        ], $lock);
+        $afterFirst = file_get_contents(FLEX_TEST_DIR.'/composer.json');
+
+        $configurator->configure($recipe, [
+            'do:cool-stuff' => 'symfony-cmd',
+        ], $lock);
+        $this->assertSame($afterFirst, file_get_contents(FLEX_TEST_DIR.'/composer.json'));
+    }
+
     public function testUnconfigure()
     {
         file_put_contents(FLEX_TEST_DIR.'/composer.json', json_encode([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Prerequisite for symfony/ai#1994

When a recipe declares `composer-scripts`, Flex now also ensures `@auto-scripts` is wired into `scripts.post-install-cmd` and `scripts.post-update-cmd` in the user's `composer.json`. Restores parity with composer plugins for non-skeleton projects, where these hooks aren't pre-configured.

## Cross-repo PRs

| # | Repo | PR | What | Status |
|---|---|---|---|---|
| 1 | symfony/ai | [symfony/ai#2027](https://github.com/symfony/ai/pull/2027) | `mate discover --ignore-missing-file` | open |
| 2 | symfony/ai | [symfony/ai#2026](https://github.com/symfony/ai/pull/2026) | Drop `symfony/ai-mate-composer-plugin` from `symfony/ai-mate`'s require list (depends on symfony/ai#2027) | draft |
| 3 | symfony/flex | [symfony/flex#1089](https://github.com/symfony/flex/pull/1089) | Auto-wire `@auto-scripts` into `post-install-cmd` / `post-update-cmd` | **this PR** |
| 4 | symfony/recipes | [symfony/recipes#1535](https://github.com/symfony/recipes/pull/1535) | The `symfony/ai-mate` recipe | draft |
| 5 | symfony/ai | _follow-up_ | Delete the composer plugin source | not started |

## Summary

`ComposerScriptsConfigurator::configure()` now, in addition to merging into `scripts.auto-scripts`, ensures `@auto-scripts` is present in both `post-install-cmd` and `post-update-cmd`:

- Hook missing → created as `["@auto-scripts"]`.
- Hook is an array without `@auto-scripts` → appended.
- Hook is a scalar → converted to array and appended.
- Hook already contains `@auto-scripts` → no-op (idempotent).

`unconfigure()` is intentionally untouched — the wiring stays even when the package is uninstalled, because other recipes may depend on it.

## Usage

Recipes can now declare `composer-scripts` and rely on the script running automatically in any project — including plain PHP projects without the Symfony skeleton's pre-wired hooks.