### PR TITLE
Show the Docker Compose instructions without -v

### DIFF
--- a/src/Configurator/DockerComposeConfigurator.php
+++ b/src/Configurator/DockerComposeConfigurator.php
@@ -48,7 +48,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
 
         $this->configureDockerCompose($recipe, $config, $options['force'] ?? false);
 
-        $this->write('Docker Compose definitions have been modified. Please run "docker compose up --build" again to apply the changes.');
+        $this->write('Docker Compose definitions have been modified. Please run "docker compose up --build" again to apply the changes.', IOInterface::NORMAL);
     }
 
     public function unconfigure(Recipe $recipe, $config, Lock $lock)
@@ -76,7 +76,7 @@ class DockerComposeConfigurator extends AbstractConfigurator
             file_put_contents($dockerComposeFile, ltrim($contents, "\n"));
         }
 
-        $this->write('Docker Compose definitions have been modified. Please run "docker compose up" again to apply the changes.');
+        $this->write('Docker Compose definitions have been modified. Please run "docker compose up" again to apply the changes.', IOInterface::NORMAL);
     }
 
     public function update(RecipeUpdate $recipeUpdate, array $originalConfig, array $newConfig): void

--- a/tests/Configurator/DockerComposeConfiguratorTest.php
+++ b/tests/Configurator/DockerComposeConfiguratorTest.php
@@ -209,6 +209,43 @@ class DockerComposeConfiguratorTest extends TestCase
         $this->assertEquals(self::ORIGINAL_CONTENT, file_get_contents($dockerComposeFile));
     }
 
+    public function testTheDockerComposeInstructionsAreNotHiddenBehindVerboseMode()
+    {
+        $dockerComposeFile = FLEX_TEST_DIR.'/compose.yaml';
+        file_put_contents($dockerComposeFile, self::ORIGINAL_CONTENT);
+
+        $messages = [];
+        $io = $this->createStub(IOInterface::class);
+        $io->method('writeError')->willReturnCallback(
+            static function ($message, $newline = true, $verbosity = IOInterface::NORMAL) use (&$messages) {
+                foreach ((array) $message as $line) {
+                    $messages[] = [trim($line), $verbosity];
+                }
+            }
+        );
+
+        $configurator = new DockerComposeConfigurator(
+            $this->composer,
+            $io,
+            new Options(['config-dir' => 'config', 'root-dir' => FLEX_TEST_DIR])
+        );
+
+        $configurator->configure($this->recipeDb, self::CONFIG_DB, $this->lock);
+
+        $this->assertContains(
+            ['Docker Compose definitions have been modified. Please run "docker compose up --build" again to apply the changes.', IOInterface::NORMAL],
+            $messages
+        );
+
+        $messages = [];
+        $configurator->unconfigure($this->recipeDb, self::CONFIG_DB, $this->lock);
+
+        $this->assertContains(
+            ['Docker Compose definitions have been modified. Please run "docker compose up" again to apply the changes.', IOInterface::NORMAL],
+            $messages
+        );
+    }
+
     public function testReconfigureDoesNotDuplicateLaterTopLevelKey()
     {
         $this->configurator->configure($this->recipeDb, self::CONFIG_DB, $this->lock);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #944
| License       | MIT

`AbstractConfigurator::write()` defaults to `IOInterface::VERBOSE`, so the two messages telling the user to run `docker compose up` again were only printed with `-v`. That is the one action the user has to take, and it shared a verbosity level with progress lines such as `Adding Docker Compose definitions to "compose.yaml"`, which are fine to keep quiet.

Both are now written at `IOInterface::NORMAL`. They are the first callers of the `$verbosity` argument `write()` has carried unused since it was added.

The new test captures the `writeError()` calls and checks the verbosity for both `configure()` and `unconfigure()`. It fails on `2.x` with the level at 4.
