### PR TITLE
Show post-install instructions in composer recipes <package>

### DIFF
--- a/src/Command/RecipesCommand.php
+++ b/src/Command/RecipesCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Flex\GithubApi;
 use Symfony\Flex\InformationOperation;
 use Symfony\Flex\Lock;
+use Symfony\Flex\Options;
 use Symfony\Flex\Recipe;
 
 /**
@@ -34,12 +35,14 @@ class RecipesCommand extends BaseCommand
 
     private Lock $symfonyLock;
     private GithubApi $githubApi;
+    private ?Options $options;
 
-    public function __construct(/* cannot be type-hinted */ $flex, Lock $symfonyLock, HttpDownloader $downloader)
+    public function __construct(/* cannot be type-hinted */ $flex, Lock $symfonyLock, HttpDownloader $downloader, ?Options $options = null)
     {
         $this->flex = $flex;
         $this->symfonyLock = $symfonyLock;
         $this->githubApi = new GithubApi($downloader);
+        $this->options = $options;
 
         parent::__construct();
     }
@@ -243,6 +246,17 @@ class RecipesCommand extends BaseCommand
             $tree = $this->generateFilesTree($lockFiles);
 
             $this->displayFilesTree($tree);
+        }
+
+        $postInstallOutput = $recipe->getManifest()['post-install-output'] ?? [];
+
+        if ($postInstallOutput) {
+            $io->write('<info>instructions</info>     : ');
+            $io->write('');
+
+            foreach ($postInstallOutput as $line) {
+                $io->write($this->options ? $this->options->expandTargetDir($line) : $line);
+            }
         }
 
         if ($lockRef !== $recipe->getRef()) {

--- a/src/Flex.php
+++ b/src/Flex.php
@@ -211,7 +211,7 @@ class Flex implements PluginInterface, EventSubscriberInterface
             }
 
             $addCommand = 'add'.(method_exists($app, 'addCommand') ? 'Command' : '');
-            $app->$addCommand(new Command\RecipesCommand($this, $this->lock, $rfs));
+            $app->$addCommand(new Command\RecipesCommand($this, $this->lock, $rfs, $this->options));
             $app->$addCommand(new Command\InstallRecipesCommand($this, $this->options->get('root-dir'), $this->options->get('runtime')['dotenv_path'] ?? '.env'));
             $app->$addCommand(new Command\UpdateRecipesCommand($this, $this->downloader, $rfs, $this->configurator, $this->options->get('root-dir')));
             $app->$addCommand(new Command\DumpEnvCommand($this->config, $this->options));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #922
| License       | MIT

The instructions a recipe prints at install time scroll away with the rest of the install output, and there was no way to read them again. `composer recipes vendor/package` now ends with them:

```
name             : acme/demo-bundle
version          : 1.0
status           : up to date
instructions     :

  * Add your credentials to config/packages/acme.yaml
  * Then run bin/console acme:setup
```

The lines go through `Options::expandTargetDir()`, so `%CONFIG_DIR%` and friends read the same as they do during the install. That is the only reason the command now receives `Options`; it is an optional trailing argument and falls back to the raw line when absent, so nothing breaks for anyone constructing the command.

No test: there is no `RecipesCommandTest` today, and this output is only reachable through a fixture that runs a real `composer install`, the way `UpdateRecipesCommandTest` does. Happy to add one on that pattern if you want it covered.
