### PR TITLE
[EnvConfigurator] Do not escape literal values in env files

### DIFF
--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -93,7 +93,7 @@ class EnvConfigurator extends AbstractConfigurator
                 }
 
                 $value = $this->options->expandTargetDir($value);
-                if (false !== strpbrk($value, " \t\n&!\"")) {
+                if (!str_starts_with($value, "'") && !str_ends_with($value, "'") && false !== strpbrk($value, " \t\n&!\"")) {
                     $value = '"'.str_replace(['\\', '"', "\t", "\n"], ['\\\\', '\\"', '\t', '\n'], $value).'"';
                 }
                 $data .= "$key=$value\n";

--- a/tests/Configurator/DotenvConfiguratorTest.php
+++ b/tests/Configurator/DotenvConfiguratorTest.php
@@ -51,6 +51,7 @@ class DotenvConfiguratorTest extends TestCase
                 '#2' => 'Comment 3',
                 '#TRUSTED_SECRET' => 's3cretf0rt3st"<>',
                 'APP_SECRET' => 's3cretf0rt3st"<>',
+                'ALLOWED_LANGUAGES' => '\'["en","de","es"]\'',
             ],
         ], $lock);
 
@@ -67,6 +68,7 @@ MAILER_USER=fabien
 # Comment 3
 #TRUSTED_SECRET="s3cretf0rt3st\"<>"
 APP_SECRET="s3cretf0rt3st\"<>"
+ALLOWED_LANGUAGES='["en","de","es"]'
 ###< FooBundle ###
 
 EOF;

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -56,6 +56,7 @@ class EnvConfiguratorTest extends TestCase
             '#2' => 'Comment 3',
             '#TRUSTED_SECRET' => 's3cretf0rt3st"<>',
             'APP_SECRET' => 's3cretf0rt3st"<>',
+            'ALLOWED_LANGUAGES' => '\'["en","de","es"]\'',
         ], $lock);
 
         $envContents = <<<EOF
@@ -71,6 +72,7 @@ MAILER_USER=fabien
 # Comment 3
 #TRUSTED_SECRET="s3cretf0rt3st\"<>"
 APP_SECRET="s3cretf0rt3st\"<>"
+ALLOWED_LANGUAGES='["en","de","es"]'
 ###< FooBundle ###
 
 EOF;
@@ -99,6 +101,7 @@ EOF;
         <!-- Comment 3 -->
         <!-- env name="TRUSTED_SECRET" value="s3cretf0rt3st&quot;&lt;&gt;" -->
         <env name="APP_SECRET" value="s3cretf0rt3st&quot;&lt;&gt;"/>
+        <env name="ALLOWED_LANGUAGES" value="'[&quot;en&quot;,&quot;de&quot;,&quot;es&quot;]'"/>
         <!-- ###- FooBundle ### -->
     </php>
 


### PR DESCRIPTION
_Closes #1096_

## Problem

When a recipe defines a value wrapped in single quotes - for example to store a JSON array:

```json
{
  "dotenv": {
    "dev": {
      "ALLOWED_LANGUAGES": "'[\"en\",\"de\",\"es\"]'"
    }
  }
}
```

The configurator incorrectly wrapped the value in double quotes and escaped the inner double quotes, producing:

`ALLOWED_LANGUAGES="'[\"en\",\"de\",\"es\"]'"`

Instead of the expected single-quoted dotenv literal:

`ALLOWED_LANGUAGES='["en","de","es"]'`

The dotenv format treats single-quoted values as fully literal strings (no escape processing), which makes them the natural fit for JSON content.

## Solution

Skip the double-quote wrapping when the value already starts and ends with a single quote. Any other value continues through the existing escaping path introduced in #200.

```php
// Before
if (false !== strpbrk($value, " \t\n&!\"")) {
  $value = '"'.str_replace([...], [...], $value).'"';
}

// After
if (!str_starts_with($value, "'") && !str_ends_with($value, "'") && false !== strpbrk($value, "\t\n&!\"")) {
  $value = '"'.str_replace([...], [...], $value).'"';
}
```

## Tests

Added a `ALLOWED_LANGUAGES='["en","de","es"]'` fixture to both EnvConfiguratorTest and
DotenvConfiguratorTest to cover this case, alongside the existing assertions for values that require double-quote escaping.