### PR TITLE
Fix `null as array offset` when running composer without command

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -162,6 +162,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
             $resolver = new PackageResolver($this->downloader);
 
+            $command = null;
             $commandObj = null;
             try {
                 $command = $input->getFirstArgument();
@@ -180,7 +181,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
                 $symfonyRequire = null;
             }
 
-            if (isset(self::$aliasResolveCommands[$command])) {
+            if (null !== $command && isset(self::$aliasResolveCommands[$command])) {
                 // When the command name is abbreviated (e.g. "req" for "require"), Composer
                 // activates plugins early to look up potential script commands, before the
                 // input has been bound to the command definition. In that case "packages"


### PR DESCRIPTION
```bash
> composer -V
Deprecation Notice: Using null as an array offset is deprecated, use an empty string instead in /var/www/application/vendor/symfony/flex/src/Flex.php:184
Composer version 2.10.1 2026-06-04 10:25:59
PHP version 8.5.5 (/usr/bin/php8.5)
```