### PR TITLE
[DockerComposeConfigurator] Fix duplicate top-level key on reconfigure

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -277,6 +277,13 @@ class DockerComposeConfigurator extends AbstractConfigurator
                 // Keep end in memory (check break line on previous line)
                 if (null !== $node) {
                     $endAt[$node] = !$i || '' !== trim($lines[$i - 1]) ? $i : $i - 1;
+                    // Prune nodesLines[old node] to match the range the splice will replace.
+                    if (isset($nodesLines[$node][$i])) {
+                        unset($nodesLines[$node][$i]);
+                        if ('' === trim($lines[$i - 1])) {
+                            unset($nodesLines[$node][$i - 1]);
+                        }
+                    }
                 }
                 $node = $matches[1];
                 if (!isset($nodesLines[$node])) {
@@ -307,14 +314,15 @@ class DockerComposeConfigurator extends AbstractConfigurator
                     array_splice($lines, $startAt[$key], $length, ltrim($updatedContents, "\n"));
 
                     // reset any start/end positions after this to the new positions
+                    $shift = $length - 1;
                     foreach ($startAt as $sectionKey => $at) {
                         if ($at > $originalEndAt) {
-                            $startAt[$sectionKey] = $at - $length - 1;
+                            $startAt[$sectionKey] = $at - $shift;
                         }
                     }
                     foreach ($endAt as $sectionKey => $at) {
                         if ($at > $originalEndAt) {
-                            $endAt[$sectionKey] = $at - $length;
+                            $endAt[$sectionKey] = $at - $shift;
                         }
                     }
 

--- a/tests/Configurator/DockerComposeConfiguratorTest.php
+++ b/tests/Configurator/DockerComposeConfiguratorTest.php
@@ -209,6 +209,29 @@ class DockerComposeConfiguratorTest extends TestCase
         $this->assertEquals(self::ORIGINAL_CONTENT, file_get_contents($dockerComposeFile));
     }
 
+    public function testReconfigureDoesNotDuplicateLaterTopLevelKey()
+    {
+        $this->configurator->configure($this->recipeDb, self::CONFIG_DB, $this->lock);
+
+        $servicesOnlyRecipe = $this->getMockBuilder(Recipe::class)->disableOriginalConstructor()->getMock();
+        $servicesOnlyRecipe->method('getName')->willReturn('acme/services-only');
+        $servicesOnlyConfig = [
+            'services' => [
+                'cache:',
+                '  image: redis:alpine',
+            ],
+        ];
+
+        $this->configurator->configure($servicesOnlyRecipe, $servicesOnlyConfig, $this->lock);
+        $afterFirstConfigure = file_get_contents(FLEX_TEST_DIR.'/compose.yaml');
+
+        $this->configurator->configure($servicesOnlyRecipe, $servicesOnlyConfig, $this->lock, ['force' => true]);
+        $afterSecondConfigure = file_get_contents(FLEX_TEST_DIR.'/compose.yaml');
+
+        $this->assertSame(1, substr_count($afterSecondConfigure, "\nvolumes:\n"), 'compose.yaml must contain exactly one top-level "volumes:" key');
+        $this->assertSame($afterFirstConfigure, $afterSecondConfigure, 'configure must be idempotent when re-run');
+    }
+
     public function testNotConfiguredIfConfigSet()
     {
         $this->package->setExtra(['symfony' => ['docker' => false]]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | —
| License       | MIT

## Problem

`composer recipes:install --reset --force` (or any re-invocation of `configure` against an already-marked `compose.yaml`) can produce a duplicate top-level key:

```yaml
###< some/recipe ###

volumes:
volumes:
###> other/recipe ###
  some-data:
###< other/recipe ###
```

`docker compose config` then rejects the file with `mapping key "volumes" already defined`.

Triggered when a recipe touches a non-last top-level section (e.g. `symfony/mailer` contributing only `services:` on a file that already has `volumes:`) and that recipe's markers are already present.

## Root cause

Two interacting bugs in `DockerComposeConfigurator::configureDockerCompose`. Either alone is harmless; the duplicate top-level key requires both.

**`$nodesLines` accounting.** The parser appends each line to `$nodesLines[$node]` *before* checking whether the line itself starts a new top-level key. So when the loop reaches `volumes:`, that header is recorded under the outgoing `services` node. When `services` is later updated and spliced back, the replacement carries a trailing `volumes:`; the original `volumes:` header sits one index past the splice range and survives — duplicate.

**Position-adjustment math.** After the in-place splice, `$startAt`/`$endAt` for later sections are adjusted by `-$length - 1` and `-$length` respectively. The correct shift is `-($length - 1)`.

**Why they mask each other.** Fix only the accounting bug and the next section's splice (with the off-by-two `startAt`) deletes that section's header. Fix only the math and the leftover key compounds — three consecutive `volumes:` lines. Together, the splice range matches what `$nodesLines[old node]` mirrors, and subsequent sections land at correct positions.

## Fix

1. On node transition, unset `$nodesLines[$node][$i]` (plus `[$i - 1]` if the previous line was blank) so recorded content matches the splice range `[startAt..endAt-1]`.
2. Use `$shift = $length - 1` for both `$startAt` and `$endAt` adjustments.

## Test

`testReconfigureDoesNotDuplicateLaterTopLevelKey` — fails on `2.x`, passes here.
