### PR TITLE
Write single-quoted dotenv values as-is

### DIFF
--- a/src/Configurator/EnvConfigurator.php
+++ b/src/Configurator/EnvConfigurator.php
@@ -93,7 +93,7 @@ class EnvConfigurator extends AbstractConfigurator
                 }
 
                 $value = $this->options->expandTargetDir($value);
-                if (false !== strpbrk($value, " \t\n&!\"")) {
+                if (!$this->isSingleQuotedLiteral($value) && false !== strpbrk($value, " \t\n&!\"")) {
                     $value = '"'.str_replace(['\\', '"', "\t", "\n"], ['\\\\', '\\"', '\t', '\n'], $value).'"';
                 }
                 $data .= "$key=$value\n";
@@ -126,7 +126,7 @@ class EnvConfigurator extends AbstractConfigurator
                         $doc = new \DOMDocument();
                         $data .= '        '.$doc->saveXML($doc->createComment(' '.$value.' '))."\n";
                     } else {
-                        $value = $this->options->expandTargetDir($value);
+                        $value = $this->unquoteLiteral($this->options->expandTargetDir($value));
                         $doc = new \DOMDocument();
                         $fragment = $doc->createElement('env');
                         $fragment->setAttribute('name', substr($key, 1));
@@ -134,7 +134,7 @@ class EnvConfigurator extends AbstractConfigurator
                         $data .= '        '.str_replace(['<', '/>'], ['<!-- ', ' -->'], $doc->saveXML($fragment))."\n";
                     }
                 } else {
-                    $value = $this->options->expandTargetDir($value);
+                    $value = $this->unquoteLiteral($this->options->expandTargetDir($value));
                     $doc = new \DOMDocument();
                     $fragment = $doc->createElement('env');
                     $fragment->setAttribute('name', $key);
@@ -187,6 +187,24 @@ class EnvConfigurator extends AbstractConfigurator
             $this->write(\sprintf('Removing environment variables from %s', $file));
             file_put_contents($phpunit, $contents);
         }
+    }
+
+    /**
+     * Single-quoted values are dotenv literals (no variable interpolation, no
+     * escape sequences, e.g. to store JSON content) and must be written as-is.
+     */
+    private function isSingleQuotedLiteral(string $value): bool
+    {
+        return \strlen($value) > 1 && str_starts_with($value, "'") && str_ends_with($value, "'");
+    }
+
+    /**
+     * The quotes of a dotenv literal are syntax, not part of the value: strip
+     * them where the raw value is expected, like a phpunit.xml env attribute.
+     */
+    private function unquoteLiteral(string $value): string
+    {
+        return $this->isSingleQuotedLiteral($value) ? substr($value, 1, -1) : $value;
     }
 
     /**

--- a/tests/Configurator/EnvConfiguratorTest.php
+++ b/tests/Configurator/EnvConfiguratorTest.php
@@ -52,6 +52,7 @@ class EnvConfiguratorTest extends TestCase
             'DATABASE_URL' => 'mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7',
             'MAILER_URL' => 'null://localhost',
             'MAILER_USER' => 'fabien',
+            'ALLOWED_LANGUAGES' => '\'["en","de","es"]\'',
             '#1' => 'Comment 1',
             '#2' => 'Comment 3',
             '#TRUSTED_SECRET' => 's3cretf0rt3st"<>',
@@ -67,6 +68,7 @@ APP_PARAGRAPH="foo\\n\\"bar\\"\\\\t"
 DATABASE_URL="mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7"
 MAILER_URL=null://localhost
 MAILER_USER=fabien
+ALLOWED_LANGUAGES='["en","de","es"]'
 # Comment 1
 # Comment 3
 #TRUSTED_SECRET="s3cretf0rt3st\"<>"
@@ -95,6 +97,7 @@ EOF;
         <env name="DATABASE_URL" value="mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&amp;serverVersion=5.7"/>
         <env name="MAILER_URL" value="null://localhost"/>
         <env name="MAILER_USER" value="fabien"/>
+        <env name="ALLOWED_LANGUAGES" value="[&quot;en&quot;,&quot;de&quot;,&quot;es&quot;]"/>
         <!-- Comment 1 -->
         <!-- Comment 3 -->
         <!-- env name="TRUSTED_SECRET" value="s3cretf0rt3st&quot;&lt;&gt;" -->


### PR DESCRIPTION
The dotenv format treats single-quoted values as fully literal strings (no variable interpolation, no escape sequences), which is the standard way to embed JSON content in a `.env` file.

However, the `strpbrk()` check introduced in #200 detects the inner double quotes and unconditionally re-wraps such values in double quotes with escaping, so `'["en","de","es"]'` ends up as `"'[\"en\",\"de\",\"es\"]'"` and the single quotes become part of the value.

This PR:
- writes values already wrapped in single quotes as-is in the `.env` files;
- strips the wrapping quotes when writing the corresponding `<env>` attribute in `phpunit.xml` (the quotes are dotenv syntax, not part of the value), so the value seen by the tests matches the one seen in dev.

Verified end to end with symfony/dotenv: the produced line parses back to the raw JSON string and `json_decode()` works, while the previous output kept the literal single quotes in the value.

Fix #1096