### PR TITLE
Warn when a root constraint bypasses extra.symfony.require

### DIFF
--- a/src/PackageFilter.php
+++ b/src/PackageFilter.php
@@ -31,6 +31,8 @@ class PackageFilter
     private $downloader;
     private $io;
     private $ignorePreleases;
+    private $notifiedRestriction = false;
+    private $warnedPackages = [];
 
     public function __construct(IOInterface $io, string $symfonyRequire, Downloader $downloader, bool $ignorePreleases = false)
     {
@@ -91,9 +93,21 @@ class PackageFilter
             if ('symfony/symfony' !== $name && (
                 array_intersect($versions, $lockedVersions[$name] ?? [])
                 || (($knownVersions ??= $this->getVersions()) && !isset($knownVersions['splits'][$name]))
-                || (isset($rootConstraints[$name]) && !Intervals::haveIntersections($this->symfonyConstraints, $rootConstraints[$name]))
                 || ('symfony/psr-http-message-bridge' === $name && 6.4 > $versions[0])
             )) {
+                $filteredPackages[] = $package;
+                continue;
+            }
+
+            if ('symfony/symfony' !== $name && isset($rootConstraints[$name]) && !Intervals::haveIntersections($this->symfonyConstraints, $rootConstraints[$name])) {
+                // the root constraint wins when it has no intersection with the
+                // "symfony/*" one, e.g. to allow requiring a dev version; be
+                // loud about it as this also triggers when the root constraint
+                // simply misses the versions the user asked for
+                if (null !== $this->io && !isset($this->warnedPackages[$name])) {
+                    $this->warnedPackages[$name] = true;
+                    $this->io->writeError(\sprintf('<warning>Version constraint "%s" for "%s" has no intersection with "%s", keeping the package unrestricted</>', $rootConstraints[$name]->getPrettyString(), $name, $this->symfonyRequire));
+                }
                 $filteredPackages[] = $package;
                 continue;
             }
@@ -112,9 +126,9 @@ class PackageFilter
 
             if ('symfony/symfony' === $name) {
                 $symfonyPackages[] = $package;
-            } elseif (null !== $this->io) {
+            } elseif (null !== $this->io && !$this->notifiedRestriction) {
+                $this->notifiedRestriction = true;
                 $this->io->writeError(\sprintf('<info>Restricting packages listed in "symfony/symfony" to "%s"</>', $this->symfonyRequire));
-                $this->io = null;
             }
         }
 

--- a/tests/PackageFilterTest.php
+++ b/tests/PackageFilterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Flex\Tests;
 
+use Composer\IO\BufferIO;
 use Composer\IO\NullIO;
 use Composer\Package\CompletePackage;
 use Composer\Package\Link;
@@ -207,6 +208,33 @@ class PackageFilterTest extends TestCase
         yield 'root-constraints-are-preserved' => [$packages, $packages, '~2.8', ['splits' => [
             'symfony/bar' => ['2.8', '3.0'],
         ]]];
+    }
+
+    public function testRootConstraintWithoutIntersectionIsPreservedButWarnedAbout()
+    {
+        $io = new BufferIO();
+        $downloader = $this->createStub(Downloader::class);
+        $downloader
+            ->method('getVersions')
+            ->willReturn(['splits' => ['symfony/bar' => ['2.8', '3.0']]]);
+        $filter = new PackageFilter($io, '~2.8', $downloader);
+
+        $l = new ArrayLoader();
+        $packages = [];
+        foreach (['2.8.0', '3.0.0'] as $version) {
+            $packages[] = $l->load(['name' => 'symfony/bar', 'version' => $version], CompletePackage::class);
+        }
+
+        $rootPackage = new RootPackage('test/test', '1.0.0.0', '1.0');
+        $rootPackage->setRequires([
+            'symfony/bar' => new Link('__root__', 'symfony/bar', new Constraint('>=', '3.0.0.0'), Link::TYPE_REQUIRE, '>=3.0'),
+        ]);
+
+        $this->assertSame($packages, $filter->removeLegacyPackages($packages, $rootPackage, []));
+
+        $output = $io->getOutput();
+        $this->assertStringContainsString('Version constraint ">= 3.0.0.0" for "symfony/bar" has no intersection with "~2.8", keeping the package unrestricted', $output);
+        $this->assertSame(1, substr_count($output, 'no intersection'), 'the warning should be emitted once per package, not once per version');
     }
 
     public function testIgnorePreleases()


### PR DESCRIPTION
Fixes the silent part of #1073.

Since #713, a root constraint that has no intersection with `extra.symfony.require` wins over it, on purpose: that's what allows requiring `symfony/foo:dev-main` while the filter is active. But the same rule kicks in when the root constraint is disjoint *by mistake* (e.g. `"symfony/yaml": "^6.0 || ^7.4"` with `SYMFONY_REQUIRE=8.*`): the package is silently kept unrestricted and the solver happily picks a version outside the requested range, which is how #1073 went unnoticed.

This keeps the #713 behavior untouched and simply makes the exemption loud, once per package:

```
Version constraint "^6.0 || ^7.4" for "symfony/yaml" has no intersection with "8.*", keeping the package unrestricted
```

The `$this->io = null` trick used to print the "Restricting packages" notice once is replaced with a boolean flag, as it would otherwise swallow warnings emitted after it.
