### PR TITLE
Warn when SYMFONY_REQUIRE is set to an exact version constraint

### DIFF
--- a/src/Flex.php
+++ b/src/Flex.php
@@ -39,6 +39,7 @@ use Composer\Plugin\PluginInterface;
 use Composer\Plugin\PrePoolCreateEvent;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
+use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\VersionParser;
 use Symfony\Component\Console\Exception\ExceptionInterface as ConsoleExceptionInterface;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -219,10 +220,14 @@ class Flex implements PluginInterface, EventSubscriberInterface
             break;
         }
 
-        $symfonyRequire = preg_replace('/\.x$/', '.x-dev', getenv('SYMFONY_REQUIRE') ?: ($composer->getPackage()->getExtra()['symfony']['require'] ?? ''));
+        $rawSymfonyRequire = getenv('SYMFONY_REQUIRE') ?: ($composer->getPackage()->getExtra()['symfony']['require'] ?? '');
+        $symfonyRequire = preg_replace('/\.x$/', '.x-dev', $rawSymfonyRequire);
 
-        if ($symfonyRequire && preg_match('/^\d+(\.\d+)*$/', $symfonyRequire)) {
-            $io->writeError(\sprintf('<warning>SYMFONY_REQUIRE="%s" is an exact version constraint. Did you mean "%s.*" or "^%s"?</>', $symfonyRequire, $symfonyRequire, $symfonyRequire));
+        if ($rawSymfonyRequire) {
+            $parsedConstraint = (new VersionParser())->parseConstraints($rawSymfonyRequire);
+            if ($parsedConstraint instanceof Constraint && '==' === $parsedConstraint->getOperator()) {
+                $io->writeError(\sprintf('<warning>SYMFONY_REQUIRE="%s" is an exact version constraint. Did you mean "%s.*" or "^%s"?</>', $rawSymfonyRequire, $rawSymfonyRequire, $rawSymfonyRequire));
+            }
         }
 
         if ($symfonyRequire || $this->ignorePreleases) {

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -221,6 +221,10 @@ class Flex implements PluginInterface, EventSubscriberInterface
 
         $symfonyRequire = preg_replace('/\.x$/', '.x-dev', getenv('SYMFONY_REQUIRE') ?: ($composer->getPackage()->getExtra()['symfony']['require'] ?? ''));
 
+        if ($symfonyRequire && preg_match('/^\d+(\.\d+)*$/', $symfonyRequire)) {
+            $io->writeError(\sprintf('<warning>SYMFONY_REQUIRE="%s" is an exact version constraint. Did you mean "%s.*" or "^%s"?</>', $symfonyRequire, $symfonyRequire, $symfonyRequire));
+        }
+
         if ($symfonyRequire || $this->ignorePreleases) {
             $this->filter = new PackageFilter($io, $symfonyRequire, $this->downloader, $this->ignorePreleases);
         }

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -112,7 +112,7 @@ class FlexTest extends TestCase
     }
 
     #[DataProvider('getSymfonyRequireConstraints')]
-    public function testSymfonyRequireExactVersionWarning(string $constraint, bool $expectWarning): void
+    public function testSymfonyRequireExactVersionWarning(string $constraint, bool $expectWarning)
     {
         $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
 

--- a/tests/FlexTest.php
+++ b/tests/FlexTest.php
@@ -111,6 +111,47 @@ class FlexTest extends TestCase
         );
     }
 
+    #[DataProvider('getSymfonyRequireConstraints')]
+    public function testSymfonyRequireExactVersionWarning(string $constraint, bool $expectWarning): void
+    {
+        $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);
+
+        $package = $this->mockRootPackage();
+        $package->method('getRequires')->willReturn([new Link('dummy', 'symfony/flex', class_exists(MatchAllConstraint::class) ? new MatchAllConstraint() : null)]);
+
+        $composer = $this->mockComposer($this->mockLocker(), $package, Factory::createConfig($io));
+        if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
+            $composer->setRepositoryManager($this->mockManager());
+        }
+
+        putenv('SYMFONY_REQUIRE='.$constraint);
+        try {
+            (new Flex())->activate($composer, $io);
+        } finally {
+            putenv('SYMFONY_REQUIRE');
+        }
+
+        if ($expectWarning) {
+            $this->assertStringContainsString(\sprintf('SYMFONY_REQUIRE="%s" is an exact version constraint', $constraint), $io->getOutput());
+        } else {
+            $this->assertStringNotContainsString('is an exact version constraint', $io->getOutput());
+        }
+    }
+
+    public static function getSymfonyRequireConstraints(): array
+    {
+        return [
+            'exact major' => ['7', true],
+            'exact minor' => ['7.4', true],
+            'exact patch' => ['7.4.1', true],
+            'caret' => ['^7.4', false],
+            'tilde' => ['~7.4', false],
+            'wildcard' => ['7.4.*', false],
+            'greater or equal' => ['>=7.4', false],
+            'x-range' => ['7.4.x', false],
+        ];
+    }
+
     public function testActivateLoadsClasses()
     {
         $io = new BufferIO('', OutputInterface::VERBOSITY_VERBOSE);


### PR DESCRIPTION
## Problem

Setting `SYMFONY_REQUIRE=7.4` (or any exact version like `7`, `7.4.1`) is treated by Composer as the constraint `= 7.4.0.0` — it will only match that single specific version.

This causes two classes of silent failures:

- **Security advisories block exact versions.** When a package version is flagged by a security advisory, Composer refuses to install it. With an exact constraint, there is no fallback version, so the installation fails with no clear explanation. See composer/composer#12936.

- **Not all packages exist at every bugfix version.** Symfony skips publishing packages that have no changes in a given bugfix release. For example, `symfony/console 7.4.3` may not exist if there were no changes to that component in that release. An exact constraint would then fail to resolve.

The intended constraints are `7.4.*` (allows any `7.4.x`) or `^7.4` (allows `>=7.4.0 <8.0.0`).

## Solution

Use `Composer\Semver\VersionParser` to parse the constraint and detect when it resolves to a single `==` constraint (i.e. an exact version). A warning is then emitted suggesting the correct form:

```
[warning] SYMFONY_REQUIRE="7.4" is an exact version constraint. Did you mean "7.4.*" or "^7.4"?
```

This applies whether the value comes from the `SYMFONY_REQUIRE` environment variable or from `extra.symfony.require` in `composer.json`.