### PR TITLE
Do not abort the whole install when importmap:require fails

### DIFF
--- a/src/PackageJsonSynchronizer.php
+++ b/src/PackageJsonSynchronizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Flex;
 
+use Composer\EventDispatcher\ScriptExecutionException;
 use Composer\IO\IOInterface;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
@@ -265,6 +266,7 @@ class PackageJsonSynchronizer
 
         $importMapData = include $this->rootDir.'/importmap.php';
 
+        $failed = [];
         foreach ($importMapEntries as $name => $importMapEntry) {
             if (isset($importMapData[$name])) {
                 if (!isset($importMapData[$name]['version'])) {
@@ -288,32 +290,32 @@ class PackageJsonSynchronizer
                 if (isset($importMapEntry['entrypoint']) && true === $importMapEntry['entrypoint']) {
                     $arguments[] = '--entrypoint';
                 }
-
-                $this->scriptExecutor->execute(
-                    'symfony-cmd',
-                    'importmap:require',
-                    $arguments
-                );
-
-                continue;
-            }
-
-            if (isset($importMapEntry['version'])) {
+            } elseif (isset($importMapEntry['version'])) {
                 $packageName = $importMapEntry['package'].'@'.$importMapEntry['version'];
                 if ($importMapEntry['package'] !== $name) {
                     $packageName .= '='.$name;
                 }
                 $arguments = [$packageName];
-                $this->scriptExecutor->execute(
-                    'symfony-cmd',
-                    'importmap:require',
-                    $arguments
-                );
-
-                continue;
+            } else {
+                throw new \InvalidArgumentException(\sprintf('Invalid importmap entry: "%s".', var_export($importMapEntry, true)));
             }
 
-            throw new \InvalidArgumentException(\sprintf('Invalid importmap entry: "%s".', var_export($importMapEntry, true)));
+            try {
+                $this->scriptExecutor->execute('symfony-cmd', 'importmap:require', $arguments);
+            } catch (ScriptExecutionException) {
+                // "importmap:require" reaches out to the network (e.g. the jsDelivr API),
+                // so it may fail because of a connectivity issue or a rate limit. Don't let
+                // that abort the whole recipe installation, leaving the app half-configured:
+                // report the entries that could not be added and how to add them later.
+                $failed[] = $name;
+            }
+        }
+
+        if ($failed) {
+            $this->io->writeError([
+                \sprintf('<warning>Could not add the following packages to your importmap: %s.</>', implode(', ', $failed)),
+                '<warning>This is often caused by a temporary network issue. Run "composer install" again once your connection is back to add them.</>',
+            ]);
         }
     }
 

--- a/tests/PackageJsonSynchronizerTest.php
+++ b/tests/PackageJsonSynchronizerTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Flex\Tests;
 
+use Composer\EventDispatcher\ScriptExecutionException;
+use Composer\IO\BufferIO;
 use Composer\IO\IOInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -410,6 +412,31 @@ class PackageJsonSynchronizerTest extends TestCase
         ];
 
         $this->assertSame($expectedArguments, $actualArguments);
+    }
+
+    public function testSynchronizeAssetMapperIsFailSafeWhenImportmapRequireFails()
+    {
+        file_put_contents($this->tempDir.'/importmap.php', '<?php return [];');
+
+        // "importmap:require" reaches out to the network and may fail (e.g. a rate
+        // limit or a connectivity issue), which must not abort the whole install
+        $this->scriptExecutor
+            ->expects($this->atLeastOnce())
+            ->method('execute')
+            ->willThrowException(new ScriptExecutionException('importmap:require', 1));
+
+        $io = new BufferIO();
+        $synchronizer = new PackageJsonSynchronizer($this->tempDir, 'vendor', $this->scriptExecutor, $io);
+
+        $synchronizer->synchronize([
+            ['name' => 'symfony/existing-package', 'keywords' => ['symfony-ux']],
+            ['name' => 'symfony/new-package', 'keywords' => ['symfony-ux']],
+        ]);
+
+        $output = $io->getOutput();
+        $this->assertStringContainsString('Could not add the following packages to your importmap', $output);
+        $this->assertStringContainsString('@hotcake/foo', $output);
+        $this->assertStringContainsString('composer install', $output);
     }
 
     public function testSynchronizeAssetMapperUpgradesPackageIfNeeded()


### PR DESCRIPTION
Fixes #1015.

When `PackageJsonSynchronizer` synchronizes AssetMapper packages, it runs `importmap:require`, which reaches out to the network (the jsDelivr API). If that call fails (a rate limit, or just bad connectivity, as @nicolas-grekas hit during a workshop), the `ScriptExecutionException` propagates and aborts the whole `composer require`, leaving the app half configured with no obvious way for a newcomer to recover.

This makes that step fail safe: a failing `importmap:require` no longer aborts the install. The entries that could not be added are collected and reported at the end, with a hint to run `composer install` again once the network is back (the synchronization re-runs on every install and retries the missing entries).

Before:
```
Executing script importmap:require [KO]
 [KO]
Script importmap:require returned with error code 1
[the whole "composer require webapp" aborts]
```

After the recipes are still applied, and you get:
```
Could not add the following packages to your importmap: @hotwired/stimulus.
This is often caused by a temporary network issue. Run "composer install" again once your connection is back to add them.
```

This is the smaller, incremental fix. @nicolas-grekas, you mentioned you'd rather have `PackageJsonSynchronizer` not touch the network at all and defer it to a later stage (e.g. `cache:clear`). That is a larger change, happy to look into it separately if you'd prefer that direction instead.

Thanks!
